### PR TITLE
fix(ask): remove deprecated pydantic-ai kwargs + fix gateway callback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "seeknal"
-version = "2.6.0"
+version = "2.6.1"
 description = "All-in-one platform for data and AI/ML engineering"
 authors = [
     {name = "Fitra Kacamarga"}

--- a/src/seeknal/__init__.py
+++ b/src/seeknal/__init__.py
@@ -29,7 +29,7 @@ Example:
 For more information, see the documentation at https://seeknal.readthedocs.io/
 """
 
-__version__ = "2.6.0"
+__version__ = "2.6.1"
 
 # Export validation functions
 from .validation import (

--- a/src/seeknal/ask/agents/agent.py
+++ b/src/seeknal/ask/agents/agent.py
@@ -210,10 +210,6 @@ def create_agent(
         # Subagents
         include_subagents=True,
         subagents=get_subagent_configs(),
-        # Web search disabled: seeknal has domain-specific DuckDuckGo toolset
-        # added via toolsets_list when include_web=True.
-        web_search=False,
-        web_fetch=False,
         # Disabled: seeknal has domain-specific alternatives
         include_filesystem=False,
         include_execute=False,

--- a/src/seeknal/cli/gateway.py
+++ b/src/seeknal/cli/gateway.py
@@ -177,13 +177,12 @@ def gateway_start(
 
     # Pass temporal_client if already connected (for sync startup path)
     # The lifespan will also set it on app.state for the async path
-    # Default callback_url to self when Temporal is enabled and not specified.
-    # This lets workers POST streaming events back to the gateway without
-    # requiring the operator to explicitly pass --callback-url for single-host
-    # or locally reachable deployments. For cross-machine deployments, the
-    # operator should still set --callback-url to the externally reachable URL.
+    # Default callback_url to self ONLY in --no-worker mode (gateway-only).
+    # When the worker is embedded (default), _run_agent_streaming() already
+    # publishes to SSE directly — adding a callback to self would double-publish.
+    # For remote/split workers, the callback lets them POST events back.
     effective_callback_url = callback_url
-    if temporal_enabled and not effective_callback_url:
+    if temporal_enabled and no_worker and not effective_callback_url:
         effective_callback_url = f"http://{host}:{port}"
         typer.echo(typer.style(
             f"Callback URL defaulted to {effective_callback_url} (for worker event delivery)",


### PR DESCRIPTION
## Summary
- Remove deprecated `web_search`/`web_fetch` kwargs from `create_deep_agent()` call — newer `pydantic-ai` replaced these with the capabilities system, causing `UserError: Unknown keyword arguments` on agent init
- Fix gateway `callback_url` defaulting to self when the worker is embedded (default mode), which caused double-publish of SSE events — now only defaults in `--no-worker` mode
- Bump version to 2.6.1

## Test plan
- [ ] Run `seeknal ask` and verify agent initializes without `UserError: Unknown keyword arguments`
- [ ] Run `seeknal gateway start` (embedded worker) and verify no double SSE events
- [ ] Run `seeknal gateway start --no-worker` and verify callback_url still auto-defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)