### PR TITLE
feat(workflow): Pipeline error logging & --verbose mode

### DIFF
--- a/src/seeknal/workflow/executors/base.py
+++ b/src/seeknal/workflow/executors/base.py
@@ -65,6 +65,7 @@ class ExecutorResult:
         metadata: Additional executor-specific metadata (metrics, warnings, etc.)
         is_dry_run: Whether this was a dry-run execution
         created_at: ISO timestamp of execution completion
+        output_log: Optional untruncated subprocess output for log files (not persisted to state)
 
     Example:
         >>> result = ExecutorResult(
@@ -88,6 +89,7 @@ class ExecutorResult:
     created_at: str = field(
         default_factory=lambda: time.time()
     )
+    output_log: Optional[str] = None
 
     def is_success(self) -> bool:
         """Check if execution was successful."""

--- a/src/seeknal/workflow/run_logger.py
+++ b/src/seeknal/workflow/run_logger.py
@@ -1,0 +1,164 @@
+"""
+Per-run log file writer for pipeline execution.
+
+Collects node execution details and writes them to a structured
+plain-text log file at target/logs/run_{run_id}.log.
+
+Default mode: log file only created when at least one node fails.
+Verbose mode: log file always created with all node details.
+"""
+
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+
+@dataclass
+class NodeLogEntry:
+    """A single node's execution log entry."""
+    node_id: str
+    status: str
+    duration_seconds: float = 0.0
+    error_message: Optional[str] = None
+    output_log: Optional[str] = None
+    row_count: int = 0
+    attempt: Optional[int] = None
+    total_attempts: Optional[int] = None
+
+
+class RunLogger:
+    """Collects node execution results and writes a structured log file.
+
+    Thread-safe: uses a lock for concurrent log_node() calls in parallel mode.
+
+    Args:
+        target_path: Base target directory (e.g., target/ or target/envs/{env}/).
+        run_id: Unique run identifier (timestamp-based).
+        project_name: Name of the project being executed.
+        verbose: If True, log all nodes; if False, log only failures.
+        flags: CLI flags used for this run (for header display).
+    """
+
+    def __init__(
+        self,
+        target_path: Path,
+        run_id: str,
+        project_name: str,
+        verbose: bool = False,
+        flags: Optional[List[str]] = None,
+    ):
+        self.target_path = target_path
+        self.run_id = run_id
+        self.project_name = project_name
+        self.verbose = verbose
+        self.flags = flags or []
+        self._entries: List[NodeLogEntry] = []
+        self._lock = threading.Lock()
+        self._start_time = time.time()
+
+    def log_node(
+        self,
+        node_id: str,
+        status: str,
+        duration_seconds: float = 0.0,
+        error_message: Optional[str] = None,
+        output_log: Optional[str] = None,
+        row_count: int = 0,
+        attempt: Optional[int] = None,
+        total_attempts: Optional[int] = None,
+    ) -> None:
+        """Record a node's execution result. Thread-safe."""
+        entry = NodeLogEntry(
+            node_id=node_id,
+            status=status,
+            duration_seconds=duration_seconds,
+            error_message=error_message,
+            output_log=output_log,
+            row_count=row_count,
+            attempt=attempt,
+            total_attempts=total_attempts,
+        )
+        with self._lock:
+            self._entries.append(entry)
+
+    @property
+    def has_failures(self) -> bool:
+        """Check if any logged node has failed."""
+        return any(e.status.upper() == "FAILED" for e in self._entries)
+
+    @property
+    def log_path(self) -> Path:
+        """Path where the log file will be written."""
+        return self.target_path / "logs" / f"run_{self.run_id}.log"
+
+    def write(self) -> Optional[Path]:
+        """Write the log file if conditions are met.
+
+        Returns the path to the written log file, or None if no file was written.
+
+        In default mode, only writes when there are failures.
+        In verbose mode, always writes.
+        """
+        if not self.verbose and not self.has_failures:
+            return None
+
+        log_path = self.log_path
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        total_duration = time.time() - self._start_time
+
+        lines: List[str] = []
+
+        # Header
+        lines.append("=== Seeknal Run Log ===")
+        lines.append(f"Run ID:    {self.run_id}")
+        lines.append(f"Project:   {self.project_name}")
+        lines.append(f"Started:   {datetime.fromtimestamp(self._start_time).isoformat()}")
+        if self.flags:
+            lines.append(f"Flags:     {' '.join(self.flags)}")
+        lines.append("")
+
+        # Determine which entries to include
+        entries = self._entries if self.verbose else [
+            e for e in self._entries if e.status.upper() == "FAILED"
+        ]
+
+        # Node sections
+        for entry in entries:
+            status_label = entry.status.upper()
+            attempt_suffix = ""
+            if entry.attempt is not None and entry.total_attempts is not None:
+                attempt_suffix = f" (attempt {entry.attempt}/{entry.total_attempts})"
+
+            lines.append(f"--- {entry.node_id} [{status_label}]{attempt_suffix} ---")
+            lines.append(f"Duration:  {entry.duration_seconds:.2f}s")
+
+            if entry.row_count > 0:
+                lines.append(f"Rows:      {entry.row_count:,}")
+
+            if entry.error_message:
+                lines.append(f"Error:     {entry.error_message}")
+
+            if entry.output_log:
+                lines.append("")
+                lines.append("Subprocess output:")
+                for line in entry.output_log.splitlines():
+                    lines.append(f"  {line}")
+
+            lines.append("")
+
+        # Summary
+        total = len(self._entries)
+        failed = sum(1 for e in self._entries if e.status.upper() == "FAILED")
+        cached = sum(1 for e in self._entries if e.status.upper() == "CACHED")
+        succeeded = sum(1 for e in self._entries if e.status.upper() == "SUCCESS")
+
+        lines.append("=== Summary ===")
+        lines.append(f"Total: {total} | Executed: {succeeded} | Cached: {cached} | Failed: {failed}")
+        lines.append(f"Duration: {total_duration:.2f}s")
+
+        log_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return log_path

--- a/tests/workflow/test_run_logger.py
+++ b/tests/workflow/test_run_logger.py
@@ -1,0 +1,238 @@
+"""Tests for RunLogger — per-run log file writer."""
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from seeknal.workflow.run_logger import RunLogger, NodeLogEntry
+
+
+@pytest.fixture
+def tmp_target(tmp_path):
+    """Create a temporary target directory."""
+    return tmp_path / "target"
+
+
+class TestRunLogger:
+    """Tests for RunLogger class."""
+
+    def test_log_node_records_entry(self, tmp_target):
+        logger = RunLogger(tmp_target, "20260228_120000", "test-project")
+        logger.log_node("transform.clean", "SUCCESS", duration_seconds=1.5, row_count=100)
+
+        assert len(logger._entries) == 1
+        assert logger._entries[0].node_id == "transform.clean"
+        assert logger._entries[0].status == "SUCCESS"
+        assert logger._entries[0].row_count == 100
+
+    def test_has_failures_false_when_no_failures(self, tmp_target):
+        logger = RunLogger(tmp_target, "20260228_120000", "test-project")
+        logger.log_node("source.data", "CACHED")
+        logger.log_node("transform.clean", "SUCCESS", duration_seconds=1.0)
+
+        assert logger.has_failures is False
+
+    def test_has_failures_true_when_failure_exists(self, tmp_target):
+        logger = RunLogger(tmp_target, "20260228_120000", "test-project")
+        logger.log_node("transform.clean", "SUCCESS", duration_seconds=1.0)
+        logger.log_node("transform.model", "FAILED", error_message="No module named 'sklearn'")
+
+        assert logger.has_failures is True
+
+    def test_log_path(self, tmp_target):
+        logger = RunLogger(tmp_target, "20260228_120000", "test-project")
+        assert logger.log_path == tmp_target / "logs" / "run_20260228_120000.log"
+
+    def test_write_skips_when_no_failures_default_mode(self, tmp_target):
+        logger = RunLogger(tmp_target, "20260228_120000", "test-project", verbose=False)
+        logger.log_node("transform.clean", "SUCCESS", duration_seconds=1.0)
+
+        result = logger.write()
+        assert result is None
+        assert not logger.log_path.exists()
+
+    def test_write_creates_file_on_failure_default_mode(self, tmp_target):
+        logger = RunLogger(tmp_target, "20260228_120000", "test-project", verbose=False)
+        logger.log_node("transform.clean", "SUCCESS", duration_seconds=1.0)
+        logger.log_node("transform.model", "FAILED", error_message="ImportError: sklearn")
+
+        result = logger.write()
+        assert result == logger.log_path
+        assert result.exists()
+
+        content = result.read_text()
+        assert "=== Seeknal Run Log ===" in content
+        assert "Run ID:    20260228_120000" in content
+        assert "Project:   test-project" in content
+        # Default mode: only FAILED nodes in the log
+        assert "transform.model [FAILED]" in content
+        assert "ImportError: sklearn" in content
+        # SUCCESS nodes NOT included in default mode
+        assert "transform.clean [SUCCESS]" not in content
+
+    def test_write_creates_file_always_in_verbose_mode(self, tmp_target):
+        logger = RunLogger(tmp_target, "20260228_120000", "test-project", verbose=True)
+        logger.log_node("source.data", "CACHED")
+        logger.log_node("transform.clean", "SUCCESS", duration_seconds=1.0, row_count=50)
+
+        result = logger.write()
+        assert result is not None
+        assert result.exists()
+
+        content = result.read_text()
+        assert "source.data [CACHED]" in content
+        assert "transform.clean [SUCCESS]" in content
+        assert "Rows:      50" in content
+
+    def test_write_includes_all_nodes_in_verbose_mode(self, tmp_target):
+        logger = RunLogger(tmp_target, "20260228_120000", "test-project", verbose=True)
+        logger.log_node("source.data", "CACHED")
+        logger.log_node("transform.clean", "SUCCESS", duration_seconds=1.5)
+        logger.log_node("transform.model", "FAILED", error_message="timeout")
+
+        result = logger.write()
+        content = result.read_text()
+
+        assert "source.data [CACHED]" in content
+        assert "transform.clean [SUCCESS]" in content
+        assert "transform.model [FAILED]" in content
+
+    def test_write_includes_subprocess_output(self, tmp_target):
+        logger = RunLogger(tmp_target, "20260228_120000", "test-project", verbose=False)
+        logger.log_node(
+            "transform.model", "FAILED",
+            error_message="Process exited with code 1",
+            output_log="stderr:\nModuleNotFoundError: No module named 'sklearn'\n",
+        )
+
+        result = logger.write()
+        content = result.read_text()
+        assert "Subprocess output:" in content
+        assert "ModuleNotFoundError" in content
+
+    def test_write_includes_flags(self, tmp_target):
+        logger = RunLogger(
+            tmp_target, "20260228_120000", "test-project",
+            verbose=True, flags=["--verbose", "--full"]
+        )
+        logger.log_node("source.data", "CACHED")
+
+        result = logger.write()
+        content = result.read_text()
+        assert "Flags:     --verbose --full" in content
+
+    def test_write_includes_summary(self, tmp_target):
+        logger = RunLogger(tmp_target, "20260228_120000", "test-project", verbose=True)
+        logger.log_node("source.data", "CACHED")
+        logger.log_node("transform.clean", "SUCCESS", duration_seconds=1.0)
+        logger.log_node("transform.model", "FAILED", error_message="error")
+
+        result = logger.write()
+        content = result.read_text()
+        assert "=== Summary ===" in content
+        assert "Total: 3" in content
+        assert "Executed: 1" in content
+        assert "Cached: 1" in content
+        assert "Failed: 1" in content
+
+    def test_write_retry_attempts(self, tmp_target):
+        logger = RunLogger(tmp_target, "20260228_120000", "test-project", verbose=True)
+        logger.log_node(
+            "transform.model", "FAILED",
+            error_message="Connection refused",
+            attempt=1, total_attempts=3,
+        )
+        logger.log_node(
+            "transform.model", "FAILED",
+            error_message="Connection refused",
+            attempt=2, total_attempts=3,
+        )
+        logger.log_node(
+            "transform.model", "SUCCESS",
+            duration_seconds=2.0,
+            attempt=3, total_attempts=3,
+        )
+
+        result = logger.write()
+        content = result.read_text()
+        assert "(attempt 1/3)" in content
+        assert "(attempt 2/3)" in content
+        assert "(attempt 3/3)" in content
+
+    def test_thread_safety(self, tmp_target):
+        """Log nodes from multiple threads concurrently."""
+        logger = RunLogger(tmp_target, "20260228_120000", "test-project", verbose=True)
+        errors = []
+
+        def log_from_thread(thread_id):
+            try:
+                for i in range(10):
+                    logger.log_node(
+                        f"node.thread{thread_id}_{i}",
+                        "SUCCESS",
+                        duration_seconds=0.01,
+                    )
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=log_from_thread, args=(i,)) for i in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+        assert len(logger._entries) == 50  # 5 threads × 10 nodes
+
+        result = logger.write()
+        assert result is not None
+        assert result.exists()
+
+    def test_creates_log_directory(self, tmp_target):
+        """Log directory is created automatically."""
+        logger = RunLogger(tmp_target, "20260228_120000", "test-project", verbose=True)
+        logger.log_node("source.data", "CACHED")
+
+        assert not (tmp_target / "logs").exists()
+        logger.write()
+        assert (tmp_target / "logs").exists()
+
+
+class TestPythonExecutorErrorMessage:
+    """Tests for PythonExecutor error_message fix."""
+
+    def test_executor_result_has_output_log_field(self):
+        from seeknal.workflow.executors.base import ExecutorResult, ExecutionStatus
+
+        result = ExecutorResult(
+            node_id="transform.test",
+            status=ExecutionStatus.FAILED,
+            error_message="Process exited with code 1: ImportError",
+            output_log="stderr:\nImportError: no module named 'foo'",
+        )
+        assert result.output_log is not None
+        assert "ImportError" in result.output_log
+
+    def test_output_log_excluded_from_to_dict(self):
+        from seeknal.workflow.executors.base import ExecutorResult, ExecutionStatus
+
+        result = ExecutorResult(
+            node_id="transform.test",
+            status=ExecutionStatus.FAILED,
+            error_message="error",
+            output_log="full output here",
+        )
+        d = result.to_dict()
+        assert "output_log" not in d
+        assert d["error_message"] == "error"
+
+    def test_output_log_default_none(self):
+        from seeknal.workflow.executors.base import ExecutorResult, ExecutionStatus
+
+        result = ExecutorResult(
+            node_id="transform.test",
+            status=ExecutionStatus.SUCCESS,
+        )
+        assert result.output_log is None


