### PR TITLE
feat(ask,gateway): webhook-based streaming via POST /ask/stream

### DIFF
--- a/src/seeknal/ask/gateway/server.py
+++ b/src/seeknal/ask/gateway/server.py
@@ -24,6 +24,7 @@ from starlette.websockets import WebSocket, WebSocketDisconnect
 
 from seeknal.ask.gateway.session_manager import SessionManager
 from seeknal.ask.gateway.sse import SSEBroadcaster
+from seeknal.ask.gateway.webhook import WebhookClient, WebhookConfig
 
 # Validate session IDs: alphanumeric, hyphens, underscores, max 128 chars
 _SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9_-]{1,128}$")
@@ -186,6 +187,41 @@ async def ask_oneshot(request: Request) -> JSONResponse:
     return JSONResponse({"answer": answer, "events": events})
 
 
+async def ask_stream(request: Request) -> JSONResponse:
+    """Webhook-based streaming: POST a question, get 201, receive events via callback."""
+    body = await request.json()
+    question = body.get("question", "")
+    session_id = body.get("session_id", "default")
+    message_id = body.get("message_id", "")
+    webhook_path = body.get("webhook_path", "")
+
+    if not question:
+        return JSONResponse({"error": "question is required"}, status_code=400)
+    if not message_id:
+        return JSONResponse({"error": "message_id is required"}, status_code=400)
+    if not webhook_path:
+        return JSONResponse({"error": "webhook_path is required"}, status_code=400)
+    if not _validate_session_id(session_id):
+        return JSONResponse({"error": "invalid session_id"}, status_code=400)
+
+    try:
+        webhook_url = WebhookClient.build_webhook_url(webhook_path)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+
+    config = WebhookConfig(
+        message_id=message_id,
+        session_id=session_id,
+        webhook_url=webhook_url,
+    )
+    client = WebhookClient(config)
+
+    project_path = Path(request.app.state.project_path)
+    asyncio.create_task(client.run_and_deliver(project_path, session_id, question))
+
+    return JSONResponse({"message_id": message_id}, status_code=201)
+
+
 async def websocket_endpoint(websocket: WebSocket) -> None:
     """WebSocket streaming per session."""
     session_id = websocket.path_params["session_id"]
@@ -257,6 +293,7 @@ def create_gateway_app(project_path: str | Path) -> Starlette:
         Route("/health", health),
         Route("/sessions", list_sessions),
         Route("/ask", ask_oneshot, methods=["POST"]),
+        Route("/ask/stream", ask_stream, methods=["POST"]),
         WebSocketRoute("/ws/{session_id}", websocket_endpoint),
         Route("/events/{session_id}", sse_endpoint),
     ]

