### PR TITLE
fix(iceberg): quote DuckDB identifiers with hyphens in warehouse/catalog names

### DIFF
--- a/src/seeknal/workflow/dry_run.py
+++ b/src/seeknal/workflow/dry_run.py
@@ -605,13 +605,18 @@ def _load_iceberg_source(table: str, params: dict):
 
         # Normalize table name: if 3-part (catalog.namespace.table), strip
         # the catalog prefix since we've attached our own catalog alias.
+        # Quote identifiers that contain hyphens for DuckDB compatibility.
+        import re as _re
+        def _qi(n):
+            return n if _re.match(r'^[A-Za-z_][A-Za-z0-9_]*$', n) else f'"{n}"'
+
         parts = table.split(".")
         if len(parts) == 3:
-            query_table = f"iceberg_cat.{parts[1]}.{parts[2]}"
+            query_table = f"iceberg_cat.{_qi(parts[1])}.{_qi(parts[2])}"
         elif len(parts) == 2:
-            query_table = f"iceberg_cat.{parts[0]}.{parts[1]}"
+            query_table = f"iceberg_cat.{_qi(parts[0])}.{_qi(parts[1])}"
         else:
-            query_table = f"iceberg_cat.{table}"
+            query_table = f"iceberg_cat.{_qi(table)}"
 
         df = con.execute(f"SELECT * FROM {query_table}").df()
         con.close()

--- a/src/seeknal/workflow/executors/source_executor.py
+++ b/src/seeknal/workflow/executors/source_executor.py
@@ -23,9 +23,17 @@ Key Components:
 from __future__ import annotations
 
 import logging
+import re
 import time
 from pathlib import Path
 from typing import Any, Dict, Optional
+
+
+def _qi(name: str) -> str:
+    """Quote a DuckDB identifier if it contains special characters (e.g. hyphens)."""
+    if re.match(r'^[A-Za-z_][A-Za-z0-9_]*$', name):
+        return name
+    return f'"{name}"'
 
 from seeknal.dag.manifest import Node, NodeType  # ty: ignore[unresolved-import]
 from seeknal.validation import validate_file_path  # ty: ignore[unresolved-import]
@@ -1128,7 +1136,9 @@ class SourceExecutor(BaseExecutor):
                 f"got '{table}' ({len(parts)} parts)"
             )
 