### PR DESCRIPTION
## Summary

- **Fix `FAILED: None` bug**: `PythonExecutor` now always sets `error_message` on subprocess failure (last stderr line) and timeout
- **Add `--verbose`/`-v` flag** to `seeknal run`: shows full tracebacks and subprocess output inline on failure; writes detailed log file for all nodes
- **Per-run log files**: `RunLogger` writes structured log to `target/logs/run_{run_id}.log` — default mode creates file only on failures (failed nodes only), verbose mode always creates with all nodes
- **Untruncated subprocess output**: New `output_log` field on `ExecutorResult` carries full stdout/stderr for log files while keeping `metadata` truncated for state safety
- **Retry logging**: Each retry attempt logged with `(attempt N/M)` suffix
- **Thread-safe**: `RunLogger` uses `threading.Lock` for parallel pipeline execution

## Files Changed

| File | Change |
|------|--------|
| `src/seeknal/workflow/executors/base.py` | Add `output_log: Optional[str]` to `ExecutorResult` |
| `src/seeknal/workflow/executors/python_executor.py` | Fix error_message=None, populate output_log |
| `src/seeknal/cli/main.py` | Add `--verbose` flag, integrate `RunLogger`, show log path |
| `src/seeknal/workflow/run_logger.py` | **NEW**: `RunLogger` class + `NodeLogEntry` dataclass |
| `tests/workflow/test_run_logger.py` | **NEW**: 17 unit tests |

## Test Plan

- [x] 17 new unit tests covering: log recording, has_failures, log_path, write behavior (default/verbose), subprocess output, flags, summary, retry attempts, thread safety, directory creation
- [x] 572 existing workflow tests pass (1 pre-existing failure in prefect_integration — unrelated)
- [x] `ExecutorResult.output_log` excluded from `to_dict()` (verified by test)

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: This is a CLI-only feature (log files + terminal output). No server, database, or external service changes.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)