--- a/src/seeknal/ask/gateway/webhook.py
+++ b/src/seeknal/ask/gateway/webhook.py
@@ -1,0 +1,197 @@
+"""Webhook-based streaming for seeknal ask gateway.
+
+Client POSTs a question to /ask/stream, gets an immediate 201,
+and receives events via HTTP POST callbacks to a configurable
+webhook URL. Events follow a sparse-envelope schema with typed
+payloads per event kind.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# How often heartbeat events fire while the agent is running
+_HEARTBEAT_INTERVAL = 15
+
+
+@dataclass
+class WebhookConfig:
+    message_id: str
+    session_id: str
+    webhook_url: str
+
+
+class WebhookClient:
+    """Delivers agent events to a remote webhook URL via HTTP POST."""
+
+    def __init__(self, config: WebhookConfig) -> None:
+        self._config = config
+        self._running = False
+        self._heartbeat_task: asyncio.Task | None = None
+
+    # ------------------------------------------------------------------
+    # URL construction
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def build_webhook_url(webhook_path: str) -> str:
+        """Construct a full webhook URL from a path.
+
+        Reads ``SEEKNAL_WEBHOOK_BASE_URL`` from the environment and appends
+        *webhook_path*.  The path **must** start with ``/`` to prevent
+        external-URL injection (e.g. ``https://evil.com/steal``).
+
+        Raises:
+            ValueError: If the env var is missing or the path is invalid.
+        """
+        base_url = os.environ.get("SEEKNAL_WEBHOOK_BASE_URL", "").strip()
+        if not base_url:
+            raise ValueError("SEEKNAL_WEBHOOK_BASE_URL is not set")
+        base_url = base_url.rstrip("/")
+        if not webhook_path.startswith("/"):
+            raise ValueError(
+                "webhook_path must start with '/' "
+                "(use a path, not a full URL)"
+            )
+        return base_url + webhook_path
+
+    # ------------------------------------------------------------------
+    # Event envelope
+    # ------------------------------------------------------------------
+
+    def _make_event(
+        self, event_name: str, payload: dict | None = None,
+    ) -> dict[str, Any]:
+        """Build a webhook envelope with sparse payload."""
+        return {
+            "event": event_name,
+            "message_id": self._config.message_id,
+            "conversation_id": self._config.session_id,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "payload": payload or {},
+        }
+
+    # ------------------------------------------------------------------
+    # HTTP delivery (fire-and-forget)
+    # ------------------------------------------------------------------
+
+    async def _post(self, payload: dict) -> None:
+        """POST a single event.  Retries once on failure; never raises."""
+        for attempt in range(2):
+            try:
+                async with httpx.AsyncClient(timeout=5) as client:
+                    resp = await client.post(
+                        self._config.webhook_url, json=payload,
+                    )
+                    resp.raise_for_status()
+                    return
+            except Exception:
+                if attempt == 0:
+                    await asyncio.sleep(0.5)
+                    continue
+                logger.warning(
+                    "Webhook delivery failed for event=%s",
+                    payload.get("event"),
+                )
+
+    # ------------------------------------------------------------------
+    # Event mapping
+    # ------------------------------------------------------------------
+
+    def _map_event(self, raw: dict) -> dict | None:
+        """Map a raw agent event to a webhook envelope.
+
+        Returns ``None`` for events that should be skipped (e.g. ``token``).
+        """
+        kind = raw.get("type")
+        data = raw.get("data")
+
+        if kind == "token":
+            return None
+
+        if kind == "reasoning":
+            return self._make_event("message", {"answer": data})
+
+        if kind == "answer":
+            return self._make_event("message", {"answer": data})
+
+        if kind == "tool_start":
+            return self._make_event("tool_call", {
+                "tool_name": data.get("name", ""),
+                "tool_args": data.get("args", {}),
+            })
+
+        if kind == "tool_end":
+            return self._make_event("tool_result", {
+                "tool_name": data.get("name", ""),
+                "tool_result": data.get("output", ""),
+            })
+
+        # Unknown event types are silently skipped
+        return None
+
+    # ------------------------------------------------------------------
+    # Heartbeat
+    # ------------------------------------------------------------------
+
+    async def _heartbeat_loop(self) -> None:
+        """Fire heartbeat events every 15 s while the agent is running."""
+        while self._running:
+            await asyncio.sleep(_HEARTBEAT_INTERVAL)
+            if self._running:
+                await self._post(self._make_event("heartbeat"))
+
+    # ------------------------------------------------------------------
+    # Main driver
+    # ------------------------------------------------------------------
+
+    async def run_and_deliver(
+        self,
+        project_path,
+        session_id: str,
+        question: str,
+    ) -> None:
+        """Run the agent and deliver mapped events to the webhook.
+
+        Emits: ``start`` → … mapped events … → ``done``.
+        On exception emits ``error`` instead of ``done``.
+        """
+        # Lazy import matches the Telegram channel pattern
+        from seeknal.ask.gateway.server import _run_agent_streaming
+
+        self._running = True
+        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+
+        try:
+            await self._post(self._make_event("start"))
+
+            async for event in _run_agent_streaming(
+                project_path, session_id, question,
+            ):
+                mapped = self._map_event(event)
+                if mapped is not None:
+                    await self._post(mapped)
+
+        except Exception as exc:
+            await self._post(self._make_event("error", {
+                "error_code": "agent_error",
+                "error_message": str(exc),
+            }))
+        finally:
+            self._running = False
+            if self._heartbeat_task is not None:
+                self._heartbeat_task.cancel()
+                try:
+                    await self._heartbeat_task
+                except asyncio.CancelledError:
+                    pass
+            await self._post(self._make_event("done"))

--- a/src/seeknal/cli/gateway.py
+++ b/src/seeknal/cli/gateway.py
@@ -80,6 +80,7 @@ def gateway_start(
     typer.echo(f"  GET  /health")
     typer.echo(f"  GET  /sessions")
     typer.echo(f"  POST /ask")
+    typer.echo(f"  POST /ask/stream  (webhook streaming)")
     typer.echo(f"  WS   /ws/{{session_id}}")
     typer.echo(f"  GET  /events/{{session_id}}")
 

--- a/tests/ask/test_webhook.py
+++ b/tests/ask/test_webhook.py
@@ -330,6 +330,114 @@ class TestAskStreamEndpoint:
         assert resp.status_code == 400
 
 
+# ===================================================================
+# E2E tests — gateway → background task → real HTTP webhook delivery
+# ===================================================================
+
+
+class TestE2E:
+    """End-to-end: POST /ask/stream → background task → real HTTP webhook delivery.
+
+    Uses an aiohttp TCP server as the webhook receiver and httpx.AsyncClient
+    with ASGITransport to call the gateway in-process.  _run_agent_streaming
+    is patched to yield deterministic events without a real LLM.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _require_deps(self):
+        pytest.importorskip("starlette")
+        pytest.importorskip("aiohttp")
+        pytest.importorskip("httpx")
+
+    def test_full_webhook_delivery(self, tmp_path, monkeypatch):
+        """POST /ask/stream → events arrive at real webhook via HTTP."""
+        import asyncio
+
+        import seeknal.ask.gateway.server as server_mod
+        from httpx import ASGITransport, AsyncClient
+        from aiohttp import web
+
+        raw_events = [
+            {"type": "reasoning", "data": "Let me think..."},
+            {
+                "type": "tool_start",
+                "data": {"name": "execute_sql", "args": {"query": "SELECT 1"}},
+            },
+            {"type": "tool_end", "data": {"name": "execute_sql", "output": "1 row"}},
+            {"type": "answer", "data": "The answer is 1."},
+        ]
+
+        # --- Set up real aiohttp webhook receiver on random port ---
+        received: list[dict] = []
+
+        async def handle_post(request: web.Request) -> web.Response:
+            body = await request.json()
+            received.append(body)
+            return web.json_response({"ok": True})
+
+        hook_app = web.Application()
+        hook_app.router.add_post("/hook", handle_post)
+
+        async def _run() -> None:
+            runner = web.AppRunner(hook_app)
+            await runner.setup()
+            site = web.TCPSite(runner, "127.0.0.1", 0)
+            await site.start()
+            port = site._server.sockets[0].getsockname()[1]
+            base_url = f"http://127.0.0.1:{port}"
+
+            monkeypatch.setenv("SEEKNAL_WEBHOOK_BASE_URL", base_url)
+
+            gateway_app = server_mod.create_gateway_app(str(tmp_path))
+
+            with patch.object(
+                server_mod,
+                "_run_agent_streaming",
+                return_value=_async_iter(raw_events),
+            ):
+                transport = ASGITransport(app=gateway_app)
+                async with AsyncClient(
+                    transport=transport, base_url="http://test",
+                ) as http:
+                    resp = await http.post(
+                        "/ask/stream",
+                        json={
+                            "question": "What is 1?",
+                            "message_id": "e2e-001",
+                            "webhook_path": "/hook",
+                        },
+                    )
+                    assert resp.status_code == 201
+
+                    # Wait for all 6 events to arrive at the webhook receiver
+                    for _ in range(50):
+                        if len(received) >= 6:
+                            break
+                        await asyncio.sleep(0.1)
+
+            await runner.cleanup()
+
+        asyncio.run(_run())
+
+        # Verify the full event sequence
+        event_names = [e["event"] for e in received]
+        assert event_names == [
+            "start",
+            "message",      # reasoning
+            "tool_call",
+            "tool_result",
+            "message",      # answer
+            "done",
+        ]
+
+        # Verify envelope fields are present on every event
+        for evt in received:
+            assert evt["message_id"] == "e2e-001"
+            assert evt["conversation_id"] == "default"
+            assert "created_at" in evt
+            assert "payload" in evt
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/ask/test_webhook.py
+++ b/tests/ask/test_webhook.py
@@ -1,0 +1,341 @@
+"""Tests for webhook-based streaming (POST /ask/stream).
+
+Unit tests verify event mapping, envelope structure, delivery, and
+error handling.  Integration tests verify the HTTP endpoint contract
+(request validation and response shape).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from seeknal.ask.gateway.webhook import WebhookClient, WebhookConfig
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def config() -> WebhookConfig:
+    return WebhookConfig(
+        message_id="test-msg-001",
+        session_id="default",
+        webhook_url="https://example.com/hook",
+    )
+
+
+@pytest.fixture
+def client(config: WebhookConfig) -> WebhookClient:
+    return WebhookClient(config)
+
+
+# ===================================================================
+# Unit tests — build_webhook_url
+# ===================================================================
+
+
+class TestBuildWebhookUrl:
+    def test_valid_path(self, monkeypatch):
+        monkeypatch.setenv("SEEKNAL_WEBHOOK_BASE_URL", "https://example.com")
+        url = WebhookClient.build_webhook_url("/sse/push?id=1")
+        assert url == "https://example.com/sse/push?id=1"
+
+    def test_strips_trailing_slash_on_base(self, monkeypatch):
+        monkeypatch.setenv("SEEKNAL_WEBHOOK_BASE_URL", "https://example.com/")
+        url = WebhookClient.build_webhook_url("/hook")
+        assert url == "https://example.com/hook"
+
+    def test_strips_whitespace_on_base(self, monkeypatch):
+        monkeypatch.setenv("SEEKNAL_WEBHOOK_BASE_URL", "  https://example.com  ")
+        url = WebhookClient.build_webhook_url("/hook")
+        assert url == "https://example.com/hook"
+
+    def test_missing_env_raises(self, monkeypatch):
+        monkeypatch.delenv("SEEKNAL_WEBHOOK_BASE_URL", raising=False)
+        with pytest.raises(ValueError, match="SEEKNAL_WEBHOOK_BASE_URL"):
+            WebhookClient.build_webhook_url("/hook")
+
+    def test_empty_env_raises(self, monkeypatch):
+        monkeypatch.setenv("SEEKNAL_WEBHOOK_BASE_URL", "  ")
+        with pytest.raises(ValueError, match="SEEKNAL_WEBHOOK_BASE_URL"):
+            WebhookClient.build_webhook_url("/hook")
+
+    def test_no_leading_slash_raises(self, monkeypatch):
+        monkeypatch.setenv("SEEKNAL_WEBHOOK_BASE_URL", "https://example.com")
+        with pytest.raises(ValueError, match="must start with '/'"):
+            WebhookClient.build_webhook_url("https://evil.com/steal")
+
+
+# ===================================================================
+# Unit tests — _make_event (envelope)
+# ===================================================================
+
+
+class TestMakeEvent:
+    def test_envelope_structure(self, client: WebhookClient):
+        evt = client._make_event("start")
+        assert evt["event"] == "start"
+        assert evt["message_id"] == "test-msg-001"
+        assert evt["conversation_id"] == "default"
+        assert "created_at" in evt
+        assert evt["payload"] == {}
+
+    def test_payload_passed_through(self, client: WebhookClient):
+        evt = client._make_event("message", {"answer": "Paris"})
+        assert evt["event"] == "message"
+        assert evt["payload"] == {"answer": "Paris"}
+
+    def test_created_at_is_iso8601(self, client: WebhookClient):
+        evt = client._make_event("done")
+        # Should parse without error
+        from datetime import datetime
+        datetime.fromisoformat(evt["created_at"])
+
+
+# ===================================================================
+# Unit tests — _map_event
+# ===================================================================
+
+
+class TestMapEvent:
+    def test_token_skipped(self, client: WebhookClient):
+        assert client._map_event({"type": "token", "data": "x"}) is None
+
+    def test_reasoning_maps_to_message(self, client: WebhookClient):
+        evt = client._map_event({"type": "reasoning", "data": "thinking..."})
+        assert evt["event"] == "message"
+        assert evt["payload"]["answer"] == "thinking..."
+
+    def test_answer_maps_to_message(self, client: WebhookClient):
+        evt = client._map_event({"type": "answer", "data": "Paris"})
+        assert evt["event"] == "message"
+        assert evt["payload"]["answer"] == "Paris"
+
+    def test_tool_start_maps_to_tool_call(self, client: WebhookClient):
+        evt = client._map_event({
+            "type": "tool_start",
+            "data": {"name": "execute_sql", "args": {"query": "SELECT 1"}},
+        })
+        assert evt["event"] == "tool_call"
+        assert evt["payload"]["tool_name"] == "execute_sql"
+        assert evt["payload"]["tool_args"] == {"query": "SELECT 1"}
+
+    def test_tool_end_maps_to_tool_result(self, client: WebhookClient):
+        evt = client._map_event({
+            "type": "tool_end",
+            "data": {"name": "execute_sql", "output": "5 rows"},
+        })
+        assert evt["event"] == "tool_result"
+        assert evt["payload"]["tool_name"] == "execute_sql"
+        assert evt["payload"]["tool_result"] == "5 rows"
+
+    def test_unknown_type_skipped(self, client: WebhookClient):
+        assert client._map_event({"type": "weird", "data": "x"}) is None
+
+
+# ===================================================================
+# Unit tests — run_and_deliver (event sequence)
+# ===================================================================
+
+
+class TestRunAndDeliver:
+    @pytest.fixture(autouse=True)
+    def _require_starlette(self):
+        pytest.importorskip("starlette")
+
+    def test_full_sequence(self, client: WebhookClient):
+        """start → message → tool_call → tool_result → message → done"""
+        import seeknal.ask.gateway.server as server_mod
+
+        raw_events = [
+            {"type": "reasoning", "data": "Let me think..."},
+            {"type": "tool_start", "data": {"name": "execute_sql", "args": {"query": "SELECT 1"}}},
+            {"type": "tool_end", "data": {"name": "execute_sql", "output": "1 row"}},
+            {"type": "answer", "data": "The answer is 1."},
+        ]
+
+        with patch(
+            "seeknal.ask.gateway.webhook.WebhookClient._post",
+            new_callable=AsyncMock,
+        ) as mock_post, patch.object(
+            server_mod, "_run_agent_streaming",
+            return_value=_async_iter(raw_events),
+        ):
+            asyncio.run(client.run_and_deliver(Path("/tmp/proj"), "default", "test"))
+
+        event_names = [call.args[0]["event"] for call in mock_post.call_args_list]
+        assert event_names == [
+            "start",
+            "message",      # reasoning
+            "tool_call",
+            "tool_result",
+            "message",      # answer
+            "done",
+        ]
+
+    def test_error_event_on_exception(self, client: WebhookClient):
+        """Agent raises → error event with code + message, then done."""
+        import seeknal.ask.gateway.server as server_mod
+
+        async def _fail(*args, **kwargs):
+            raise RuntimeError("DB connection lost")
+            yield  # noqa: unreachable — makes this an async generator
+
+        with patch(
+            "seeknal.ask.gateway.webhook.WebhookClient._post",
+            new_callable=AsyncMock,
+        ) as mock_post, patch.object(
+            server_mod, "_run_agent_streaming",
+            side_effect=_fail,
+        ):
+            asyncio.run(client.run_and_deliver(Path("/tmp/proj"), "default", "test"))
+
+        event_names = [call.args[0]["event"] for call in mock_post.call_args_list]
+        assert event_names == ["start", "error", "done"]
+        error_evt = mock_post.call_args_list[1].args[0]
+        assert error_evt["payload"]["error_code"] == "agent_error"
+        assert "DB connection lost" in error_evt["payload"]["error_message"]
+
+    def test_heartbeat_fires(self, client: WebhookClient):
+        """Heartbeat event should be posted during a long agent run."""
+        import seeknal.ask.gateway.server as server_mod
+
+        async def _slow_iter():
+            """Simulate a slow agent that takes long enough for heartbeat."""
+            yield {"type": "reasoning", "data": "thinking"}
+            await asyncio.sleep(0.05)  # hold long enough for heartbeat
+
+        async def _run():
+            with patch(
+                "seeknal.ask.gateway.webhook.WebhookClient._post",
+                new_callable=AsyncMock,
+            ) as mock_post, patch.object(
+                server_mod, "_run_agent_streaming",
+                return_value=_slow_iter(),
+            ), patch(
+                "seeknal.ask.gateway.webhook._HEARTBEAT_INTERVAL",
+                0.01,  # tiny interval for testing
+            ):
+                await client.run_and_deliver(Path("/tmp/proj"), "default", "test")
+                return mock_post
+
+        mock_post = asyncio.run(_run())
+        event_names = [call.args[0]["event"] for call in mock_post.call_args_list]
+        assert "heartbeat" in event_names
+        assert "start" in event_names
+        assert "done" in event_names
+
+
+# ===================================================================
+# Integration tests — POST /ask/stream endpoint
+# ===================================================================
+
+
+class TestAskStreamEndpoint:
+    @pytest.fixture(autouse=True)
+    def _require_starlette(self):
+        pytest.importorskip("starlette")
+
+    @pytest.fixture
+    def app(self, tmp_path: Path):
+        from starlette.testclient import TestClient  # noqa: F401
+        from seeknal.ask.gateway.server import create_gateway_app
+        return create_gateway_app(str(tmp_path))
+
+    @pytest.fixture
+    def test_client(self, app):
+        from starlette.testclient import TestClient
+        return TestClient(app)
+
+    def test_returns_201_with_message_id(self, test_client, monkeypatch):
+        monkeypatch.setenv("SEEKNAL_WEBHOOK_BASE_URL", "https://example.com")
+        resp = test_client.post("/ask/stream", json={
+            "question": "What is the capital of France?",
+            "message_id": "abc-123",
+            "webhook_path": "/hook",
+        })
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["message_id"] == "abc-123"
+
+    def test_missing_question_returns_400(self, test_client, monkeypatch):
+        monkeypatch.setenv("SEEKNAL_WEBHOOK_BASE_URL", "https://example.com")
+        resp = test_client.post("/ask/stream", json={
+            "message_id": "abc-123",
+            "webhook_path": "/hook",
+        })
+        assert resp.status_code == 400
+        assert "question" in resp.json()["error"]
+
+    def test_missing_message_id_returns_400(self, test_client, monkeypatch):
+        monkeypatch.setenv("SEEKNAL_WEBHOOK_BASE_URL", "https://example.com")
+        resp = test_client.post("/ask/stream", json={
+            "question": "test",
+            "webhook_path": "/hook",
+        })
+        assert resp.status_code == 400
+        assert "message_id" in resp.json()["error"]
+
+    def test_missing_webhook_path_returns_400(self, test_client, monkeypatch):
+        monkeypatch.setenv("SEEKNAL_WEBHOOK_BASE_URL", "https://example.com")
+        resp = test_client.post("/ask/stream", json={
+            "question": "test",
+            "message_id": "abc-123",
+        })
+        assert resp.status_code == 400
+        assert "webhook_path" in resp.json()["error"]
+
+    def test_invalid_webhook_path_returns_400(self, test_client, monkeypatch):
+        monkeypatch.setenv("SEEKNAL_WEBHOOK_BASE_URL", "https://example.com")
+        resp = test_client.post("/ask/stream", json={
+            "question": "test",
+            "message_id": "abc-123",
+            "webhook_path": "https://evil.com/steal",
+        })
+        assert resp.status_code == 400
+
+    def test_missing_base_url_returns_400(self, test_client, monkeypatch):
+        monkeypatch.delenv("SEEKNAL_WEBHOOK_BASE_URL", raising=False)
+        resp = test_client.post("/ask/stream", json={
+            "question": "test",
+            "message_id": "abc-123",
+            "webhook_path": "/hook",
+        })
+        assert resp.status_code == 400
+
+    def test_message_id_echoed_back(self, test_client, monkeypatch):
+        monkeypatch.setenv("SEEKNAL_WEBHOOK_BASE_URL", "https://example.com")
+        resp = test_client.post("/ask/stream", json={
+            "question": "test",
+            "message_id": "custom-id-999",
+            "webhook_path": "/hook",
+        })
+        assert resp.json()["message_id"] == "custom-id-999"
+
+    def test_invalid_session_id_returns_400(self, test_client, monkeypatch):
+        monkeypatch.setenv("SEEKNAL_WEBHOOK_BASE_URL", "https://example.com")
+        resp = test_client.post("/ask/stream", json={
+            "question": "test",
+            "message_id": "abc-123",
+            "webhook_path": "/hook",
+            "session_id": "bad session!!!",
+        })
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _async_iter(items: list):
+    """Wrap a list as an async iterator for mocking _run_agent_streaming."""
+    for item in items:
+        yield item


### PR DESCRIPTION
## Summary
- Adds `POST /ask/stream` endpoint: client POSTs a question with a `webhook_path`, gets an immediate 201, and receives agent events via HTTP POST callbacks
- New `WebhookClient` + `WebhookConfig` in `webhook.py` handles event mapping (token→skip, reasoning/answer→message, tool_start→tool_call, tool_end→tool_result), HTTP delivery with retries, and a 15s heartbeat loop
- 26 tests: unit tests for URL building, envelope structure, event mapping, full delivery sequence, error handling, and heartbeat; integration tests for the HTTP endpoint contract (201/400 responses)

## Test plan
- [x] `uv run pytest tests/ask/test_webhook.py -v` — 26 passed
- [x] `uv run pytest tests/ask/ -v` — 578 passed, 67 skipped, 0 regressions
- [ ] Manual smoke test: start gateway with `SEEKNAL_WEBHOOK_BASE_URL=https://httpbin.org/post`, POST to `/ask/stream`, observe webhook events arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)