### PR TITLE
chore: bump version to 2.5.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "seeknal"
-version = "2.5.2"
+version = "2.5.3"
 description = "All-in-one platform for data and AI/ML engineering"
 authors = [
     {name = "Fitra Kacamarga"}

--- a/uv.lock
+++ b/uv.lock
@@ -4001,7 +4001,7 @@ wheels = [
 
 [[package]]
 name = "seeknal"
-version = "2.5.2"
+version = "2.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary

- Bump version to 2.5.3 (follows hyphenated warehouse fix in #33)

🤖 Generated with [Claude Code](https://claude.com/claude-code)