-        catalog_alias, namespace, table_name = parts
+        catalog_alias_raw, namespace_raw, table_name = parts
+        catalog_alias = _qi(catalog_alias_raw)
+        namespace = _qi(namespace_raw)
 
         # Get connection config from params or env vars
         catalog_uri = params.get(
@@ -1223,6 +1233,7 @@ class SourceExecutor(BaseExecutor):
                             AUTHORIZATION_TYPE 'none'
                         )
                     """)
+                logger.info(f"Attached Iceberg catalog: {catalog_alias}")
             except Exception as attach_err:
                 # Catalog may already be attached from a previous source
                 if "already exists" not in str(attach_err).lower():
@@ -1286,7 +1297,7 @@ class SourceExecutor(BaseExecutor):
             snapshot_id = None
             try:
                 snap_result = con.execute(
-                    f"SELECT snapshot_id FROM iceberg_snapshots('{catalog_alias}.{namespace}.{table_name}') "
+                    f"SELECT snapshot_id FROM iceberg_snapshots('{catalog_alias_raw}.{namespace_raw}.{table_name}') "
                     f"ORDER BY timestamp_ms DESC LIMIT 1"
                 ).fetchone()
                 if snap_result:

--- a/src/seeknal/workflow/materialization/operations.py
+++ b/src/seeknal/workflow/materialization/operations.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import re
 import threading
 import time
 import uuid
@@ -53,6 +54,13 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Set
+
+
+def _qi(name: str) -> str:
+    """Quote a DuckDB identifier if it contains special characters (e.g. hyphens)."""
+    if re.match(r'^[A-Za-z_][A-Za-z0-9_]*$', name):
+        return name
+    return f'"{name}"'
 
 from seeknal.workflow.materialization.config import (
     MaterializationConfig,
@@ -388,9 +396,11 @@ class DuckDBIcebergExtension:
                 catalog_url = base_url
 
             # Build ATTACH SQL with inline token auth
+            # Quote catalog_name for identifiers with hyphens (e.g. prod-dwa-hot-bronze)
+            quoted_name = _qi(catalog_name)
             if bearer_token:
                 sql = (
-                    f"ATTACH '{warehouse_path}' AS {catalog_name} ("
+                    f"ATTACH '{warehouse_path}' AS {quoted_name} ("
                     f"TYPE ICEBERG, "
                     f"ENDPOINT '{catalog_url}', "
                     f"AUTHORIZATION_TYPE 'oauth2', "
@@ -399,7 +409,7 @@ class DuckDBIcebergExtension:
                 )
             else:
                 sql = (
-                    f"ATTACH '{warehouse_path}' AS {catalog_name} ("
+                    f"ATTACH '{warehouse_path}' AS {quoted_name} ("
                     f"TYPE ICEBERG, "
                     f"ENDPOINT '{catalog_url}', "
                     f"AUTHORIZATION_TYPE 'none'"
@@ -683,11 +693,13 @@ def create_iceberg_table(
     # Build SQL
     # When table_name is 3-part (catalog.namespace.table), strip the
     # catalog prefix since ATTACH already provides it as catalog_name.
+    # Quote identifiers that contain hyphens for DuckDB compatibility.
+    _qcat = _qi(catalog_name)
     _parts = table_name.split(".")
     if len(_parts) == 3:
-        full_table_name = f"{catalog_name}.{_parts[1]}.{_parts[2]}"
+        full_table_name = f"{_qcat}.{_qi(_parts[1])}.{_qi(_parts[2])}"
     else:
-        full_table_name = f"{catalog_name}.{table_name}"
+        full_table_name = f"{_qcat}.{_qi(table_name)}"
     sql = f"""
         CREATE TABLE IF NOT EXISTS {full_table_name} (
             {', '.join(column_defs)}
@@ -763,15 +775,16 @@ def write_to_iceberg(
 
     # When table_name is 3-part (catalog.namespace.table), strip the
     # catalog prefix since ATTACH already provides it as catalog_name.
+    _qcat = _qi(catalog_name)
     _parts = table_name.split(".")
     if len(_parts) == 3:
-        full_table_name = f"{catalog_name}.{_parts[1]}.{_parts[2]}"
+        full_table_name = f"{_qcat}.{_qi(_parts[1])}.{_qi(_parts[2])}"
         namespace = _parts[1]
     elif len(_parts) == 2:
-        full_table_name = f"{catalog_name}.{table_name}"
+        full_table_name = f"{_qcat}.{_qi(_parts[0])}.{_qi(_parts[1])}"
         namespace = _parts[0]
     else:
-        full_table_name = f"{catalog_name}.{table_name}"
+        full_table_name = f"{_qcat}.{_qi(table_name)}"
         namespace = None
 
     # Auto-create namespace and table if they don't exist
@@ -887,7 +900,7 @@ def _ensure_table_exists(
     # Create namespace if provided
     if namespace:
         try:
-            con.execute(f"CREATE SCHEMA IF NOT EXISTS {catalog_name}.{namespace}")
+            con.execute(f"CREATE SCHEMA IF NOT EXISTS {_qi(catalog_name)}.{_qi(namespace)}")
             logger.info(f"Created namespace: {catalog_name}.{namespace}")
         except Exception as exc:
             # Schema may already exist; log and continue

--- a/uv.lock
+++ b/uv.lock
@@ -4001,7 +4001,7 @@ wheels = [
 
 [[package]]
 name = "seeknal"
-version = "2.5.1"
+version = "2.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary

- **Fix DuckDB parser error for hyphenated warehouse names** like `prod-dwa-hot-bronze`: add `_qi()` helper that double-quotes identifiers containing special characters
- Applied across all 3 Iceberg code paths: source executor, materialization operations, and dry-run preview
- Fixes: `Parser Error: syntax error at or near "-"` when using `ATTACH ... AS prod-dwa-hot-bronze`

## Test plan

- [x] Reproduced exact error against live Lakekeeper: unquoted `AS seeknal-warehouse` → `syntax error at "-"`
- [x] Verified fix: quoted `AS "seeknal-warehouse"` → ATTACH succeeded, query returned rows
- [x] Verified `_qi()` quoting: `prod-dwa-hot-bronze` → `"prod-dwa-hot-bronze"`, `ACCTMGMT` → `ACCTMGMT` (no unnecessary quoting)
- [x] `iceberg_snapshots()` function arg uses raw (unquoted) names since it takes a string, not SQL identifier
- [x] All tested against real Lakekeeper + MinIO on atlas-dev-server (172.19.0.9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)