### PR TITLE
Release v26.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [26.3.0] - 2026-04-14
+
+### Added
+- **Per-node Iceberg overrides**: `catalog_uri` and `warehouse` can now be overridden per materialization node, allowing a single pipeline to write to multiple Iceberg catalogs/warehouses (#38)
+- **Seeknal Ask QA test suite**: full end-to-end QA coverage for the Ask agent, including Iceberg and remote source dry-runs (#29)
+
+### Fixed
+- **Iceberg identifier quoting**: DuckDB identifiers in warehouse/catalog names are now quoted when they contain hyphens, preventing SQL parse errors (#33)
+- **Iceberg dry-run auth**: dry-run now uses `SET`-based S3 auth instead of `ATTACH SECRET`, fixing credential leakage during planning (#31)
+
+### Changed
+- **Version bump**: 2.5.x → 26.3.0
+
 ## [2.5.0] - 2026-04-06
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "seeknal"
-version = "2.5.4"
+version = "26.3.0"
 description = "All-in-one platform for data and AI/ML engineering"
 authors = [
     {name = "Fitra Kacamarga"}

--- a/src/seeknal/__init__.py
+++ b/src/seeknal/__init__.py
@@ -29,7 +29,7 @@ Example:
 For more information, see the documentation at https://seeknal.readthedocs.io/
 """
 
-__version__ = "2.5.0"
+__version__ = "26.3.0"
 
 # Export validation functions
 from .validation import (

--- a/src/seeknal/workflow/executors/__init__.py
+++ b/src/seeknal/workflow/executors/__init__.py
@@ -148,4 +148,4 @@ __all__ = [
 ]
 
 # Version info
-__version__ = "2.5.0"
+__version__ = "26.3.0"


### PR DESCRIPTION
## Summary

Cuts release **v26.3.0** by bumping the version and updating the changelog. This PR targets the new `release/v26.3.0` branch (forked from `main` at `b8b61dc`).

### Version bumps
- `pyproject.toml`: `2.5.4` → `26.3.0`
- `src/seeknal/__init__.py`: `2.5.0` → `26.3.0`
- `src/seeknal/workflow/executors/__init__.py`: `2.5.0` → `26.3.0`

### Changelog
Added `[26.3.0] - 2026-04-14` entry summarizing what has landed on `main` since `2.5.0`:

**Added**
- Per-node `catalog_uri` and `warehouse` overrides for Iceberg materialization (#38)
- Full Seeknal Ask QA test suite + dry-run fix for Iceberg/remote sources (#29)

**Fixed**
- DuckDB identifier quoting for hyphenated Iceberg warehouse/catalog names (#33)
- Iceberg dry-run S3 auth now uses `SET` instead of `ATTACH SECRET` (#31)

## Test plan

- [ ] `pyproject.toml` version matches `__version__` in `src/seeknal/__init__.py` and `src/seeknal/workflow/executors/__init__.py`
- [ ] `seeknal --version` reports `26.3.0` after install
- [ ] CI passes on `release/v26.3.0`
- [ ] Tag `v26.3.0` after merge

https://claude.ai/code/session_01WMf6iotEsBv4cThHQ4Fqw3