### PR TITLE
Fixed error when delete feature group when offline store is stored on a path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "delta-spark>=3.2.1",
+    "delta-spark==3.2.0",
     "duckdb>=1.1.3",
     "findspark>=2.0.1",
     "httpx>=0.28.1",
@@ -25,7 +25,7 @@ dependencies = [
     "pyarrow>=18.1.0",
     "pydantic==2.10.4",
     "pyiceberg>=0.8.1",
-    "pyspark==3.5.4",
+    "pyspark==3.5.1",
     "python-box>=7.3.0",
     "python-decouple>=3.8",
     "python-dotenv>=1.0.1",
@@ -47,6 +47,8 @@ dev = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/seeknal"]
+include = ["config.toml"]
 
 [tool.hatch.build]
+include-package-data = true
 packages = ["src/seeknal"]

--- a/quickstart.ipynb
+++ b/quickstart.ipynb
@@ -707,7 +707,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2.1 Feature Engine Task"
+    "## 2.1 Spark Engine Task"
    ]
   },
   {

--- a/spark-engine/bin/spark-engine
+++ b/spark-engine/bin/spark-engine
@@ -13,7 +13,7 @@ USAGE=$(cat <<-EOF
 Usage: $0 command [ options ]
 
 Parameters:
-    command   command to execute, "run", "migrate-schema" or "pipeline"
+    command   command to execute, "run"
 
 Options:
     --master master, -m master

--- a/src/seeknal/featurestore/featurestore.py
+++ b/src/seeknal/featurestore/featurestore.py
@@ -235,7 +235,10 @@ class OfflineStore:
                     table_name = "fg_{}__{}".format(kwds["project"], kwds["entity"])
                     path = os.path.join(base_path, "data", table_name)
                 else:
-                    base_path = self.value["path"]
+                    if isinstance(self.value, FeatureStoreFileOutput):
+                        base_path = self.value.path
+                    else:
+                        base_path = self.value["path"]
                     table_name = "fg_{}__{}".format(kwds["project"], kwds["entity"])
                     path = os.path.join(base_path, table_name)
                 start_date = kwds.get("start_date", None)
@@ -358,7 +361,10 @@ class OfflineStore:
                     table_name = "fg_{}__{}".format(kwds["project"], kwds["entity"])
                     path = os.path.join(base_path, "data", table_name)
                 else:
-                    base_path = self.value["path"]
+                    if isinstance(self.value, FeatureStoreFileOutput):
+                        base_path = self.value.path
+                    else:
+                        base_path = self.value["path"]
                     table_name = "fg_{}__{}".format(kwds["project"], kwds["entity"])
                     path = os.path.join(base_path, table_name)
                 try:

--- a/src/seeknal/flow.py
+++ b/src/seeknal/flow.py
@@ -10,7 +10,6 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import typer
 import yaml
-from prefect import flow, task
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql import functions as F
 from tabulate import tabulate
@@ -425,7 +424,6 @@ class Flow:
         return FlowRequest.delete_by_id(self.flow_id)
 
 
-@flow
 def run_flow(
     flow_name: Optional[str] = None,
     flow: Optional[Flow] = None,

--- a/uv.lock
+++ b/uv.lock
@@ -562,15 +562,15 @@ wheels = [
 
 [[package]]
 name = "delta-spark"
-version = "3.2.1"
+version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata" },
     { name = "pyspark" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/6e/a940d14a764fea1dba5e131e041351a99bc26974f73a6ac19b143598bb34/delta_spark-3.2.1.tar.gz", hash = "sha256:05384ebfeee8e779435302a3e0f1e565636270a2404bedc3a2ee1fea7c980626", size = 22125 }
+sdist = { url = "https://files.pythonhosted.org/packages/38/06/a64cc4e17fe959cf60dc126bf3283fc9f22fc91f000b7f3f5e465338022d/delta-spark-3.2.0.tar.gz", hash = "sha256:641967828e47c64805f8c746513da80bea24b5f19b069cdcf64561cd3692e11d", size = 22147 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/5e/209b8ec57e61e9a9598e68b8d2de6af2853fafbe54c6a41ebc869e15fe12/delta_spark-3.2.1-py3-none-any.whl", hash = "sha256:662ff591acbe190d0d0a07e65cde77f9b81f58da940ae8ca85f620b562165fc3", size = 21170 },
+    { url = "https://files.pythonhosted.org/packages/3c/8e/bb778f5049aa371bf80a7a781b237eb10ef104f8736fe00d25fcfee80c2b/delta_spark-3.2.0-py3-none-any.whl", hash = "sha256:c4ff3fa7218e58a702cb71eb64384b0005c4d6f0bbdd0fe0b38a53564d946e09", size = 21186 },
 ]
 
 [[package]]
@@ -1995,12 +1995,12 @@ wheels = [
 
 [[package]]
 name = "pyspark"
-version = "3.5.4"
+version = "3.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "py4j" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/18/6bb8c4e857122fc898f32336cb6e9e98415a7802c2a3738e907b4bd60953/pyspark-3.5.4.tar.gz", hash = "sha256:1c2926d63020902163f58222466adf6f8016f6c43c1f319b8e7a71dbaa05fc51", size = 317313656 }
+sdist = { url = "https://files.pythonhosted.org/packages/73/e5/c9eb78cc982dafb7b5834bc5c368fe596216c8b9f7c4b4ffa104c4d2ab8f/pyspark-3.5.1.tar.gz", hash = "sha256:dd6569e547365eadc4f887bf57f153e4d582a68c4b490de475d55b9981664910", size = 316955685 }
 
 [[package]]
 name = "pytest"
@@ -2500,7 +2500,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "delta-spark", specifier = ">=3.2.1" },
+    { name = "delta-spark", specifier = "==3.2.0" },
     { name = "duckdb", specifier = ">=1.1.3" },
     { name = "findspark", specifier = ">=2.0.1" },
     { name = "httpx", specifier = ">=0.28.1" },
@@ -2511,9 +2511,9 @@ requires-dist = [
     { name = "pendulum", specifier = ">=3.0.0" },
     { name = "prefect", specifier = ">=3.1.10" },
     { name = "pyarrow", specifier = ">=18.1.0" },
-    { name = "pydantic", specifier = ">=2.10.4" },
+    { name = "pydantic", specifier = "==2.10.4" },
     { name = "pyiceberg", specifier = ">=0.8.1" },
-    { name = "pyspark", specifier = "==3.5.4" },
+    { name = "pyspark", specifier = "==3.5.1" },
     { name = "python-box", specifier = ">=7.3.0" },
     { name = "python-decouple", specifier = ">=3.8" },
     { name = "python-dotenv", specifier = ">=1.0.1" },


### PR DESCRIPTION
* Fixed the error that occurred when deleting a feature group while the offline store was stored on a path.
* Downgrade requirement to use spark 3.5.1