### PR TITLE
feat(ask): conversational data ingestion + record-entry (images + /record)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.0] - 2026-04-18
+
+### Added
+
+- **Conversational data ingestion** — drop an `.xlsx / .csv / .tsv / .json` file or a direct-download URL into chat and the `data-ingest` built-in skill walks the user through schema preview → business key → append-or-create → reusable SKILL.md. Re-runs surface a self-defending drift/dedup report before any append write.
+  - New tools: `read_tabular`, `write_ingested_table`, `save_ingestion_skill`, `check_ingestion_drift`
+  - Every write emits a provenance JSON sidecar with SHA-256 of the source, row counts, and drift decisions
+- **Record entry from text or image** — `/record fitra, 1 mie ayam, 1 mineral water` or a BCA/Mandiri/GoPay/OVO/DANA fund-transfer screenshot becomes one row in a kind-appropriate `ingest_*` table. The `record-entry` skill classifies across `transfer`, `order`, `expense`, `activity`, `meeting`, `health`, `note`, and custom kinds, and asks for clarification until every required field is resolved.
+  - New tools: `parse_record` (kind-aware hint extractor), `extract_from_image` (Gemini vision via pydantic-ai `BinaryContent`), `propose_record_table` (table-aware schema router with per-kind templates + agent-supplied `_columns` override)
+- **Gateway endpoints**
+  - `POST /upload` — accepts tabular and image uploads with a shared body, returns `kind` (`"tabular"` | `"image"`) and a `next` hint. Tenant-scoped staging under `target/ask_ingest/_staging/{tenant}/{uuid}/`
+  - `POST /record` — runs the record-entry skill on free-form text via the streaming runner
+- **Telegram channel**
+  - `filters.Document.ALL` handler routes file uploads into `data-ingest`
+  - `filters.PHOTO` handler routes screenshots into `record-entry` with live status edits
+- **REPL Phase 1c** — on startup, `target/ask_ingest/*.parquet` files auto-register as `ingest_{stem}` DuckDB views (non-recursive `glob` deliberately excludes `_staging/` subdirectories)
+- **Built-in skills**: `data-ingest`, `record-entry`
+- **Dependency**: `openpyxl>=3.1` added to `seeknal[ask]` extras for `.xlsx` parsing
+
+### Changed
+
+- `WRITABLE_DIRS` in the ask agent's write-security allowlist now includes `target/` (canonical pipeline output scope)
+- `ToolContext` gained `last_read_staging_path` for tool-to-tool handoff of parsed file locations
+- Gateway startup banner now lists `/upload` and `/record` alongside the existing endpoints
+
+### Security
+
+- **SSRF** — `read_tabular` blocks private / loopback / link-local / reserved IP ranges (incl. `169.254.169.254` cloud metadata) and disables HTTP redirect following so a public URL cannot bounce into an internal host
+- **Content-Disposition traversal** — attacker-controlled filenames from HTTP responses normalised via `Path(...).name` before joining to the staging root
+- **Tenant isolation** — `POST /upload` resolves tenant via `X-Tenant-ID` and stages under per-tenant UUID directories
+- **fs_lock** — `write_ingested_table`'s parquet swap + provenance write are now serialised against sibling filesystem tools (`draft_node`, `apply_draft`, `save_ingestion_skill`)
+- **Self-defending write** — `write_ingested_table(mode='append', user_confirmed=False)` returns the drift report without touching disk, eliminating any reliance on the per-turn `reset_report_approval()` flag reset
+
+### Fixed
+
+- `TestTemporalWorkerFactory::test_create_worker` now patches `Worker` at the call site instead of passing a `MagicMock` to the constructor (newer `temporalio` versions enforce that the client argument is a real bridge client)
+
 ## [2.6.0] - 2026-04-16
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ ask = [
     "scikit-learn>=1.5.0",
     "scipy>=1.14.0",
     "redis>=4.5.0",
+    "openpyxl>=3.1",
 ]
 
 # Telegram bot integration (optional, on top of ask)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ ask = [
     "scipy>=1.14.0",
     "redis>=4.5.0",
     "openpyxl>=3.1",
+    "python-multipart>=0.0.9",
 ]
 
 # Telegram bot integration (optional, on top of ask)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "seeknal"
-version = "2.6.3"
+version = "2.7.0"
 description = "All-in-one platform for data and AI/ML engineering"
 authors = [
     {name = "Fitra Kacamarga"}

--- a/src/seeknal/ask/agents/tools/_context.py
+++ b/src/seeknal/ask/agents/tools/_context.py
@@ -58,6 +58,7 @@ class ToolContext:
     console: Any = None
     plan_steps: list[str] = field(default_factory=list)
     plan_step_index: int = 0
+    last_read_staging_path: str | None = None
 
 
 def _make_registry():

--- a/src/seeknal/ask/agents/tools/_write_security.py
+++ b/src/seeknal/ask/agents/tools/_write_security.py
@@ -18,6 +18,7 @@ WRITABLE_DIRS = {
     "seeknal",        # Pipeline definitions
     "data",           # Data files
     ".seeknal",       # Internal state (drafts, plans, checkpoints)
+    "target",         # Pipeline outputs (intermediate, cache, ask_ingest)
 }
 
 # Files that must never be written by the agent

--- a/src/seeknal/ask/agents/tools/check_ingestion_drift.py
+++ b/src/seeknal/ask/agents/tools/check_ingestion_drift.py
@@ -1,0 +1,240 @@
+"""Check ingestion drift tool — compare new file against an existing table.
+
+Returns a structured markdown report of schema differences (missing/extra/
+changed columns), duplicate business key count, and row count comparison.
+The report ends with an explicit recommendation the agent can relay to
+the user via ``ask_user``.
+
+The write tool also runs its own internal drift check; this tool exists so
+the SKILL.md prose can request a user-presentable report as a first pass.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_TABLE_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+_COLUMN_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+_SUPPORTED_SUFFIXES = {".csv", ".tsv", ".json", ".parquet"}
+
+
+def check_ingestion_drift(
+    source_path: str,
+    table_name: str,
+    business_key: str,
+) -> str:
+    """Compare a new file's schema and data against an existing ingested table.
+
+    Returns a structured report of: schema differences (missing/extra/changed columns),
+    duplicate business key count, and row count comparison. Use this before
+    write_ingested_table in append mode to inform the user.
+
+    Args:
+        source_path: Path to the new source file.
+        table_name: Existing ingested table name (without 'ingest_' prefix).
+        business_key: Comma-separated business key columns.
+    """
+    from seeknal.ask.agents.tools._context import get_tool_context
+
+    ctx = get_tool_context()
+
+    if not _TABLE_NAME_RE.match(table_name):
+        return f"Error: invalid table_name '{table_name}'."
+
+    business_key_cols = [c.strip() for c in business_key.split(",") if c.strip()]
+    if not business_key_cols:
+        return "Error: business_key must name at least one column."
+    for col in business_key_cols:
+        if not _COLUMN_NAME_RE.match(col):
+            return f"Error: invalid business key column '{col}'."
+
+    candidate = _resolve_source(source_path, ctx)
+    if candidate is None:
+        return (
+            "Error: source file not found. Pass an absolute path or call "
+            "read_tabular first."
+        )
+
+    suffix = candidate.suffix.lower()
+    if suffix not in _SUPPORTED_SUFFIXES:
+        return (
+            f"Error: unsupported source suffix '{suffix}'. "
+            "Use read_tabular to stage an xlsx file into parquet first."
+        )
+
+    existing_parquet = ctx.project_path / "target" / "ask_ingest" / f"{table_name}.parquet"
+    if not existing_parquet.exists():
+        return (
+            f"No existing table `ingest_{table_name}` found at {existing_parquet}.\n\n"
+            "This is a first ingestion. Call `write_ingested_table(mode='create')` "
+            "to create the table."
+        )
+
+    return _report(
+        candidate=candidate,
+        existing_parquet=existing_parquet,
+        table_name=table_name,
+        business_key_cols=business_key_cols,
+    )
+
+
+def _resolve_source(source_path: str, ctx) -> Path | None:
+    candidate_raw = source_path or getattr(ctx, "last_read_staging_path", None) or ""
+    if not candidate_raw:
+        return None
+    candidate = Path(candidate_raw).expanduser()
+    if not candidate.is_absolute():
+        candidate = (ctx.project_path / candidate).resolve()
+    else:
+        candidate = candidate.resolve()
+    if not candidate.exists() or not candidate.is_file():
+        return None
+    return candidate
+
+
+def _reader_expr(path: Path) -> str:
+    safe = str(path.resolve()).replace("'", "''")
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        return f"read_csv_auto('{safe}')"
+    if suffix == ".tsv":
+        return f"read_csv_auto('{safe}', delim='\\t')"
+    if suffix == ".json":
+        return f"read_json_auto('{safe}')"
+    if suffix == ".parquet":
+        return f"read_parquet('{safe}')"
+    raise ValueError(f"unsupported suffix: {suffix}")
+
+
+def _report(
+    candidate: Path,
+    existing_parquet: Path,
+    table_name: str,
+    business_key_cols: list[str],
+) -> str:
+    import duckdb
+
+    new_reader = _reader_expr(candidate)
+    safe_existing = str(existing_parquet.resolve()).replace("'", "''")
+    existing_reader = f"read_parquet('{safe_existing}')"
+
+    # Own in-memory DuckDB — does not share state with the session REPL, so
+    # there is no need to hold ctx.db_lock (which protects ctx.repl.conn).
+    con = duckdb.connect(":memory:")
+    try:
+        schema_new = [
+            (row[0], row[1])
+            for row in con.execute(f"DESCRIBE SELECT * FROM {new_reader}").fetchall()
+        ]
+        schema_existing = [
+            (row[0], row[1])
+            for row in con.execute(
+                f"DESCRIBE SELECT * FROM {existing_reader}"
+            ).fetchall()
+        ]
+        (new_rows,) = con.execute(f"SELECT COUNT(*) FROM {new_reader}").fetchone()
+        (existing_rows,) = con.execute(
+            f"SELECT COUNT(*) FROM {existing_reader}"
+        ).fetchone()
+
+        new_map = dict(schema_new)
+        existing_map = dict(schema_existing)
+        missing_in_new = [c for c in existing_map if c not in new_map]
+        extra_in_new = [c for c in new_map if c not in existing_map]
+        type_mismatches = [
+            (c, existing_map[c], new_map[c])
+            for c in new_map
+            if c in existing_map and new_map[c] != existing_map[c]
+        ]
+        missing_bk_new = [c for c in business_key_cols if c not in new_map]
+        missing_bk_existing = [
+            c for c in business_key_cols if c not in existing_map
+        ]
+
+        duplicate_count = 0
+        if not missing_bk_new and not missing_bk_existing:
+            bk_select = ", ".join(f'"{c}"' for c in business_key_cols)
+            (duplicate_count,) = con.execute(
+                f"SELECT COUNT(*) FROM ("
+                f"SELECT {bk_select} FROM {new_reader} "
+                f"INTERSECT "
+                f"SELECT {bk_select} FROM {existing_reader})"
+            ).fetchone()
+    except Exception as exc:
+        con.close()
+        return f"Error comparing schemas: {exc}"
+    con.close()
+
+    lines: list[str] = []
+    lines.append(f"## Drift check for `ingest_{table_name}`")
+    lines.append("")
+    lines.append(f"- New file rows: **{new_rows:,}**")
+    lines.append(f"- Existing table rows: **{existing_rows:,}**")
+    lines.append(f"- Business key: {', '.join(business_key_cols)}")
+    lines.append(f"- Duplicate business-key rows: **{duplicate_count:,}**")
+    lines.append("")
+
+    if (
+        not missing_in_new
+        and not extra_in_new
+        and not type_mismatches
+        and not missing_bk_new
+        and not missing_bk_existing
+    ):
+        lines.append("**Schema match.** All existing columns are present with matching types.")
+    else:
+        lines.append("### Schema differences")
+        if missing_in_new:
+            lines.append(
+                "- Missing from new file: " + ", ".join(f"`{c}`" for c in missing_in_new)
+            )
+        if extra_in_new:
+            lines.append(
+                "- New columns not in existing table: "
+                + ", ".join(f"`{c}`" for c in extra_in_new)
+            )
+        if type_mismatches:
+            mismatch_str = "; ".join(
+                f"`{col}` (was `{e}`, now `{n}`)" for col, e, n in type_mismatches
+            )
+            lines.append(f"- Type mismatches: {mismatch_str}")
+        if missing_bk_new:
+            lines.append(
+                "- Business key missing in new file: "
+                + ", ".join(f"`{c}`" for c in missing_bk_new)
+            )
+        if missing_bk_existing:
+            lines.append(
+                "- Business key missing in existing table: "
+                + ", ".join(f"`{c}`" for c in missing_bk_existing)
+            )
+    lines.append("")
+
+    if duplicate_count > 0:
+        lines.append(
+            f"**Recommendation:** {duplicate_count:,} row(s) already exist for the "
+            "same business key. I suggest **skipping duplicates** (keep existing) "
+            "unless the new file is a correction, in which case choose "
+            "**replace duplicates**."
+        )
+    elif type_mismatches or missing_in_new or extra_in_new:
+        lines.append(
+            "**Recommendation:** schema drifted. Confirm the differences with the "
+            "user before appending."
+        )
+    else:
+        lines.append(
+            "**Recommendation:** no duplicates or drift. Safe to append with "
+            "`dedup_strategy='skip'`."
+        )
+
+    lines.append("")
+    lines.append(
+        "Next: present this report via `ask_user` with options like "
+        "`Skip duplicates (keep existing)`, `Replace duplicates (keep new)`, "
+        "`Skip this file`, `Type your own`. After the user confirms, call "
+        "`write_ingested_table(mode='append', user_confirmed=True, "
+        "dedup_strategy='skip'|'replace')`."
+    )
+    return "\n".join(lines)

--- a/src/seeknal/ask/agents/tools/extract_from_image.py
+++ b/src/seeknal/ask/agents/tools/extract_from_image.py
@@ -1,0 +1,214 @@
+"""Extract from image tool — Gemini-vision OCR for receipts and transfer proofs.
+
+Spawns a short-lived pydantic-ai Agent bound to the same Google Gemini model
+used by the main ask agent, passes the image as a ``BinaryContent`` part,
+and asks for a structured JSON draft. The tool does NOT write anywhere — it
+returns the draft for the agent to inspect and confirm via ``ask_user``.
+
+Prioritises Indonesian banking / e-wallet terminology (BCA, Mandiri, GoPay,
+OVO, DANA, QRIS, ShopeePay) since fund-transfer proof screenshots are the
+most common input in that market.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+# Top-level imports so tests can patch `extract_from_image.Agent` /
+# `extract_from_image.BinaryContent` without triggering the deferred import.
+try:
+    from pydantic_ai import Agent, BinaryContent  # type: ignore[import]
+except ImportError:  # pragma: no cover — pydantic_ai is a hard dep of seeknal[ask]
+    Agent = None  # type: ignore[assignment]
+    BinaryContent = None  # type: ignore[assignment]
+
+_MAX_IMAGE_BYTES = 20 * 1024 * 1024  # 20 MB
+_MIME_BY_SUFFIX = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".webp": "image/webp",
+    ".heic": "image/heic",
+    ".heif": "image/heif",
+}
+
+_EXTRACTION_PROMPT = (
+    "You are analysing an image commonly shared in Indonesian chats: a bank "
+    "transfer proof (BCA, Mandiri, BNI, BRI, CIMB, BSI), an e-wallet receipt "
+    "(GoPay, OVO, DANA, ShopeePay, LinkAja), a QRIS confirmation, or a shop "
+    "receipt.\n\n"
+    "Extract the fields below. Use null if you are not confident. Never "
+    "invent values. All amounts must be plain integers in the smallest unit "
+    "of the currency (so IDR 1,500,000 becomes 1500000). Dates must be ISO "
+    "8601.\n\n"
+    "Required JSON schema:\n"
+    "{\n"
+    "  \"kind\": \"transfer\" | \"receipt\" | \"order\" | \"other\",\n"
+    "  \"amount\": integer | null,\n"
+    "  \"currency\": string (default \"IDR\"),\n"
+    "  \"sender_name\": string | null,\n"
+    "  \"sender_account\": string | null,\n"
+    "  \"recipient_name\": string | null,\n"
+    "  \"recipient_account\": string | null,\n"
+    "  \"bank\": string | null,     // e.g. BCA, Mandiri, GoPay, QRIS\n"
+    "  \"transaction_date\": string | null,\n"
+    "  \"reference_number\": string | null,\n"
+    "  \"merchant\": string | null, // for receipts / orders\n"
+    "  \"items\": [{\"name\": string, \"quantity\": integer | null, "
+    "\"price\": integer | null}] | [],\n"
+    "  \"note\": string | null,    // memo / berita / keterangan\n"
+    "  \"raw_text\": string        // full OCR text for audit\n"
+    "}\n\n"
+    "Return the JSON object only. No markdown fences. No prose before or "
+    "after."
+)
+
+
+def extract_from_image(image_path: str, hint: str = "") -> str:
+    """Run Gemini vision on an image and return a structured JSON draft.
+
+    Use this for fund-transfer proofs, receipts, QRIS confirmations, and
+    order photos. Do NOT use it for tabular data (spreadsheets, PDFs of
+    tables, screenshots of CSVs) — use ``read_tabular`` for those.
+
+    The returned JSON is a DRAFT only. The agent must confirm or resolve
+    missing fields via ``ask_user`` before calling ``write_ingested_table``.
+
+    Args:
+        image_path: Absolute path to a local image file (jpg, png, webp, heic).
+        hint: Optional free-text hint about what the image contains, e.g.
+            'BCA mobile transfer receipt' or 'Warteg dinner bill'.
+    """
+    from seeknal.ask.agents.tools._context import get_tool_context
+
+    ctx = get_tool_context()
+
+    path = Path(image_path).expanduser()
+    if not path.is_absolute():
+        path = (ctx.project_path / path).resolve()
+    else:
+        path = path.resolve()
+    if not path.exists() or not path.is_file():
+        return f"Error: image not found at {image_path}"
+
+    suffix = path.suffix.lower()
+    mime = _MIME_BY_SUFFIX.get(suffix)
+    if not mime:
+        return (
+            f"Error: unsupported image format '{suffix}'. "
+            f"Supported: {', '.join(sorted(_MIME_BY_SUFFIX))}."
+        )
+
+    size = path.stat().st_size
+    if size > _MAX_IMAGE_BYTES:
+        return (
+            f"Error: image is {size / 1024 / 1024:.1f} MB, exceeds "
+            f"{_MAX_IMAGE_BYTES / 1024 / 1024:.0f} MB limit."
+        )
+
+    try:
+        draft = _call_gemini(path, mime, hint)
+    except Exception as exc:
+        return f"Error: vision extraction failed: {exc}"
+
+    # Stash the image path so write_ingested_table can emit it in provenance
+    # (source_file will hash the image, giving us dedup-by-image-content).
+    try:
+        ctx.last_read_staging_path = str(path)
+    except Exception:
+        pass
+
+    lines = ["## Extracted draft from image"]
+    lines.append(f"- **Source:** `{path.name}`")
+    if hint:
+        lines.append(f"- **Hint:** {hint}")
+    lines.append("")
+    lines.append("```json")
+    lines.append(json.dumps(draft, ensure_ascii=False, indent=2))
+    lines.append("```")
+
+    missing = _missing_required(draft)
+    if missing:
+        lines.append("")
+        lines.append(
+            "**Required fields not yet resolved:** " + ", ".join(missing)
+        )
+        lines.append(
+            "Call `ask_user` to confirm each missing field before calling "
+            "`write_ingested_table`."
+        )
+    else:
+        lines.append("")
+        lines.append(
+            "All required fields extracted. Confirm the draft with the user "
+            "via `ask_user` (they may spot OCR mistakes), then propose a "
+            "target table with `propose_record_table` before writing."
+        )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _call_gemini(path: Path, mime: str, hint: str) -> dict:
+    """Run the vision model and return the parsed JSON draft."""
+    from seeknal.ask.agents.providers import get_model_string
+
+    if Agent is None or BinaryContent is None:
+        raise RuntimeError(
+            "pydantic_ai is required for image extraction; install seeknal[ask]."
+        )
+
+    image_bytes = path.read_bytes()
+    model_string = get_model_string()
+
+    prompt = _EXTRACTION_PROMPT
+    if hint:
+        prompt = f"{prompt}\n\nUser hint: {hint.strip()}"
+
+    agent = Agent(model_string)
+    result = agent.run_sync(
+        [
+            prompt,
+            BinaryContent(data=image_bytes, media_type=mime),
+        ]
+    )
+    text = (result.output or "").strip()
+    return _parse_json_output(text)
+
+
+def _parse_json_output(raw: str) -> dict:
+    """Strip markdown fences (if any) and parse JSON defensively."""
+    text = raw.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json)?\s*", "", text, flags=re.IGNORECASE)
+        text = re.sub(r"\s*```$", "", text)
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"Gemini returned non-JSON output: {exc}. Raw (first 500 chars): {text[:500]!r}"
+        )
+    if not isinstance(data, dict):
+        raise ValueError(f"Gemini output was not a JSON object: {type(data).__name__}")
+    # Normalise defaults
+    data.setdefault("currency", "IDR")
+    data.setdefault("items", [])
+    return data
+
+
+def _missing_required(draft: dict) -> list[str]:
+    """Required fields depend on the `kind`."""
+    kind = (draft.get("kind") or "").lower()
+    required: list[str] = []
+    if kind == "transfer":
+        required = ["amount", "recipient_name", "transaction_date"]
+    elif kind in {"receipt", "order"}:
+        required = ["amount", "merchant"]
+    else:
+        required = ["amount"]
+    return [k for k in required if not draft.get(k)]

--- a/src/seeknal/ask/agents/tools/parse_record.py
+++ b/src/seeknal/ask/agents/tools/parse_record.py
@@ -1,0 +1,292 @@
+"""Parse record tool — best-effort hint extractor for /record text messages.
+
+Pure Python, no LLM. The job is NOT to be exhaustive and NOT to dictate
+which fields are required. The agent classifies the record kind and
+decides which fields matter via SKILL.md reasoning + ``ask_user``; this
+tool just surfaces obvious signals so the agent doesn't waste a turn
+re-spotting them.
+
+Works for any record type, not just financial:
+
+    "/record fitra, 1 mie ayam, 1 mineral water"
+      -> hints: items=[...], person=fitra (agent decides kind = order)
+
+    "/record transfer ke budi Rp 1.500.000 via BCA"
+      -> hints: amount=1500000, bank=BCA (agent decides kind = transfer)
+
+    "/record workout, 30 min running, 10 pushups"
+      -> hints: items=[{qty:30,...}, {qty:10,...}] (agent decides
+         kind = activity, treats items as exercises)
+
+    "/record meeting with budi, discussed Q2 plan"
+      -> hints: note="meeting with budi | discussed Q2 plan" (agent
+         decides kind = meeting, extracts attendees + summary)
+
+    "/record weight 72.5 kg, bp 120/80"
+      -> hints: note preserved (agent decides kind = health, extracts
+         metrics from raw_text)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+_PREFIXES = ("/record ", "/record:", "/record", "record:", "record ", "/r ")
+
+# Quantity-first patterns: "1 mie ayam", "2x nasi goreng", "3 * kopi"
+_QTY_ITEM_RE = re.compile(r"^(\d{1,3})\s*[x*]?\s+(.{2,})$", re.IGNORECASE)
+
+# Amount patterns (Indonesian-aware)
+# Matches: 1.500.000 | 1,500,000 | 45000 | 1.5jt | 12.5k | 2500
+# The `(?![a-zA-Z])` guard stops "m" in "mie ayam" from being mis-read as
+# a "million" suffix during full-body sweeps.
+_AMOUNT_TOKEN_RE = re.compile(
+    r"(?i)"
+    r"(?:Rp\.?\s*|IDR\s*|USD\s*|\$)?"
+    r"(\d{1,3}(?:[.,]\d{3})+|\d+(?:[.,]\d+)?|\d+)"
+    r"\s*(k|rb|ribu|m|jt|juta|mil|million)?(?![a-zA-Z])"
+)
+# Decimal form with a magnitude suffix (e.g. "1.5jt" = 1,500,000)
+_DECIMAL_AMOUNT_RE = re.compile(r"^\d+[.,]\d+$")
+
+# Bank / e-wallet hints (Indonesian context)
+_BANK_TOKENS = {
+    "bca", "mandiri", "bni", "bri", "cimb", "permata", "danamon",
+    "btpn", "maybank", "panin", "bsi", "mega",
+    "gopay", "ovo", "dana", "shopeepay", "linkaja", "qris",
+}
+
+
+def parse_record(text: str) -> str:
+    """Extract best-effort hints from a free-form /record message.
+
+    Returns a markdown scaffold that includes a JSON hint object plus the
+    kind most likely implied by detected signals. The agent MUST:
+
+      1. Treat the JSON as *hints*, not as the final schema.
+      2. Classify the record kind itself (financial / activity / meeting
+         / health / note / custom) based on the raw message — use
+         `kind_hint` only as a starting point.
+      3. Decide which fields are required for that kind and resolve any
+         ambiguity via `ask_user` before writing.
+
+    Accepts Indonesian and English. Handles amount shorthand (45rb,
+    1.5jt) and bank/e-wallet keywords (BCA, GoPay, OVO, ...). No field
+    is ever marked "required" — requiredness is the agent's call.
+
+    Args:
+        text: The raw message, e.g. "/record fitra, 1 mie ayam, 1 mineral water".
+    """
+    raw = (text or "").strip()
+    if not raw:
+        return json.dumps({"error": "empty record"}, ensure_ascii=False)
+
+    body = _strip_prefix(raw)
+    parts = [p.strip() for p in body.split(",") if p.strip()]
+
+    person: str | None = None
+    items: list[dict[str, Any]] = []
+    amount: int | None = None
+    currency: str = "IDR"
+    bank: str | None = None
+    note_parts: list[str] = []
+
+    for idx, part in enumerate(parts):
+        qi = _QTY_ITEM_RE.match(part)
+        if qi:
+            qty = int(qi.group(1))
+            name = qi.group(2).strip()
+            # Guard: a big leading number (>99) is more likely an amount than a qty
+            if qty > 99 and not re.search(r"[a-zA-Z]", name):
+                amt = _coerce_amount(part)
+                if amt is not None:
+                    amount = _prefer_amount(amount, amt)
+                    continue
+            items.append({"quantity": qty, "name": name})
+            continue
+
+        amt = _coerce_amount(part)
+        if amt is not None and (amount is None or amt > amount):
+            amount = amt
+            continue
+
+        bank_hit = _find_bank(part)
+        if bank_hit and bank is None:
+            bank = bank_hit
+
+        # First non-item-looking segment with no digits is the likely person
+        if (
+            person is None
+            and idx == 0
+            and len(part.split()) <= 3
+            and not any(ch.isdigit() for ch in part)
+            and not bank_hit
+        ):
+            person = part.lower()
+            continue
+
+        note_parts.append(part)
+
+    # Second pass: sweep the whole string for an amount if nothing found yet.
+    if amount is None:
+        matches = list(_AMOUNT_TOKEN_RE.finditer(body))
+        candidates = [
+            _coerce_amount_match(m) for m in matches
+        ]
+        candidates = [c for c in candidates if c is not None]
+        if candidates:
+            amount = max(candidates)
+
+    # Second pass: sweep for a bank keyword anywhere
+    if bank is None:
+        low = body.lower()
+        for b in _BANK_TOKENS:
+            if re.search(rf"\b{re.escape(b)}\b", low):
+                bank = b.upper() if len(b) <= 4 else b.capitalize()
+                break
+
+    kind_hint = _guess_kind(amount, bank, items, body)
+
+    draft = {
+        "kind_hint": kind_hint,
+        "person": person,
+        "items": items,
+        "amount": amount,
+        "currency": currency,
+        "bank": bank,
+        "note": " | ".join(note_parts) or None,
+        "raw_text": body,
+    }
+
+    lines = ["## Detected hints"]
+    lines.append("```json")
+    lines.append(json.dumps(draft, ensure_ascii=False, indent=2))
+    lines.append("```")
+    lines.append("")
+    lines.append(
+        f"**Kind hint:** `{kind_hint}` — a first guess. Re-classify from the "
+        "raw message if this doesn't fit."
+    )
+    lines.append("")
+    lines.append(
+        "Next steps (record-entry SKILL.md):\n"
+        "1. Classify the record kind yourself (financial, activity, meeting, "
+        "health, note, or custom). Do not accept `kind_hint` blindly.\n"
+        "2. Decide which fields are required for that kind.\n"
+        "3. Call `ask_user` to resolve any required fields still null.\n"
+        "4. Call `propose_record_table` with the enriched draft (pass "
+        "`_columns` in the draft to override the template if needed) and "
+        "route through `write_ingested_table`."
+    )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _strip_prefix(text: str) -> str:
+    for prefix in _PREFIXES:
+        if text.lower().startswith(prefix):
+            return text[len(prefix):].strip()
+    return text
+
+
+def _coerce_amount(token: str) -> int | None:
+    """Return an integer amount from a single token, or None."""
+    m = _AMOUNT_TOKEN_RE.fullmatch(token.strip())
+    if not m:
+        return None
+    return _coerce_amount_match(m)
+
+
+def _coerce_amount_match(m: "re.Match[str]") -> int | None:
+    raw = m.group(1)
+    suffix = (m.group(2) or "").lower()
+
+    # Decimal form with magnitude suffix (e.g. "1.5jt" -> 1,500,000).
+    if _DECIMAL_AMOUNT_RE.match(raw) and suffix:
+        try:
+            val = float(raw.replace(",", "."))
+        except ValueError:
+            return None
+        if suffix in {"k", "rb", "ribu"}:
+            val *= 1000
+        elif suffix in {"m", "jt", "juta", "mil", "million"}:
+            val *= 1_000_000
+        return int(val)
+
+    digits = raw.replace(".", "").replace(",", "")
+    if not digits.isdigit():
+        return None
+    try:
+        val = int(digits)
+    except ValueError:
+        return None
+    if suffix in {"k", "rb", "ribu"}:
+        val *= 1000
+    elif suffix in {"m", "jt", "juta", "mil", "million"}:
+        val *= 1_000_000
+    # Sanity: anything under 100 as a standalone amount is probably a qty.
+    if val < 100 and not suffix:
+        return None
+    return val
+
+
+def _prefer_amount(current: int | None, candidate: int) -> int:
+    return candidate if current is None or candidate > current else current
+
+
+def _find_bank(token: str) -> str | None:
+    low = token.lower().strip()
+    for b in _BANK_TOKENS:
+        if low == b or low.endswith(f" {b}") or low.startswith(f"{b} "):
+            return b.upper() if len(b) <= 4 else b.capitalize()
+    return None
+
+
+_ACTIVITY_WORDS = {
+    "workout", "running", "run", "jog", "walk", "gym", "yoga", "swim",
+    "pushup", "pushups", "pullup", "pullups", "squat", "squats",
+    "cycling", "bike", "lari", "jalan", "olahraga",
+}
+_MEETING_WORDS = {
+    "meeting", "rapat", "call", "standup", "sync", "interview", "discussed",
+    "bahas", "diskusi", "ngobrol",
+}
+_HEALTH_WORDS = {
+    "weight", "berat", "bp", "tekanan", "blood", "pulse", "detak", "sugar",
+    "glucose", "gula", "temp", "suhu", "sleep", "tidur",
+}
+
+
+def _guess_kind(
+    amount: int | None,
+    bank: str | None,
+    items: list[dict],
+    body: str,
+) -> str:
+    """Heuristic kind classifier used only as a hint — the agent has final say."""
+    low = body.lower()
+    tokens = set(re.findall(r"[a-z]+", low))
+
+    if tokens & _HEALTH_WORDS:
+        return "health"
+    if tokens & _MEETING_WORDS:
+        return "meeting"
+    if bank:
+        return "transfer"
+    if amount and items:
+        return "order"
+    if amount and not items:
+        return "expense"
+    if items and tokens & _ACTIVITY_WORDS:
+        return "activity"
+    if tokens & _ACTIVITY_WORDS:
+        return "activity"
+    if items:
+        return "order"
+    return "note"

--- a/src/seeknal/ask/agents/tools/propose_record_table.py
+++ b/src/seeknal/ask/agents/tools/propose_record_table.py
@@ -1,0 +1,445 @@
+"""Propose record table tool — table-aware router for record drafts.
+
+Given a draft from ``parse_record`` or ``extract_from_image``, scan the
+session's existing ``ingest_*`` views, score how well each covers the
+draft's fields, and either:
+
+  - **Match**: recommend appending to an existing table (all required
+    draft fields map to existing columns).
+  - **New**: propose a new table with a schema derived from the draft
+    plus a sensible business key.
+
+The tool returns a recommendation as markdown; it NEVER writes. The agent
+must take the proposal into ``ask_user`` for confirmation, then call
+``write_ingested_table`` with ``mode='create'`` or ``mode='append'``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+
+_INGEST_VIEW_PREFIX = "ingest_"
+_TABLE_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+# Known draft shapes. Keys are field names that parse_record /
+# extract_from_image emit; values are (preferred column name, DuckDB type).
+_TEXT_DRAFT_COLUMNS = [
+    ("entered_at",     "TIMESTAMP"),
+    ("person",         "VARCHAR"),
+    ("amount",         "BIGINT"),
+    ("currency",       "VARCHAR"),
+    ("bank",           "VARCHAR"),
+    ("items",          "JSON"),
+    ("note",           "VARCHAR"),
+    ("raw_text",       "VARCHAR"),
+]
+_IMAGE_TRANSFER_COLUMNS = [
+    ("entered_at",        "TIMESTAMP"),
+    ("transaction_date",  "TIMESTAMP"),
+    ("amount",            "BIGINT"),
+    ("currency",          "VARCHAR"),
+    ("sender_name",       "VARCHAR"),
+    ("sender_account",    "VARCHAR"),
+    ("recipient_name",    "VARCHAR"),
+    ("recipient_account", "VARCHAR"),
+    ("bank",              "VARCHAR"),
+    ("reference_number",  "VARCHAR"),
+    ("note",              "VARCHAR"),
+    ("raw_text",          "VARCHAR"),
+]
+_IMAGE_RECEIPT_COLUMNS = [
+    ("entered_at",        "TIMESTAMP"),
+    ("transaction_date",  "TIMESTAMP"),
+    ("amount",            "BIGINT"),
+    ("currency",          "VARCHAR"),
+    ("merchant",          "VARCHAR"),
+    ("items",             "JSON"),
+    ("note",              "VARCHAR"),
+    ("raw_text",          "VARCHAR"),
+]
+_ACTIVITY_COLUMNS = [
+    ("entered_at",  "TIMESTAMP"),
+    ("person",      "VARCHAR"),
+    ("activity",    "VARCHAR"),
+    ("exercises",   "JSON"),
+    ("duration_min","INTEGER"),
+    ("note",        "VARCHAR"),
+    ("raw_text",    "VARCHAR"),
+]
+_MEETING_COLUMNS = [
+    ("entered_at",  "TIMESTAMP"),
+    ("title",       "VARCHAR"),
+    ("attendees",   "JSON"),
+    ("summary",     "VARCHAR"),
+    ("action_items","JSON"),
+    ("note",        "VARCHAR"),
+    ("raw_text",    "VARCHAR"),
+]
+_HEALTH_COLUMNS = [
+    ("entered_at", "TIMESTAMP"),
+    ("person",     "VARCHAR"),
+    ("metrics",    "JSON"),
+    ("note",       "VARCHAR"),
+    ("raw_text",   "VARCHAR"),
+]
+_NOTE_COLUMNS = [
+    ("entered_at", "TIMESTAMP"),
+    ("person",     "VARCHAR"),
+    ("kind",       "VARCHAR"),
+    ("note",       "VARCHAR"),
+    ("raw_text",   "VARCHAR"),
+]
+_EXPENSE_COLUMNS = [
+    ("entered_at",  "TIMESTAMP"),
+    ("person",      "VARCHAR"),
+    ("amount",      "BIGINT"),
+    ("currency",    "VARCHAR"),
+    ("category",    "VARCHAR"),
+    ("merchant",    "VARCHAR"),
+    ("note",        "VARCHAR"),
+    ("raw_text",    "VARCHAR"),
+]
+
+
+@dataclass
+class _TableScore:
+    table_name: str
+    matched: list[str]
+    missing: list[str]
+    extra_required: list[str]
+    score: float
+
+
+def propose_record_table(
+    draft_json: str,
+    hint_table_name: str = "",
+) -> str:
+    """Recommend a target table for a record draft.
+
+    Scans existing ``ingest_*`` views, ranks them by field overlap with
+    the draft, and returns either a MATCH (append existing) or NEW
+    (create table) proposal.
+
+    Args:
+        draft_json: JSON string returned by ``parse_record`` or
+            ``extract_from_image`` — just the inner JSON, not the markdown
+            wrapper. Pass ``json.dumps(...)`` of the draft dict.
+        hint_table_name: Optional name the user already mentioned. The
+            proposer will pick this over its own heuristic if it's valid
+            and doesn't collide.
+    """
+    from seeknal.ask.agents.tools._context import get_tool_context
+
+    ctx = get_tool_context()
+
+    draft = _parse_draft(draft_json)
+    if isinstance(draft, str):
+        return draft  # error
+
+    kind = _infer_kind(draft)
+    draft_keys = {k for k, v in draft.items() if v is not None}
+
+    existing = _load_existing_tables(ctx)
+
+    scores = [_score_table(name, cols, draft_keys) for name, cols in existing.items()]
+    scores.sort(key=lambda s: s.score, reverse=True)
+    best = scores[0] if scores else None
+
+    # High-score matches pick up the existing table; ``extra_required`` is
+    # informational (null-tolerable columns) and does not disqualify a match.
+    if best and best.score >= 0.8:
+        return _format_match(best, draft, kind)
+
+    return _format_new(draft, kind, hint_table_name, best, existing)
+
+
+# ---------------------------------------------------------------------------
+# Draft parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_draft(raw: str) -> dict | str:
+    if not raw or not raw.strip():
+        return "Error: draft_json is empty."
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return f"Error: draft_json is not valid JSON: {exc}"
+    if not isinstance(payload, dict):
+        return "Error: draft_json must be a JSON object."
+    return payload
+
+
+_KNOWN_KINDS = {
+    "transfer", "receipt", "order", "activity", "meeting", "health",
+    "note", "expense", "other",
+}
+
+
+def _infer_kind(draft: dict) -> str:
+    """Classify the draft so we can pick the right schema template.
+
+    Accepts ``kind`` (authoritative), ``kind_hint`` (from parse_record),
+    or falls back to field-presence heuristics.
+    """
+    for key in ("kind", "kind_hint"):
+        declared = (draft.get(key) or "").lower()
+        if declared in _KNOWN_KINDS:
+            return declared
+
+    # Heuristics based on present fields
+    has_transfer_fields = any(
+        draft.get(k) for k in ("sender_name", "recipient_name", "reference_number")
+    )
+    if has_transfer_fields:
+        return "transfer"
+    if draft.get("merchant"):
+        return "receipt"
+    if draft.get("metrics"):
+        return "health"
+    if draft.get("attendees") or draft.get("action_items"):
+        return "meeting"
+    if draft.get("exercises") or draft.get("activity"):
+        return "activity"
+    if draft.get("items"):
+        return "order"
+    return "other"
+
+
+# ---------------------------------------------------------------------------
+# Existing-table introspection
+# ---------------------------------------------------------------------------
+
+
+def _load_existing_tables(ctx) -> dict[str, list[tuple[str, str]]]:
+    """Return {view_name: [(column_name, column_type), ...]} for ingest_* views."""
+    try:
+        with ctx.db_lock:
+            rows = ctx.repl.conn.execute(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_catalog='memory' AND table_schema='main' "
+                "AND table_type='VIEW' AND table_name LIKE 'ingest_%' "
+                "ORDER BY table_name"
+            ).fetchall()
+    except Exception:
+        return {}
+
+    out: dict[str, list[tuple[str, str]]] = {}
+    for (view_name,) in rows:
+        try:
+            with ctx.db_lock:
+                cols = ctx.repl.conn.execute(f'DESCRIBE "{view_name}"').fetchall()
+            out[view_name] = [(c[0], c[1]) for c in cols]
+        except Exception:
+            continue
+    return out
+
+
+def _score_table(
+    view_name: str,
+    columns: list[tuple[str, str]],
+    draft_keys: set[str],
+) -> _TableScore:
+    """Score overlap between draft fields and existing columns."""
+    col_names = {c for c, _ in columns}
+    # Strip ingest_ prefix from view name for display purposes
+    display_name = view_name[len(_INGEST_VIEW_PREFIX):] if view_name.startswith(_INGEST_VIEW_PREFIX) else view_name
+
+    matched = sorted(k for k in draft_keys if k in col_names)
+    missing = sorted(k for k in draft_keys if k not in col_names)
+    # Required columns in the existing table that the draft can't populate
+    required_cols = {c for c, _ in columns}
+    extra_required = sorted(c for c in required_cols if c not in draft_keys and c != "entered_at")
+
+    denom = max(len(draft_keys), 1)
+    score = len(matched) / denom
+
+    return _TableScore(
+        table_name=display_name,
+        matched=matched,
+        missing=missing,
+        extra_required=extra_required,
+        score=score,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def _format_match(best: _TableScore, draft: dict, kind: str) -> str:
+    lines = [f"## Match: append to `ingest_{best.table_name}`"]
+    lines.append("")
+    lines.append(
+        f"Existing table `ingest_{best.table_name}` covers all draft fields "
+        f"(score {best.score:.0%}). Suggested call:"
+    )
+    lines.append("")
+    bk = _suggest_business_key(best.table_name, kind)
+    lines.append("```")
+    lines.append(
+        f"write_ingested_table(\n"
+        f"    source_path=<staged parquet from read_tabular/extract>,\n"
+        f"    table_name='{best.table_name}',\n"
+        f"    business_key='{bk}',\n"
+        f"    mode='append', user_confirmed=False,\n"
+        f")"
+    )
+    lines.append("```")
+    lines.append("")
+    lines.append(
+        f"Matched columns: {', '.join(f'`{c}`' for c in best.matched) or '(none)'}"
+    )
+    if best.missing:
+        lines.append(
+            f"Draft fields NOT in the existing schema (will be dropped or "
+            f"need a migration): {', '.join(f'`{c}`' for c in best.missing)}. "
+            f"Surface this to the user via `ask_user` before appending."
+        )
+    lines.append("")
+    lines.append(
+        "Next: first convert the draft to a single-row parquet via "
+        "`read_tabular` (write it to a temp CSV then parse) OR pass it to a "
+        "helper that stages the row. Then call the append with "
+        "`user_confirmed=False` first to get the drift report."
+    )
+    return "\n".join(lines)
+
+
+def _format_new(
+    draft: dict,
+    kind: str,
+    hint_table_name: str,
+    best: _TableScore | None,
+    existing: dict,
+) -> str:
+    slug = _slug_from_hint_or_kind(hint_table_name, kind, existing)
+    # Agent-provided column override wins over the kind template.
+    override = draft.get("_columns")
+    columns = _normalise_column_override(override) if override else _columns_for_kind(kind)
+    business_key = _suggest_business_key(slug, kind)
+
+    lines = [f"## New: create `ingest_{slug}`"]
+    lines.append("")
+    if best:
+        lines.append(
+            f"Closest existing table is `ingest_{best.table_name}` "
+            f"(score {best.score:.0%}), but that isn't a strong enough fit "
+            f"for this draft's shape. Proposing a new table instead."
+        )
+    else:
+        lines.append("No existing `ingest_*` tables. Proposing a fresh schema.")
+    lines.append("")
+    lines.append(f"**Kind:** `{kind}`")
+    lines.append("")
+    lines.append("**Proposed schema**")
+    lines.append("| Column | Type |")
+    lines.append("| --- | --- |")
+    for name, ctype in columns:
+        lines.append(f"| `{name}` | {ctype} |")
+    lines.append("")
+    lines.append(f"**Business key suggestion:** `{business_key}`")
+    lines.append("")
+    lines.append("**Suggested call**")
+    lines.append("```")
+    lines.append(
+        f"write_ingested_table(\n"
+        f"    source_path=<staged parquet with the confirmed draft row>,\n"
+        f"    table_name='{slug}',\n"
+        f"    business_key='{business_key}',\n"
+        f"    mode='create',\n"
+        f")"
+    )
+    lines.append("```")
+    lines.append("")
+    lines.append(
+        "Before calling, walk the user through each field in `ask_user` "
+        "(required fields only — anything still null in the draft must be "
+        "resolved first). After the write, call `save_ingestion_skill` so "
+        "the next identical record auto-routes to this table."
+    )
+    return "\n".join(lines)
+
+
+def _slug_from_hint_or_kind(
+    hint: str, kind: str, existing: dict
+) -> str:
+    """Pick a table name, preferring a valid user hint."""
+    if hint:
+        clean = re.sub(r"[^a-zA-Z0-9_]+", "_", hint.strip()).strip("_").lower()
+        if clean and _TABLE_NAME_RE.match(clean):
+            return clean
+    base = {
+        "transfer": "transfers",
+        "receipt": "receipts",
+        "order": "orders",
+        "other": "records",
+    }.get(kind, "records")
+    # Avoid colliding with an existing view
+    candidate = base
+    idx = 2
+    taken = {n[len(_INGEST_VIEW_PREFIX):] for n in existing if n.startswith(_INGEST_VIEW_PREFIX)}
+    while candidate in taken:
+        candidate = f"{base}_{idx}"
+        idx += 1
+    return candidate
+
+
+def _columns_for_kind(kind: str) -> list[tuple[str, str]]:
+    mapping = {
+        "transfer": _IMAGE_TRANSFER_COLUMNS,
+        "receipt":  _IMAGE_RECEIPT_COLUMNS,
+        "order":    _IMAGE_RECEIPT_COLUMNS,
+        "activity": _ACTIVITY_COLUMNS,
+        "meeting":  _MEETING_COLUMNS,
+        "health":   _HEALTH_COLUMNS,
+        "expense":  _EXPENSE_COLUMNS,
+        "note":     _NOTE_COLUMNS,
+    }
+    return mapping.get(kind, _TEXT_DRAFT_COLUMNS)
+
+
+def _normalise_column_override(raw) -> list[tuple[str, str]]:
+    """Convert an agent-supplied _columns list into [(name, type), ...].
+
+    Accepts either [{"name": "...", "type": "..."}] or [["name", "type"], ...]
+    so the agent can pass the shape most natural to it.
+    """
+    out: list[tuple[str, str]] = []
+    if not isinstance(raw, list):
+        return out
+    for entry in raw:
+        if isinstance(entry, dict):
+            name = str(entry.get("name", "")).strip()
+            ctype = str(entry.get("type", "VARCHAR")).strip() or "VARCHAR"
+        elif isinstance(entry, (list, tuple)) and len(entry) >= 2:
+            name = str(entry[0]).strip()
+            ctype = str(entry[1]).strip() or "VARCHAR"
+        else:
+            continue
+        if name:
+            out.append((name, ctype))
+    # Ensure entered_at and raw_text are always present for audit
+    names = {n for n, _ in out}
+    if "entered_at" not in names:
+        out.insert(0, ("entered_at", "TIMESTAMP"))
+    if "raw_text" not in names:
+        out.append(("raw_text", "VARCHAR"))
+    return out
+
+
+def _suggest_business_key(table_name: str, kind: str) -> str:
+    mapping = {
+        "transfer": "reference_number",
+        "receipt":  "entered_at,merchant",
+        "order":    "entered_at,merchant",
+        "activity": "entered_at,person",
+        "meeting":  "entered_at,title",
+        "health":   "entered_at,person",
+        "expense":  "entered_at,person,amount",
+        "note":     "entered_at,person",
+    }
+    return mapping.get(kind, "entered_at,person")

--- a/src/seeknal/ask/agents/tools/read_tabular.py
+++ b/src/seeknal/ask/agents/tools/read_tabular.py
@@ -1,0 +1,313 @@
+"""Read tabular tool — parse a file or direct-download URL into a DuckDB preview.
+
+Supports .xlsx, .csv, .tsv, and tabular .json files. For URLs, downloads
+the file first via HTTP GET (no auth, no scraping). Stashes the resolved
+source path on the ToolContext so write_ingested_table can pick it up.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+import uuid
+from pathlib import Path
+from urllib.parse import urlparse
+
+_MAX_FILE_BYTES = 200 * 1024 * 1024  # 200 MB
+_SUPPORTED_SUFFIXES = {".csv", ".tsv", ".json", ".xlsx", ".parquet"}
+
+
+def read_tabular(path_or_url: str, sample_rows: int = 20) -> str:
+    """Read a tabular file or direct-download URL and return schema + sample rows.
+
+    Supports .xlsx, .csv, .tsv, and tabular .json files. For URLs, downloads
+    the file first via HTTP GET (no auth, no scraping).
+
+    Returns a formatted summary: inferred column names, types, row count,
+    and a sample preview table. Use this to inspect data before ingestion.
+
+    Args:
+        path_or_url: Absolute file path or direct-download HTTP(S) URL.
+        sample_rows: Number of sample rows to include in preview (default 20).
+    """
+    from seeknal.ask.agents.tools._context import get_tool_context
+
+    ctx = get_tool_context()
+
+    try:
+        sample_rows = max(1, min(int(sample_rows), 200))
+    except (TypeError, ValueError):
+        sample_rows = 20
+
+    try:
+        source_path = _resolve_source(path_or_url, ctx.project_path)
+    except ValueError as exc:
+        return f"Error: {exc}"
+
+    suffix = source_path.suffix.lower()
+    if suffix not in _SUPPORTED_SUFFIXES:
+        return (
+            f"Error: unsupported file format '{suffix}'. "
+            f"Supported: {', '.join(sorted(_SUPPORTED_SUFFIXES))}."
+        )
+
+    try:
+        size = source_path.stat().st_size
+    except OSError as exc:
+        return f"Error: cannot access file: {exc}"
+    if size > _MAX_FILE_BYTES:
+        return (
+            f"Error: file is {size / 1024 / 1024:.1f} MB, exceeds 200 MB limit."
+        )
+
+    # For xlsx, convert to parquet via pandas so DuckDB can read it uniformly.
+    read_path = source_path
+    if suffix == ".xlsx":
+        try:
+            read_path = _xlsx_to_parquet(source_path, ctx.project_path)
+        except Exception as exc:
+            return f"Error parsing xlsx: {exc}"
+
+    try:
+        schema_rows, row_count, preview_rows = _inspect(read_path, sample_rows)
+    except Exception as exc:
+        return f"Error reading '{source_path.name}': {exc}"
+
+    # Stash the path downstream tools should read from. For xlsx inputs this
+    # is the converted parquet under the staging dir; for everything else it
+    # is the original path. Using the DuckDB-readable path means the agent
+    # does not have to pass anything explicitly to write_ingested_table.
+    ctx.last_read_staging_path = str(read_path)
+
+    return _format_report(
+        source_path=source_path,
+        read_path=read_path,
+        schema_rows=schema_rows,
+        row_count=row_count,
+        preview_rows=preview_rows,
+    )
+
+
+def _resolve_source(path_or_url: str, project_path: Path) -> Path:
+    """Resolve an input string to a local Path.
+
+    For URLs: download to target/ask_ingest/_staging/{uuid}/ and return that path.
+    For file paths: validate existence and return the resolved Path.
+    """
+    parsed = urlparse(path_or_url)
+    if parsed.scheme in {"http", "https"}:
+        return _download(path_or_url, project_path)
+
+    # File path. Accept absolute or relative.
+    candidate = Path(path_or_url).expanduser()
+    if not candidate.is_absolute():
+        candidate = (project_path / candidate).resolve()
+    else:
+        candidate = candidate.resolve()
+
+    if not candidate.exists():
+        raise ValueError(f"file not found: {path_or_url}")
+    if not candidate.is_file():
+        raise ValueError(f"not a regular file: {path_or_url}")
+    return candidate
+
+
+def _reject_if_private(hostname: str) -> None:
+    """Raise ValueError if hostname resolves to a loopback/private/link-local IP.
+
+    Prevents SSRF to cloud metadata endpoints (169.254.169.254), localhost
+    services, and RFC1918 internal networks.
+    """
+    if not hostname:
+        raise ValueError("URL has no hostname")
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as exc:
+        raise ValueError(f"DNS lookup failed for {hostname}: {exc}")
+    for info in infos:
+        ip = info[4][0]
+        try:
+            addr = ipaddress.ip_address(ip)
+        except ValueError:
+            continue
+        if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
+            raise ValueError(
+                f"URL host {hostname!r} resolves to a non-public address "
+                f"({addr}); refusing to fetch."
+            )
+
+
+def _download(url: str, project_path: Path) -> Path:
+    """Download a direct URL to the staging directory. Cap at 200 MB.
+
+    Blocks SSRF to private/loopback/link-local networks (including cloud
+    metadata endpoints like 169.254.169.254) and disables redirect-following
+    so a public URL cannot redirect into an internal host.
+    """
+    import urllib.request
+
+    parsed = urlparse(url)
+    _reject_if_private(parsed.hostname or "")
+
+    staging_root = project_path / "target" / "ask_ingest" / "_staging" / uuid.uuid4().hex[:12]
+    staging_root.mkdir(parents=True, exist_ok=True)
+
+    # Best-effort: pull a filename out of the URL path.
+    suffix = Path(parsed.path).suffix.lower()
+    base_name = Path(parsed.path).name or "download"
+    if not suffix:
+        base_name += ".csv"  # Last-resort default
+    target = staging_root / base_name
+
+    # No-redirect opener: any 3xx response raises rather than silently jumping
+    # to a different host (which would bypass our private-IP check).
+    class _DenyRedirect(urllib.request.HTTPRedirectHandler):
+        def http_error_302(self, req, fp, code, msg, headers):  # noqa: D401
+            raise ValueError(f"refusing to follow HTTP {code} redirect for {url}")
+        http_error_301 = http_error_303 = http_error_307 = http_error_308 = http_error_302
+
+    opener = urllib.request.build_opener(_DenyRedirect())
+    req = urllib.request.Request(url, headers={"User-Agent": "seeknal-ask/1.0"})
+    with opener.open(req, timeout=60) as resp:  # noqa: S310 — direct URL only, SSRF-guarded
+        # Honour Content-Disposition if present for a cleaner suffix. Apply
+        # Path(...).name to strip any traversal an attacker-controlled server
+        # tries to smuggle in (e.g. filename="../../.env").
+        disp = resp.headers.get("Content-Disposition", "")
+        if "filename=" in disp:
+            raw_fname = disp.split("filename=", 1)[1].strip().strip('"').strip("'")
+            safe_fname = Path(raw_fname).name if raw_fname else ""
+            if safe_fname:
+                fname_suffix = Path(safe_fname).suffix.lower()
+                if fname_suffix in _SUPPORTED_SUFFIXES:
+                    target = staging_root / safe_fname
+        total = 0
+        with target.open("wb") as fh:
+            while True:
+                chunk = resp.read(1024 * 1024)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > _MAX_FILE_BYTES:
+                    fh.write(b"")  # best-effort flush
+                    target.unlink(missing_ok=True)
+                    raise ValueError(
+                        f"download exceeded 200 MB limit ({total / 1024 / 1024:.1f} MB)"
+                    )
+                fh.write(chunk)
+
+    if not target.exists():
+        raise ValueError("download failed: no bytes written")
+
+    return target
+
+
+def _xlsx_to_parquet(xlsx_path: Path, project_path: Path) -> Path:
+    """Convert an xlsx file to a parquet in the staging directory."""
+    import pandas as pd
+
+    staging_root = project_path / "target" / "ask_ingest" / "_staging" / uuid.uuid4().hex[:12]
+    staging_root.mkdir(parents=True, exist_ok=True)
+
+    df = pd.read_excel(xlsx_path, engine="openpyxl")
+    parquet_path = staging_root / f"{xlsx_path.stem}.parquet"
+    df.to_parquet(parquet_path, index=False)
+    return parquet_path
+
+
+def _inspect(path: Path, sample_rows: int) -> tuple[list[tuple[str, str, int]], int, list[tuple]]:
+    """Return (schema_rows, row_count, preview_rows) for a file DuckDB can read."""
+    import duckdb
+
+    safe_path = str(path.resolve()).replace("'", "''")
+    reader = _reader_expr(path, safe_path)
+
+    con = duckdb.connect(":memory:")
+    try:
+        desc = con.execute(f"DESCRIBE SELECT * FROM {reader}").fetchall()
+        schema_cols = [(row[0], row[1]) for row in desc]
+
+        (row_count,) = con.execute(f"SELECT COUNT(*) FROM {reader}").fetchone()
+
+        # Per-column null counts (one aggregate query covers them all).
+        null_exprs = ", ".join(
+            f'SUM(CASE WHEN "{_quote(name)}" IS NULL THEN 1 ELSE 0 END) AS "nc_{idx}"'
+            for idx, (name, _) in enumerate(schema_cols)
+        )
+        null_counts: list[int] = []
+        if null_exprs:
+            row = con.execute(f"SELECT {null_exprs} FROM {reader}").fetchone()
+            null_counts = [int(v) if v is not None else 0 for v in row]
+
+        preview = con.execute(
+            f"SELECT * FROM {reader} LIMIT {int(sample_rows)}"
+        ).fetchall()
+    finally:
+        con.close()
+
+    schema_rows = [
+        (name, ctype, null_counts[idx] if idx < len(null_counts) else 0)
+        for idx, (name, ctype) in enumerate(schema_cols)
+    ]
+    return schema_rows, int(row_count), preview
+
+
+def _reader_expr(path: Path, safe_path: str) -> str:
+    """Return a DuckDB table expression for the given file path."""
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        return f"read_csv_auto('{safe_path}')"
+    if suffix == ".tsv":
+        return f"read_csv_auto('{safe_path}', delim='\\t')"
+    if suffix == ".json":
+        return f"read_json_auto('{safe_path}')"
+    if suffix == ".parquet":
+        return f"read_parquet('{safe_path}')"
+    raise ValueError(f"unsupported suffix: {suffix}")
+
+
+def _quote(name: str) -> str:
+    return name.replace('"', '""')
+
+
+def _format_report(
+    source_path: Path,
+    read_path: Path,
+    schema_rows: list[tuple[str, str, int]],
+    row_count: int,
+    preview_rows: list[tuple],
+) -> str:
+    lines: list[str] = []
+    lines.append(f"## Preview: {source_path.name}")
+    lines.append("")
+    lines.append(f"- **Source path:** `{source_path}`")
+    if read_path != source_path:
+        lines.append(f"- **Parsed as parquet at:** `{read_path}`")
+    lines.append(f"- **Rows:** {row_count:,}")
+    lines.append(f"- **Columns:** {len(schema_rows)}")
+    lines.append("")
+    lines.append("### Schema")
+    lines.append("| Column | Type | Nulls |")
+    lines.append("| --- | --- | --- |")
+    for name, ctype, nulls in schema_rows:
+        lines.append(f"| `{name}` | {ctype} | {nulls} |")
+    lines.append("")
+
+    if preview_rows:
+        header = "| " + " | ".join(name for name, _, _ in schema_rows) + " |"
+        sep = "| " + " | ".join("---" for _ in schema_rows) + " |"
+        body = []
+        for row in preview_rows:
+            cells = [str(v) if v is not None else "NULL" for v in row]
+            body.append("| " + " | ".join(cells) + " |")
+        lines.append("### Sample rows")
+        lines.append(header)
+        lines.append(sep)
+        lines.extend(body)
+        lines.append("")
+
+    lines.append(
+        "Next: call `write_ingested_table(source_path=..., table_name=..., "
+        "business_key=..., mode='create')` after the user confirms the table "
+        "name and business key."
+    )
+    return "\n".join(lines)

--- a/src/seeknal/ask/agents/tools/save_ingestion_skill.py
+++ b/src/seeknal/ask/agents/tools/save_ingestion_skill.py
@@ -1,0 +1,193 @@
+"""Save ingestion skill tool — generate a reusable SKILL.md for an ingestion.
+
+Writes {project}/seeknal/skills/{skill_name}/SKILL.md that pydantic-deep's
+SkillsToolset will auto-discover on the next session, letting the agent
+re-run same-shape ingestions via ``load_skill(skill_name)``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+_SKILL_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
+_COLUMN_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+def save_ingestion_skill(
+    skill_name: str,
+    table_name: str,
+    business_key: str,
+    columns_json: str,
+    description: str = "",
+) -> str:
+    """Save a reusable ingestion skill as a SKILL.md file.
+
+    Creates {project}/seeknal/skills/{skill_name}/SKILL.md with frontmatter
+    and step-by-step prose for re-ingesting same-shape data in future sessions.
+
+    Args:
+        skill_name: Slug for the skill directory (e.g., 'ingest-acme-sales').
+        table_name: Target DuckDB table name.
+        business_key: Comma-separated business key columns.
+        columns_json: JSON array of {"name": ..., "type": ...} objects describing the expected schema.
+        description: Human-readable description of what this data represents.
+    """
+    from seeknal.ask.agents.tools._context import get_tool_context
+    from seeknal.ask.agents.tools._write_security import validate_write_path
+
+    ctx = get_tool_context()
+
+    if not _SKILL_NAME_RE.match(skill_name):
+        return (
+            f"Error: invalid skill_name '{skill_name}'. "
+            "Must be a lowercase slug (letters, digits, hyphens), e.g. 'ingest-acme-sales'."
+        )
+    if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", table_name):
+        return f"Error: invalid table_name '{table_name}'."
+
+    business_key_cols = [c.strip() for c in business_key.split(",") if c.strip()]
+    if not business_key_cols:
+        return "Error: business_key must name at least one column."
+    for col in business_key_cols:
+        if not _COLUMN_NAME_RE.match(col):
+            return f"Error: invalid business key column '{col}'."
+
+    try:
+        columns = json.loads(columns_json)
+        if not isinstance(columns, list):
+            raise ValueError("columns_json must be a JSON array")
+        parsed_columns: list[tuple[str, str]] = []
+        for entry in columns:
+            if not isinstance(entry, dict):
+                raise ValueError("each column entry must be an object with name+type")
+            name = str(entry.get("name", "")).strip()
+            ctype = str(entry.get("type", "")).strip()
+            if not name or not ctype:
+                raise ValueError("column entries need non-empty name and type")
+            parsed_columns.append((name, ctype))
+    except Exception as exc:
+        return f"Error: columns_json invalid: {exc}"
+
+    rel_path = f"seeknal/skills/{skill_name}/SKILL.md"
+    try:
+        skill_path = validate_write_path(rel_path, ctx.project_path)
+    except ValueError as exc:
+        return f"Error: {exc}"
+
+    skill_path.parent.mkdir(parents=True, exist_ok=True)
+
+    content = _render_skill_md(
+        skill_name=skill_name,
+        table_name=table_name,
+        business_key_cols=business_key_cols,
+        columns=parsed_columns,
+        description=description.strip(),
+    )
+
+    with ctx.fs_lock:
+        skill_path.write_text(content, encoding="utf-8")
+
+    return (
+        f"Saved ingestion skill at `{skill_path}`.\n"
+        f"- Skill name: `{skill_name}`\n"
+        f"- Table: `ingest_{table_name}`\n"
+        f"- Business key: {', '.join(business_key_cols)}\n"
+        f"- Columns: {len(parsed_columns)}\n\n"
+        "Next session: the agent can `load_skill('"
+        f"{skill_name}')` to re-run this ingestion."
+    )
+
+
+def _render_skill_md(
+    skill_name: str,
+    table_name: str,
+    business_key_cols: list[str],
+    columns: list[tuple[str, str]],
+    description: str,
+) -> str:
+    desc = description or (
+        f"Re-ingest same-shape data into the `ingest_{table_name}` table "
+        f"with business key {', '.join(business_key_cols)}."
+    )
+    bk_csv = ",".join(business_key_cols)
+    bk_list_yaml = "[" + ", ".join(f'"{c}"' for c in business_key_cols) + "]"
+    schema_table_lines = ["| Column | Type |", "| --- | --- |"]
+    for name, ctype in columns:
+        schema_table_lines.append(f"| `{name}` | {ctype} |")
+    schema_table = "\n".join(schema_table_lines)
+
+    return f"""---
+name: {skill_name}
+description: "{desc}"
+tags: [data-ingest, {skill_name}]
+version: "1.0.0"
+table_name: {table_name}
+business_key: {bk_list_yaml}
+---
+
+# {skill_name}
+
+Use this skill when the user provides another file with the same shape as
+`ingest_{table_name}`. The goal is to append-and-dedup new rows while
+surfacing any schema drift or duplicate business keys to the user.
+
+## Expected schema
+
+{schema_table}
+
+Business key: **{', '.join(business_key_cols)}**
+
+## Phase 1 — Parse & inspect
+
+1. Call `read_tabular(path_or_url=<user file>)` and confirm the columns
+   match the schema above.
+2. If the schema differs, call `check_ingestion_drift(source_path=...,
+   table_name='{table_name}', business_key='{bk_csv}')` and present the
+   drift report to the user before proceeding.
+
+## Phase 2 — Self-defending drift check
+
+1. Call `write_ingested_table(source_path=..., table_name='{table_name}',
+   business_key='{bk_csv}', mode='append', user_confirmed=False)`.
+2. The tool returns a drift + duplicate report **without writing**.
+3. Present the report via `ask_user` with options:
+   - `Skip duplicates (keep existing)`
+   - `Replace duplicates (keep new)`
+   - `Skip this file`
+   - `Type your own`
+
+## Phase 3 — Write
+
+After the user confirms, call:
+
+```
+write_ingested_table(
+    source_path=...,
+    table_name='{table_name}',
+    business_key='{bk_csv}',
+    mode='append',
+    user_confirmed=True,
+    dedup_strategy='skip',   # or 'replace' per user choice
+)
+```
+
+Then verify:
+
+```
+execute_sql("SELECT COUNT(*) FROM ingest_{table_name}")
+```
+
+## Phase 4 — Analytics
+
+Offer to answer an analytical question about the ingested data using
+`execute_sql`.
+
+## Critical-analyst rules
+
+- NEVER call `write_ingested_table` with `user_confirmed=True` before
+  showing the user the drift + duplicate report.
+- NEVER silently drop rows — always report the dedup count.
+- If the user chose `Skip this file`, do not call the write tool; report
+  that nothing was ingested.
+"""

--- a/src/seeknal/ask/agents/tools/toolset.py
+++ b/src/seeknal/ask/agents/tools/toolset.py
@@ -5,6 +5,7 @@ from pydantic_ai.toolsets import FunctionToolset
 from seeknal.ask.agents.tools.apply_draft import apply_draft
 from seeknal.ask.agents.tools.ask_user_tool import ask_user
 from seeknal.ask.agents.tools.bootstrap_semantic_model import bootstrap_semantic_model
+from seeknal.ask.agents.tools.check_ingestion_drift import check_ingestion_drift
 from seeknal.ask.agents.tools.describe_table import describe_table
 from seeknal.ask.agents.tools.draft_node import draft_node
 from seeknal.ask.agents.tools.dry_run_draft import dry_run_draft
@@ -12,27 +13,33 @@ from seeknal.ask.agents.tools.edit_node import edit_node
 from seeknal.ask.agents.tools.edit_proof_document import edit_proof_document
 from seeknal.ask.agents.tools.execute_python import execute_python
 from seeknal.ask.agents.tools.execute_sql import execute_sql
+from seeknal.ask.agents.tools.extract_from_image import extract_from_image
 from seeknal.ask.agents.tools.generate_report import generate_report
 from seeknal.ask.agents.tools.get_entities import get_entities
 from seeknal.ask.agents.tools.get_entity_schema import get_entity_schema
 from seeknal.ask.agents.tools.inspect_output import inspect_output
 from seeknal.ask.agents.tools.list_tables import list_tables
 from seeknal.ask.agents.tools.open_in_browser import open_in_browser
+from seeknal.ask.agents.tools.parse_record import parse_record
 from seeknal.ask.agents.tools.plan_pipeline import plan_pipeline
 from seeknal.ask.agents.tools.profile_data import profile_data
+from seeknal.ask.agents.tools.propose_record_table import propose_record_table
 from seeknal.ask.agents.tools.publish_to_proof import publish_to_proof
 from seeknal.ask.agents.tools.publish_to_seeknal_report import publish_to_seeknal_report
 from seeknal.ask.agents.tools.query_metric import query_metric
 from seeknal.ask.agents.tools.read_pipeline import read_pipeline
+from seeknal.ask.agents.tools.read_tabular import read_tabular
 from seeknal.ask.agents.tools.read_proof_document import read_proof_document
 from seeknal.ask.agents.tools.read_project_file import read_project_file
 from seeknal.ask.agents.tools.run_pipeline import run_pipeline
+from seeknal.ask.agents.tools.save_ingestion_skill import save_ingestion_skill
 from seeknal.ask.agents.tools.save_metric import save_metric
 from seeknal.ask.agents.tools.save_report_exposure import save_report_exposure
 from seeknal.ask.agents.tools.search_pipelines import search_pipelines
 from seeknal.ask.agents.tools.search_project_files import search_project_files
 from seeknal.ask.agents.tools.show_lineage import show_lineage
 from seeknal.ask.agents.tools.submit_plan import submit_plan
+from seeknal.ask.agents.tools.write_ingested_table import write_ingested_table
 
 
 def create_ask_toolset() -> FunctionToolset:
@@ -76,6 +83,15 @@ def create_ask_toolset() -> FunctionToolset:
             # Agent workflow
             submit_plan,
             ask_user,
+            # Data ingestion
+            read_tabular,
+            write_ingested_table,
+            save_ingestion_skill,
+            check_ingestion_drift,
+            # Record entry (text + image)
+            parse_record,
+            extract_from_image,
+            propose_record_table,
         ],
         id="seeknal-ask",
     )

--- a/src/seeknal/ask/agents/tools/write_ingested_table.py
+++ b/src/seeknal/ask/agents/tools/write_ingested_table.py
@@ -1,0 +1,657 @@
+"""Write ingested table tool — persist tabular data as Parquet + DuckDB view.
+
+Self-defending: in append mode, runs deterministic drift/dedup SQL internally
+and requires ``user_confirmed=True`` to actually write. When called with
+``user_confirmed=False``, returns a markdown drift report without touching
+the parquet on disk.
+
+Emits a provenance JSON sidecar next to every successful write.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+import re
+import uuid
+from pathlib import Path
+from typing import Literal
+
+_TABLE_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+_COLUMN_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+_SUPPORTED_SUFFIXES = {".csv", ".tsv", ".json", ".xlsx", ".parquet"}
+
+
+def write_ingested_table(
+    source_path: str,
+    table_name: str,
+    business_key: str,
+    mode: str = "create",
+    user_confirmed: bool = False,
+    dedup_strategy: Literal["skip", "replace"] = "skip",
+) -> str:
+    """Write tabular data to a persistent DuckDB table (Parquet on disk).
+
+    Reads the source file, writes to {project}/target/ask_ingest/{table_name}.parquet,
+    and registers it as a DuckDB view in the current session.
+
+    For 'append' mode with user_confirmed=False: runs drift/dedup checks internally
+    (deterministic SQL, not LLM) and returns a structured drift report WITHOUT writing.
+    The agent must present this report to the user via ask_user, then call again with
+    user_confirmed=True to proceed.
+
+    For 'append' mode with user_confirmed=True: performs the write with dedup.
+
+    dedup_strategy controls duplicate handling:
+      - 'skip': keep existing rows (new rows with matching business keys are dropped).
+      - 'replace': keep new rows (existing rows with matching keys are dropped).
+
+    Also emits a provenance JSON sidecar at
+    target/ask_ingest/{table_name}_provenance.json.
+
+    Args:
+        source_path: Path to the source file (as returned by read_tabular).
+        table_name: Target table name (alphanumeric + underscores).
+        business_key: Comma-separated column names forming the business key for dedup.
+        mode: 'create' for new table, 'append' for append+dedup to existing.
+        user_confirmed: Must be True for append mode to actually write. If False,
+            returns drift report only.
+        dedup_strategy: 'skip' (default) keeps existing rows, 'replace' keeps new rows.
+    """
+    from seeknal.ask.agents.tools._context import get_tool_context
+    from seeknal.ask.agents.tools._write_security import validate_write_path
+
+    ctx = get_tool_context()
+
+    if mode not in {"create", "append"}:
+        return f"Error: mode must be 'create' or 'append', got '{mode}'."
+    if dedup_strategy not in {"skip", "replace"}:
+        return (
+            f"Error: dedup_strategy must be 'skip' or 'replace', got '{dedup_strategy}'."
+        )
+    if not _TABLE_NAME_RE.match(table_name):
+        return (
+            f"Error: invalid table_name '{table_name}'. "
+            "Must match [a-zA-Z_][a-zA-Z0-9_]*."
+        )
+
+    business_key_cols = [col.strip() for col in business_key.split(",") if col.strip()]
+    if not business_key_cols:
+        return "Error: business_key must name at least one column."
+    for col in business_key_cols:
+        if not _COLUMN_NAME_RE.match(col):
+            return (
+                f"Error: invalid business key column '{col}'. "
+                "Must match [a-zA-Z_][a-zA-Z0-9_]*."
+            )
+
+    # Resolve source path: explicit arg wins; otherwise fall back to the
+    # staged path stashed by read_tabular.
+    resolved_source = _resolve_source_path(source_path, ctx)
+    if resolved_source is None:
+        return (
+            "Error: source file not found. Pass an absolute path or call "
+            "read_tabular first."
+        )
+
+    suffix = resolved_source.suffix.lower()
+    if suffix not in _SUPPORTED_SUFFIXES:
+        return f"Error: unsupported source suffix '{suffix}'."
+
+    # Validate output paths through the write security layer.
+    rel_parquet = f"target/ask_ingest/{table_name}.parquet"
+    rel_prov = f"target/ask_ingest/{table_name}_provenance.json"
+    try:
+        parquet_path = validate_write_path(rel_parquet, ctx.project_path)
+        prov_path = validate_write_path(rel_prov, ctx.project_path)
+    except ValueError as exc:
+        return f"Error: {exc}"
+
+    parquet_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Existing-table check.
+    existing_present = parquet_path.exists()
+
+    if mode == "create":
+        if existing_present:
+            return (
+                f"Error: table '{table_name}' already exists at {parquet_path}. "
+                "Use mode='append' to add new rows."
+            )
+        return _do_create(
+            resolved_source=resolved_source,
+            parquet_path=parquet_path,
+            prov_path=prov_path,
+            table_name=table_name,
+            business_key_cols=business_key_cols,
+            ctx=ctx,
+        )
+
+    # mode == 'append'
+    if not existing_present:
+        return (
+            f"Error: no existing table '{table_name}' at {parquet_path}. "
+            "Call with mode='create' for the first ingestion."
+        )
+
+    drift = _compute_drift(
+        source_path=resolved_source,
+        existing_parquet=parquet_path,
+        business_key_cols=business_key_cols,
+    )
+
+    if not user_confirmed:
+        return _format_drift_report(
+            table_name=table_name,
+            drift=drift,
+            business_key_cols=business_key_cols,
+            duplicate_count=drift["duplicate_count"],
+        )
+
+    return _do_append(
+        resolved_source=resolved_source,
+        parquet_path=parquet_path,
+        prov_path=prov_path,
+        table_name=table_name,
+        business_key_cols=business_key_cols,
+        dedup_strategy=dedup_strategy,
+        drift=drift,
+        ctx=ctx,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_source_path(source_path: str, ctx) -> Path | None:
+    """Resolve an input path to a DuckDB-readable file.
+
+    xlsx inputs are converted to a staging parquet on the fly (matching
+    ``read_tabular``'s behavior) so the agent can call this tool directly
+    on an .xlsx upload without first calling read_tabular.
+    """
+    candidate_raw = source_path or getattr(ctx, "last_read_staging_path", None) or ""
+    if not candidate_raw:
+        return None
+    candidate = Path(candidate_raw).expanduser()
+    if not candidate.is_absolute():
+        candidate = (ctx.project_path / candidate).resolve()
+    else:
+        candidate = candidate.resolve()
+    if not candidate.exists() or not candidate.is_file():
+        return None
+
+    if candidate.suffix.lower() == ".xlsx":
+        try:
+            candidate = _xlsx_to_parquet(candidate, ctx.project_path)
+        except Exception:
+            return None
+        # Cache so subsequent calls (e.g. an append after a create) reuse the
+        # converted parquet rather than re-running pandas each turn.
+        try:
+            ctx.last_read_staging_path = str(candidate)
+        except Exception:
+            pass
+
+    return candidate
+
+
+def _xlsx_to_parquet(xlsx_path: Path, project_path: Path) -> Path:
+    """Convert an xlsx file to a parquet under target/ask_ingest/_staging/."""
+    import pandas as pd
+
+    staging_root = (
+        project_path / "target" / "ask_ingest" / "_staging" / uuid.uuid4().hex[:12]
+    )
+    staging_root.mkdir(parents=True, exist_ok=True)
+    df = pd.read_excel(xlsx_path, engine="openpyxl")
+    parquet_path = staging_root / f"{xlsx_path.stem}.parquet"
+    df.to_parquet(parquet_path, index=False)
+    return parquet_path
+
+
+def _reader_expr(path: Path) -> str:
+    safe = str(path.resolve()).replace("'", "''")
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        return f"read_csv_auto('{safe}')"
+    if suffix == ".tsv":
+        return f"read_csv_auto('{safe}', delim='\\t')"
+    if suffix == ".json":
+        return f"read_json_auto('{safe}')"
+    if suffix == ".parquet":
+        return f"read_parquet('{safe}')"
+    if suffix == ".xlsx":
+        raise ValueError("xlsx must be converted to parquet by read_tabular first")
+    raise ValueError(f"unsupported suffix: {suffix}")
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(tz=_dt.timezone.utc).isoformat(timespec="seconds")
+
+
+def _describe(con, reader: str) -> list[tuple[str, str]]:
+    rows = con.execute(f"DESCRIBE SELECT * FROM {reader}").fetchall()
+    return [(r[0], r[1]) for r in rows]
+
+
+def _register_view(ctx, table_name: str, parquet_path: Path) -> None:
+    safe = str(parquet_path.resolve()).replace("'", "''")
+    view_name = f"ingest_{table_name}"
+    try:
+        with ctx.db_lock:
+            ctx.repl.conn.execute(
+                f'CREATE OR REPLACE VIEW "{view_name}" AS '
+                f"SELECT * FROM read_parquet('{safe}')"
+            )
+    except Exception:
+        # Best-effort: view registration should not block a successful write.
+        pass
+
+
+def _write_provenance(
+    prov_path: Path,
+    source_path: Path,
+    rows_before: int,
+    rows_after: int,
+    rows_inserted: int,
+    rows_deduped: int,
+    drift_decisions: list[dict],
+) -> None:
+    payload = {
+        "source_file": str(source_path),
+        "source_file_sha256": _sha256(source_path),
+        "ingested_at": _now_iso(),
+        "rows_before": rows_before,
+        "rows_after": rows_after,
+        "rows_inserted": rows_inserted,
+        "rows_deduped": rows_deduped,
+        "drift_decisions": drift_decisions,
+    }
+    prov_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Create mode
+# ---------------------------------------------------------------------------
+
+
+def _do_create(
+    resolved_source: Path,
+    parquet_path: Path,
+    prov_path: Path,
+    table_name: str,
+    business_key_cols: list[str],
+    ctx,
+) -> str:
+    import duckdb
+
+    reader = _reader_expr(resolved_source)
+    safe_out = str(parquet_path.resolve()).replace("'", "''")
+
+    con = duckdb.connect(":memory:")
+    try:
+        # Sanity check business key columns exist.
+        schema = _describe(con, reader)
+        col_names = {name for name, _ in schema}
+        missing = [c for c in business_key_cols if c not in col_names]
+        if missing:
+            return (
+                f"Error: business_key columns not present in source: "
+                f"{', '.join(missing)}. Available columns: {', '.join(sorted(col_names))}."
+            )
+
+        (row_count,) = con.execute(f"SELECT COUNT(*) FROM {reader}").fetchone()
+        # fs_lock serialises the parquet + provenance write against other
+        # filesystem-writing tools (draft_node, apply_draft, save_ingestion_skill).
+        with ctx.fs_lock:
+            con.execute(
+                f"COPY (SELECT * FROM {reader}) TO '{safe_out}' (FORMAT PARQUET)"
+            )
+            _write_provenance(
+                prov_path=prov_path,
+                source_path=resolved_source,
+                rows_before=0,
+                rows_after=int(row_count),
+                rows_inserted=int(row_count),
+                rows_deduped=0,
+                drift_decisions=[
+                    {"kind": "create", "action": "new_table", "rows": int(row_count)}
+                ],
+            )
+    except Exception as exc:
+        return f"Error writing parquet: {exc}"
+    finally:
+        con.close()
+
+    _register_view(ctx, table_name, parquet_path)
+
+    return (
+        f"Created table `ingest_{table_name}` at {parquet_path}.\n"
+        f"- Rows inserted: {row_count:,}\n"
+        f"- Business key: {', '.join(business_key_cols)}\n"
+        f"- Provenance: {prov_path}\n\n"
+        "You can now query it via `execute_sql('SELECT ... FROM "
+        f"ingest_{table_name}')`."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Append mode — drift + dedup
+# ---------------------------------------------------------------------------
+
+
+def _compute_drift(
+    source_path: Path,
+    existing_parquet: Path,
+    business_key_cols: list[str],
+) -> dict:
+    """Return a dict describing schema diff + duplicate-key count."""
+    import duckdb
+
+    new_reader = _reader_expr(source_path)
+    safe_existing = str(existing_parquet.resolve()).replace("'", "''")
+    existing_reader = f"read_parquet('{safe_existing}')"
+
+    result: dict = {
+        "schema_new": [],
+        "schema_existing": [],
+        "missing_in_new": [],  # cols in existing but not in new
+        "extra_in_new": [],    # cols in new but not in existing
+        "type_mismatches": [],  # list of (col, existing_type, new_type)
+        "missing_bk_in_new": [],
+        "missing_bk_in_existing": [],
+        "duplicate_count": 0,
+        "new_row_count": 0,
+        "existing_row_count": 0,
+    }
+
+    con = duckdb.connect(":memory:")
+    try:
+        schema_new = _describe(con, new_reader)
+        schema_existing = _describe(con, existing_reader)
+        result["schema_new"] = schema_new
+        result["schema_existing"] = schema_existing
+
+        new_map = dict(schema_new)
+        existing_map = dict(schema_existing)
+
+        result["missing_in_new"] = [c for c in existing_map if c not in new_map]
+        result["extra_in_new"] = [c for c in new_map if c not in existing_map]
+
+        for col in new_map:
+            if col in existing_map and new_map[col] != existing_map[col]:
+                result["type_mismatches"].append((col, existing_map[col], new_map[col]))
+
+        result["missing_bk_in_new"] = [c for c in business_key_cols if c not in new_map]
+        result["missing_bk_in_existing"] = [
+            c for c in business_key_cols if c not in existing_map
+        ]
+
+        (result["new_row_count"],) = con.execute(
+            f"SELECT COUNT(*) FROM {new_reader}"
+        ).fetchone()
+        (result["existing_row_count"],) = con.execute(
+            f"SELECT COUNT(*) FROM {existing_reader}"
+        ).fetchone()
+
+        if not result["missing_bk_in_new"] and not result["missing_bk_in_existing"]:
+            bk_select = ", ".join(f'"{c}"' for c in business_key_cols)
+            dup_sql = (
+                f"SELECT COUNT(*) FROM ("
+                f"SELECT {bk_select} FROM {new_reader} "
+                f"INTERSECT "
+                f"SELECT {bk_select} FROM {existing_reader}"
+                f")"
+            )
+            (result["duplicate_count"],) = con.execute(dup_sql).fetchone()
+    finally:
+        con.close()
+
+    return result
+
+
+def _format_drift_report(
+    table_name: str,
+    drift: dict,
+    business_key_cols: list[str],
+    duplicate_count: int,
+) -> str:
+    lines: list[str] = []
+    lines.append(f"## Drift report for `ingest_{table_name}` (dry run)")
+    lines.append("")
+    lines.append(
+        f"- New file rows: **{drift['new_row_count']:,}**"
+    )
+    lines.append(
+        f"- Existing table rows: **{drift['existing_row_count']:,}**"
+    )
+    lines.append(f"- Business key: {', '.join(business_key_cols)}")
+    lines.append(f"- Duplicate business-key rows: **{duplicate_count:,}**")
+    lines.append("")
+
+    if drift["missing_in_new"]:
+        lines.append(
+            "### Columns missing from new file\n"
+            + "\n".join(f"- `{c}`" for c in drift["missing_in_new"])
+        )
+        lines.append("")
+    if drift["extra_in_new"]:
+        lines.append(
+            "### New columns not in existing table\n"
+            + "\n".join(f"- `{c}`" for c in drift["extra_in_new"])
+        )
+        lines.append("")
+    if drift["type_mismatches"]:
+        lines.append("### Type mismatches")
+        for col, existing_t, new_t in drift["type_mismatches"]:
+            lines.append(f"- `{col}`: existing `{existing_t}` vs new `{new_t}`")
+        lines.append("")
+    if drift["missing_bk_in_new"]:
+        lines.append(
+            "### Business key columns missing from new file\n"
+            + "\n".join(f"- `{c}`" for c in drift["missing_bk_in_new"])
+        )
+        lines.append("")
+    if drift["missing_bk_in_existing"]:
+        lines.append(
+            "### Business key columns missing from existing table\n"
+            + "\n".join(f"- `{c}`" for c in drift["missing_bk_in_existing"])
+        )
+        lines.append("")
+
+    if duplicate_count > 0:
+        lines.append(
+            f"**Recommendation:** {duplicate_count:,} row(s) already exist. "
+            "I suggest **skipping duplicates** (keep existing) unless the "
+            "new file is a corrected version, in which case choose "
+            "**replace duplicates**."
+        )
+    elif drift["type_mismatches"] or drift["missing_in_new"] or drift["extra_in_new"]:
+        lines.append(
+            "**Recommendation:** schema drifted. Confirm the diff above "
+            "before appending."
+        )
+    else:
+        lines.append(
+            "**Recommendation:** no duplicates or drift detected. Safe to "
+            "append with `user_confirmed=True, dedup_strategy='skip'`."
+        )
+    lines.append("")
+    lines.append(
+        "**No data was written.** Present this report to the user via "
+        "`ask_user` with options like "
+        "`Skip duplicates (keep existing)`, `Replace duplicates (keep new)`, "
+        "`Skip this file`, `Type your own`. After the user decides, call "
+        "`write_ingested_table(mode='append', user_confirmed=True, "
+        "dedup_strategy='skip'|'replace')`."
+    )
+    return "\n".join(lines)
+
+
+def _do_append(
+    resolved_source: Path,
+    parquet_path: Path,
+    prov_path: Path,
+    table_name: str,
+    business_key_cols: list[str],
+    dedup_strategy: str,
+    drift: dict,
+    ctx,
+) -> str:
+    import duckdb
+
+    if drift["missing_bk_in_new"] or drift["missing_bk_in_existing"]:
+        missing = drift["missing_bk_in_new"] + drift["missing_bk_in_existing"]
+        return (
+            "Error: business_key columns missing from schema; cannot dedup: "
+            f"{', '.join(sorted(set(missing)))}."
+        )
+
+    new_reader = _reader_expr(resolved_source)
+    safe_existing = str(parquet_path.resolve()).replace("'", "''")
+    existing_reader = f"read_parquet('{safe_existing}')"
+
+    # Temporary parquet for atomic swap. Same directory so rename is atomic.
+    tmp_path = parquet_path.with_name(
+        f"{parquet_path.stem}.{uuid.uuid4().hex[:8]}.tmp.parquet"
+    )
+    safe_tmp = str(tmp_path.resolve()).replace("'", "''")
+
+    # Choose union columns = intersection of both schemas (preserve existing order).
+    existing_cols = [name for name, _ in drift["schema_existing"]]
+    new_cols = {name for name, _ in drift["schema_new"]}
+    common_cols = [c for c in existing_cols if c in new_cols]
+    if not common_cols:
+        return "Error: no shared columns between existing table and new file."
+
+    col_select = ", ".join(f'"{c}"' for c in common_cols)
+    bk_select = ", ".join(f'"{c}"' for c in business_key_cols)
+
+    # Build a de-duplicated set using a rowid-like ordering. We tag each source
+    # so we can prefer one side on collisions.
+    if dedup_strategy == "skip":
+        # Existing wins on collision: give existing rows priority 0, new 1.
+        priority_existing = 0
+        priority_new = 1
+    else:
+        # Replace: new wins.
+        priority_existing = 1
+        priority_new = 0
+
+    combined_sql = f"""
+        WITH combined AS (
+            SELECT {col_select}, {priority_existing} AS _seek_priority
+            FROM {existing_reader}
+            UNION ALL
+            SELECT {col_select}, {priority_new} AS _seek_priority
+            FROM {new_reader}
+        ),
+        ranked AS (
+            SELECT *, ROW_NUMBER() OVER (
+                PARTITION BY {bk_select}
+                ORDER BY _seek_priority
+            ) AS _seek_rn
+            FROM combined
+        )
+        SELECT {col_select}
+        FROM ranked
+        WHERE _seek_rn = 1
+    """
+
+    con = duckdb.connect(":memory:")
+    try:
+        con.execute(
+            f"COPY ({combined_sql}) TO '{safe_tmp}' (FORMAT PARQUET)"
+        )
+        (rows_after,) = con.execute(
+            f"SELECT COUNT(*) FROM read_parquet('{safe_tmp}')"
+        ).fetchone()
+    except Exception as exc:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+        con.close()
+        return f"Error during dedup write: {exc}"
+    finally:
+        con.close()
+
+    rows_before = int(drift["existing_row_count"])
+    new_rows = int(drift["new_row_count"])
+    duplicate_count = int(drift["duplicate_count"])
+
+    if dedup_strategy == "skip":
+        rows_inserted = new_rows - duplicate_count
+        rows_deduped = duplicate_count
+    else:  # replace
+        rows_inserted = new_rows
+        rows_deduped = duplicate_count
+
+    # Atomic swap + provenance write, serialised via fs_lock.
+    drift_decisions = [
+        {
+            "kind": "append",
+            "dedup_strategy": dedup_strategy,
+            "duplicate_count": duplicate_count,
+            "rows_before": rows_before,
+            "rows_after": int(rows_after),
+        }
+    ]
+    if drift["type_mismatches"]:
+        drift_decisions.append(
+            {
+                "kind": "type_mismatch",
+                "mismatches": [
+                    {"column": col, "existing": e, "new": n}
+                    for col, e, n in drift["type_mismatches"]
+                ],
+            }
+        )
+    if drift["missing_in_new"]:
+        drift_decisions.append(
+            {"kind": "missing_in_new", "columns": drift["missing_in_new"]}
+        )
+    if drift["extra_in_new"]:
+        drift_decisions.append(
+            {"kind": "extra_in_new", "columns": drift["extra_in_new"]}
+        )
+
+    try:
+        with ctx.fs_lock:
+            tmp_path.replace(parquet_path)
+            _write_provenance(
+                prov_path=prov_path,
+                source_path=resolved_source,
+                rows_before=rows_before,
+                rows_after=int(rows_after),
+                rows_inserted=rows_inserted,
+                rows_deduped=rows_deduped,
+                drift_decisions=drift_decisions,
+            )
+    except Exception as exc:
+        tmp_path.unlink(missing_ok=True)
+        return f"Error finalising parquet: {exc}"
+
+    _register_view(ctx, table_name, parquet_path)
+
+    return (
+        f"Appended to `ingest_{table_name}` at {parquet_path}.\n"
+        f"- Dedup strategy: {dedup_strategy}\n"
+        f"- Rows before: {rows_before:,}\n"
+        f"- Rows after: {rows_after:,}\n"
+        f"- Rows inserted from new file: {rows_inserted:,}\n"
+        f"- Rows deduped: {rows_deduped:,}\n"
+        f"- Provenance: {prov_path}"
+    )

--- a/src/seeknal/ask/builtin_skills/data-ingest/SKILL.md
+++ b/src/seeknal/ask/builtin_skills/data-ingest/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: data-ingest
+description: "Conversational data ingestion — parse files, brainstorm schema, create queryable tables, and save reusable skills"
+tags: [data-ingest, import, upload]
+version: "1.0.0"
+---
+
+# Data Ingestion
+
+Use this workflow when the user provides a file (xlsx, csv, tsv, json)
+or a direct-download URL and wants to ingest it into a queryable table.
+
+## Tools you will call
+
+- `read_tabular` — parse and preview the file
+- `describe_table` / `list_tables` — check for existing tables
+- `ask_user` — confirm schema, business key, table name
+- `write_ingested_table` — persist data to Parquet + register view
+- `save_ingestion_skill` — create reusable SKILL.md
+- `execute_sql` — answer follow-up analytics questions
+- `check_ingestion_drift` — compare schemas on re-runs
+
+## Phase 1 — Parse & Inspect
+
+1. Call `read_tabular(path_or_url=<user file or URL>)`.
+2. Present the inferred schema to the user.
+3. Use `ask_user` to confirm / adjust:
+   - Table name suggestion (derived from filename)
+   - Business key suggestion (inferred from unique columns)
+   - Any column renames or type overrides
+
+## Phase 2 — Check for Existing Table
+
+1. Call `list_tables` to see whether `ingest_{table_name}` already exists.
+2. If it exists: load the matching skill (if any) and switch to re-run mode
+   (Phase 2b).
+3. If not: proceed to Phase 3 (First Ingestion).
+
+### Phase 2b — Re-run Mode (existing table found)
+
+1. Call `check_ingestion_drift(source_path=..., table_name=...,
+   business_key=...)` to compare schemas and get a human-readable report.
+2. Call `write_ingested_table(source_path=..., table_name=...,
+   business_key=..., mode='append', user_confirmed=False)` to get the
+   self-defending drift report (schema diff + dedup count).
+3. Present both reports via `ask_user` with options:
+   - `Skip duplicates (keep existing)`
+   - `Replace duplicates (keep new)`
+   - `Skip this file`
+   - `Type your own`
+4. Based on the user's answer, call
+   `write_ingested_table(mode='append', user_confirmed=True,
+   dedup_strategy='skip'|'replace')`.
+5. Skip to Phase 5.
+
+## Phase 3 — First Ingestion
+
+1. Call `write_ingested_table(source_path=..., table_name=...,
+   business_key=..., mode='create')`.
+2. Verify: `execute_sql("SELECT COUNT(*) FROM ingest_{table_name}")`.
+
+## Phase 4 — Save Skill
+
+1. Call `save_ingestion_skill(skill_name=..., table_name=...,
+   business_key=..., columns_json=..., description=...)`.
+2. Confirm: "Skill saved at {path}. Next time you provide similar data,
+   I'll auto-detect and use this skill."
+
+## Phase 5 — Analytics
+
+After ingestion, ask the user if they have a question about the data.
+Use `execute_sql` to answer it (standard analytics path).
+
+## Critical-Analyst Rules
+
+- NEVER insert data without showing the user a schema preview first.
+- NEVER silently skip or drop columns on schema drift.
+- NEVER silently dedup rows — always report the count and ask.
+- If schema drift is detected, present EXACTLY what changed and offer
+  options via `ask_user`.
+- If duplicates are detected, present the count AND a recommendation
+  (e.g., "I suggest skipping duplicates") and offer skip/replace
+  options via `ask_user`.
+- ALWAYS call `write_ingested_table` with `user_confirmed=False` first in
+  append mode to get the drift report. Only call with `user_confirmed=True`
+  after the user explicitly confirms via `ask_user`.
+
+## Housekeeping
+
+Staging files in `target/ask_ingest/_staging/` are temporary downloads and
+uploads. They can be safely deleted after ingestion completes. Cleanup is
+manual in v1; automated TTL-based cleanup is planned for v2.

--- a/src/seeknal/ask/builtin_skills/record-entry/SKILL.md
+++ b/src/seeknal/ask/builtin_skills/record-entry/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: record-entry
+description: "Data-entry, assistant, and advisor: record one-off events from text (/record ...) or receipt/transfer images into the right ingest table, asking questions until the row is complete"
+tags: [record, data-entry, image, ocr, telegram]
+version: "1.0.0"
+---
+
+# Record Entry
+
+Use this workflow when the user gives you a **single event to record** —
+either as a free-form `/record ...` text message or as a receipt /
+fund-transfer image. Common shapes:
+
+- `/record fitra, 1 mie ayam, 1 mineral water` — expense to capture
+- A photo of a BCA, Mandiri, GoPay, OVO, DANA, or QRIS transfer
+- A screenshot of a food order or shop receipt
+
+Think of yourself as a **data entry clerk + advisor**: parse the input,
+look at the tables we already have, propose where this row should go, ask
+clarifying questions until every required field is resolved, then write.
+
+**Never silently invent data.** Missing amount, missing counterparty,
+ambiguous item name — always `ask_user`.
+
+## Tools you will call
+
+- `parse_record` — deterministic parser for `/record ...` text
+- `extract_from_image` — Gemini-vision OCR for receipt/transfer images
+- `list_tables` / `describe_table` — enumerate existing `ingest_*` tables
+- `propose_record_table` — rank existing tables vs draft, recommend match or new
+- `ask_user` — resolve missing fields and confirm schema
+- `write_ingested_table` — persist as parquet + DuckDB view
+- `save_ingestion_skill` — if we just created a new table, save a re-run skill
+- `execute_sql` — verify the row landed, answer analytical follow-ups
+
+## Phase 1 — Parse the input and decide the kind
+
+- **Text:** call `parse_record(<full user message>)`. The tool returns
+  *hints only* — detected amounts, bank/e-wallet tokens, item lists,
+  a best-guess `kind_hint`. It does NOT dictate which fields are
+  required. **You** classify the record:
+
+  | Looks like | kind |
+  |---|---|
+  | Rp / bank / transfer / QRIS | `transfer` |
+  | shop / receipt / merchant | `receipt` |
+  | food order with items + amount | `order` |
+  | workout / run / pushups / gym / yoga | `activity` |
+  | meeting / rapat / standup / call / discussed | `meeting` |
+  | weight / BP / sleep / pulse / glucose | `health` |
+  | money in/out, no counterparty | `expense` |
+  | anything else | `note` |
+
+  Add a `kind` field to the draft before calling
+  `propose_record_table`. If the message spans two kinds (e.g. a
+  transfer receipt with attendees), pick the dominant one and keep the
+  rest in `note`.
+
+- **Image:** call `extract_from_image(<absolute image path>, hint='...')`.
+  The `hint` is optional — if the user captioned the image ("BCA
+  transfer to mom"), pass that verbatim so Gemini can focus.
+
+Both tools store the source path on `ToolContext.last_read_staging_path`
+so downstream tools can reference it without the user retyping.
+
+**Custom kinds.** If none of the templates fit (e.g. inventory check,
+supplier order, study session), set `kind` to a short lowercase slug and
+pass an explicit `_columns` list in the draft — see
+`propose_record_table` for the format. Templates are starting points,
+not walls.
+
+## Phase 2 — Propose the target table
+
+1. Call `list_tables` to see what exists.
+2. Take the JSON draft from Phase 1 and call
+   `propose_record_table(draft_json=<json string>, hint_table_name=<what
+   the user named it, if anything>)`.
+3. Present the proposal via `ask_user` with these options:
+   - `Use this table` — accept the proposed match / new table
+   - `Pick a different existing table` — user names another
+   - `Rename / redesign` — user provides a new slug or column tweak
+   - `Type your own`
+
+Never skip this. Even if there's only one existing table, the user might
+want a new one for this record.
+
+## Phase 3 — Resolve ambiguous fields (strict)
+
+Look at the draft's null / missing fields. For each one that is required
+for the chosen table (see the proposal's business key and schema), call
+`ask_user` with concrete options drawn from the draft. Examples:
+
+- **Amount missing from /record:** "I couldn't find an amount. How much
+  was spent total?" — free-text.
+- **Item price missing:** if the target table has a `price` column and
+  the item isn't in the menu, `ask_user` for the unit price.
+- **Recipient missing on a transfer:** show the OCR raw text, ask for
+  the recipient name.
+
+Do NOT write until every required field is resolved. The user chose
+strict clarification — zero dirty rows is the bar.
+
+## Phase 4 — Stage and write
+
+1. Build a one-row parquet for the confirmed draft. The simplest path:
+   - Write the row to `target/ask_ingest/_staging/<uuid>/row.csv`.
+   - Call `write_ingested_table(source_path=<that csv>, table_name=...,
+     business_key=..., mode='create'|'append')`.
+2. For `mode='append'`, always call first with `user_confirmed=False`,
+   inspect the drift report, then re-call with `user_confirmed=True` and
+   the user's chosen `dedup_strategy`.
+3. Verify with `execute_sql("SELECT * FROM ingest_<table> ORDER BY
+   entered_at DESC LIMIT 3")`.
+
+## Phase 5 — Save a skill (new tables only)
+
+If Phase 2 ended with a new table, call
+`save_ingestion_skill(skill_name='record-<table>', table_name=<table>,
+business_key=<chosen>, columns_json=<schema JSON>, description='...')`.
+Next time the user sends a record that fits this shape,
+`propose_record_table` will match it automatically.
+
+## Phase 6 — Offer analysis
+
+After writing, suggest 1-2 short analytical follow-ups using the data
+just recorded:
+
+- "Top 3 items this week by quantity?"
+- "How much have I transferred to this recipient this month?"
+
+Use `execute_sql` to answer when the user picks one.
+
+## Critical-analyst rules
+
+- Never write a row with required fields still null.
+- Never pick an existing table without showing the match score to the user.
+- Never OCR an image without showing the draft to the user — OCR mistakes
+  happen, especially on blurry phone screenshots.
+- On a transfer proof, double-check the `amount`, `recipient_name`, and
+  `transaction_date` with the user before writing.
+- If a draft field directly contradicts a value the user typed in their
+  message, trust the user's text over the OCR.
+
+## Housekeeping
+
+Staged CSVs and images live under `target/ask_ingest/_staging/`. Safe to
+delete once the row is persisted; `target/ask_ingest/<table>.parquet`
+and the provenance JSON are the source of truth.

--- a/src/seeknal/ask/gateway/channels/telegram.py
+++ b/src/seeknal/ask/gateway/channels/telegram.py
@@ -21,6 +21,21 @@ logger = logging.getLogger(__name__)
 # Telegram message size limit
 _MAX_MESSAGE_LENGTH = 4096
 
+# Document upload constraints (match the gateway /upload endpoint)
+_UPLOAD_MAX_BYTES = 200 * 1024 * 1024  # 200 MB
+_UPLOAD_ALLOWED_SUFFIXES = {".xlsx", ".csv", ".tsv", ".json"}
+
+# Image upload constraints (routed into record-entry skill)
+_IMAGE_MAX_BYTES = 20 * 1024 * 1024  # 20 MB
+_IMAGE_SUFFIX_FOR_MIME = {
+    "image/jpeg": ".jpg",
+    "image/jpg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
+    "image/heic": ".heic",
+    "image/heif": ".heif",
+}
+
 # Telegram formatting instruction prepended to user messages
 _TELEGRAM_FORMAT_HINT = (
     "[Format: plain text for Telegram. No markdown syntax. "
@@ -111,6 +126,17 @@ class TelegramChannel:
         self._app.add_handler(CommandHandler("start", self._handle_start))
         self._app.add_handler(
             MessageHandler(filters.TEXT & ~filters.COMMAND, self._handle_message)
+        )
+        # Document uploads (xlsx/csv/tsv/json) are routed into the data-ingest
+        # workflow so the user can converse with the ingested data.
+        self._app.add_handler(
+            MessageHandler(filters.Document.ALL, self._handle_document)
+        )
+        # Photo uploads (receipt / transfer-proof images) are routed into the
+        # record-entry workflow: download -> Gemini vision -> ask_user ->
+        # write_ingested_table.
+        self._app.add_handler(
+            MessageHandler(filters.PHOTO, self._handle_photo)
         )
 
         await self._app.initialize()
@@ -208,6 +234,221 @@ class TelegramChannel:
                 await status_msg.edit_text(f"❌ Error: {e}")
             except Exception:
                 await update.message.reply_text(f"❌ Error: {e}")
+
+    async def _handle_photo(self, update: Any, context: Any) -> None:
+        """Handle photo uploads — stage and route into record-entry skill."""
+        from telegram.constants import ChatAction
+
+        photos = update.message.photo
+        if not photos:
+            return
+
+        # Telegram serves multiple sizes; the largest is the last element.
+        photo = photos[-1]
+
+        chat_id = str(update.effective_chat.id)
+        session_id = f"telegram-{chat_id}"
+        logger.info(
+            "[telegram] photo from chat_id=%s: file_id=%s size=%s",
+            chat_id, photo.file_id, photo.file_size,
+        )
+
+        if photo.file_size and photo.file_size > _IMAGE_MAX_BYTES:
+            await update.message.reply_text(
+                f"Image too large ({photo.file_size / 1024 / 1024:.1f} MB). "
+                f"Limit is {_IMAGE_MAX_BYTES / 1024 / 1024:.0f} MB."
+            )
+            return
+
+        staging_dir = (
+            self._project_path / "target" / "ask_ingest" / "_staging"
+            / f"telegram-{chat_id}"
+        )
+        staging_dir.mkdir(parents=True, exist_ok=True)
+        staged_path = staging_dir / f"{photo.file_unique_id}.jpg"
+
+        await update.effective_chat.send_action(ChatAction.TYPING)
+        status_msg = await update.message.reply_text(
+            "📷 Received image. Downloading..."
+        )
+
+        try:
+            tg_file = await context.bot.get_file(photo.file_id)
+            await tg_file.download_to_drive(custom_path=str(staged_path))
+            logger.info(
+                "[telegram] photo staged: %s (%d bytes)",
+                staged_path, staged_path.stat().st_size,
+            )
+        except Exception as exc:
+            logger.exception(
+                "[telegram] photo download failed for chat_id=%s", chat_id
+            )
+            try:
+                await status_msg.edit_text(f"❌ Download failed: {exc}")
+            except Exception:
+                await update.message.reply_text(f"❌ Download failed: {exc}")
+            return
+
+        caption = (update.message.caption or "").strip()
+        user_prompt = (
+            "The user sent a photo via Telegram — most likely a fund-transfer "
+            "proof (BCA/Mandiri/BNI/BRI/GoPay/OVO/DANA/QRIS), a shop receipt, "
+            "or an order photo. Load the 'record-entry' skill and walk through "
+            f"the full workflow on this image:\n\n"
+            f"Absolute image path: {staged_path}\n"
+        )
+        if caption:
+            user_prompt += f"User caption / hint: {caption}\n"
+        user_prompt += (
+            "\nStart with `extract_from_image(image_path=<path>, hint=<caption "
+            "if any>)`, then `list_tables` + `propose_record_table`, then "
+            "`ask_user` until every required field is resolved, then "
+            "`write_ingested_table`. Strict clarification — do not record "
+            "until the draft is fully confirmed."
+        )
+
+        try:
+            await status_msg.edit_text("🧐 Reading the image...")
+        except Exception:
+            pass
+
+        try:
+            answer = await self._run_agent(session_id, user_prompt, update, status_msg)
+            logger.info(
+                "[telegram] record-entry agent done for session=%s, answer_len=%d",
+                session_id, len(answer) if answer else 0,
+            )
+            try:
+                await status_msg.delete()
+            except Exception:
+                pass
+            if answer:
+                clean = _strip_markdown(answer)
+                for chunk in _split_message(clean):
+                    await update.message.reply_text(chunk)
+                logger.info(
+                    "[telegram] record-entry reply sent to chat_id=%s", chat_id
+                )
+            else:
+                await update.message.reply_text(
+                    "I could read the image but didn't produce a reply. "
+                    "Ask me 'what did you extract?' to recover."
+                )
+        except Exception as exc:
+            logger.exception(
+                "[telegram] error on photo from chat_id=%s", chat_id
+            )
+            try:
+                await status_msg.edit_text(f"❌ Error: {exc}")
+            except Exception:
+                await update.message.reply_text(f"❌ Error: {exc}")
+
+    async def _handle_document(self, update: Any, context: Any) -> None:
+        """Handle document uploads — stage file and trigger data-ingest skill."""
+        from telegram.constants import ChatAction
+
+        doc = update.message.document
+        if doc is None:
+            return
+
+        chat_id = str(update.effective_chat.id)
+        session_id = f"telegram-{chat_id}"
+        original_name = Path(doc.file_name or "upload").name
+        suffix = Path(original_name).suffix.lower()
+        logger.info(
+            "[telegram] document from chat_id=%s: %s (size=%s)",
+            chat_id, original_name, doc.file_size,
+        )
+
+        if suffix not in _UPLOAD_ALLOWED_SUFFIXES:
+            await update.message.reply_text(
+                f"Sorry, I can't ingest '{suffix}' files. "
+                f"Supported: {', '.join(sorted(_UPLOAD_ALLOWED_SUFFIXES))}."
+            )
+            return
+
+        if doc.file_size and doc.file_size > _UPLOAD_MAX_BYTES:
+            await update.message.reply_text(
+                f"File too large ({doc.file_size / 1024 / 1024:.1f} MB). "
+                f"Limit is 200 MB."
+            )
+            return
+
+        staging_dir = (
+            self._project_path / "target" / "ask_ingest" / "_staging"
+            / f"telegram-{chat_id}"
+        )
+        staging_dir.mkdir(parents=True, exist_ok=True)
+        staged_path = staging_dir / original_name
+
+        await update.effective_chat.send_action(ChatAction.TYPING)
+        status_msg = await update.message.reply_text(
+            f"📥 Downloading {original_name}..."
+        )
+
+        try:
+            tg_file = await context.bot.get_file(doc.file_id)
+            await tg_file.download_to_drive(custom_path=str(staged_path))
+            logger.info(
+                "[telegram] document staged: %s (%d bytes)",
+                staged_path, staged_path.stat().st_size,
+            )
+        except Exception as exc:
+            logger.exception(
+                "[telegram] download failed for chat_id=%s", chat_id
+            )
+            try:
+                await status_msg.edit_text(f"❌ Download failed: {exc}")
+            except Exception:
+                await update.message.reply_text(f"❌ Download failed: {exc}")
+            return
+
+        caption = (update.message.caption or "").strip()
+        user_prompt = (
+            f"The user uploaded a tabular file via Telegram. "
+            f"Absolute file path: {staged_path}. "
+            f"Please load the 'data-ingest' skill and walk through the ingestion "
+            f"workflow: use read_tabular to preview the file, propose a table "
+            f"name and business key via ask_user, write it via "
+            f"write_ingested_table, and save a reusable skill via "
+            f"save_ingestion_skill. "
+        )
+        if caption:
+            user_prompt += f"User note: {caption}"
+
+        try:
+            await status_msg.edit_text(f"🔍 Inspecting {original_name}...")
+        except Exception:
+            pass
+
+        try:
+            answer = await self._run_agent(session_id, user_prompt, update, status_msg)
+            logger.info(
+                "[telegram] ingest agent done for session=%s, answer_len=%d",
+                session_id, len(answer) if answer else 0,
+            )
+            try:
+                await status_msg.delete()
+            except Exception:
+                pass
+            if answer:
+                clean = _strip_markdown(answer)
+                for chunk in _split_message(clean):
+                    await update.message.reply_text(chunk)
+                logger.info("[telegram] ingest reply sent to chat_id=%s", chat_id)
+            else:
+                await update.message.reply_text(
+                    f"Staged {original_name}, but the agent didn't respond. "
+                    f"Try asking: 'ingest the file at {staged_path}'."
+                )
+        except Exception as exc:
+            logger.exception(
+                "[telegram] error ingesting document from chat_id=%s", chat_id
+            )
+            try:
+                await status_msg.edit_text(f"❌ Error: {exc}")
+            except Exception:
+                await update.message.reply_text(f"❌ Error: {exc}")
 
     # Max tool calls before forcing early return with accumulated text
     _MAX_TOOLS = 30

--- a/src/seeknal/ask/gateway/server.py
+++ b/src/seeknal/ask/gateway/server.py
@@ -39,6 +39,12 @@ from seeknal.ask.gateway.tenant import (
 # Validate session IDs: alphanumeric, hyphens, underscores, max 128 chars
 _SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9_-]{1,128}$")
 
+# Upload constraints (kept here so they're easy to surface in error responses)
+_UPLOAD_MAX_BYTES = 200 * 1024 * 1024  # 200 MB
+_UPLOAD_ALLOWED_SUFFIXES = {".xlsx", ".csv", ".tsv", ".json"}
+_UPLOAD_IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".webp", ".heic", ".heif"}
+_IMAGE_MAX_BYTES = 20 * 1024 * 1024  # 20 MB
+
 session_manager = SessionManager()
 sse_broadcaster = SSEBroadcaster()
 
@@ -601,6 +607,174 @@ async def chat_ui(request: Request) -> FileResponse:
     return FileResponse(static_dir / "chat.html", media_type="text/html")
 
 
+async def upload_file(request: Request) -> JSONResponse:
+    """Accept a multipart file upload, stage it on disk, return a reference path.
+
+    The staged file is written under
+    ``{project}/target/ask_ingest/_staging/{tenant}/{uuid}/{filename}`` and
+    the returned ``path`` can be passed directly to the ``read_tabular``
+    tool. Tenant is resolved via the standard ``X-Tenant-ID`` header path
+    so uploads from different tenants stay isolated on disk.
+    """
+    import uuid as _uuid
+
+    tenant_id, err = _safe_resolve_tenant(request)
+    if err:
+        return err
+
+    project_path_raw = getattr(request.app.state, "project_path", None)
+    if not project_path_raw:
+        return JSONResponse(
+            {"error": "upload requires gateway to be started with --project"},
+            status_code=503,
+        )
+    project_path = Path(project_path_raw)
+
+    content_type = request.headers.get("content-type", "")
+    if "multipart/form-data" not in content_type.lower():
+        return JSONResponse(
+            {"error": "content-type must be multipart/form-data"},
+            status_code=400,
+        )
+
+    try:
+        form = await request.form()
+    except Exception as exc:
+        return JSONResponse({"error": f"invalid form data: {exc}"}, status_code=400)
+
+    upload = form.get("file")
+    if upload is None or not hasattr(upload, "read") or not hasattr(upload, "filename"):
+        return JSONResponse(
+            {"error": "no 'file' field in multipart form"},
+            status_code=400,
+        )
+
+    original_name = Path(upload.filename or "upload").name
+    suffix = Path(original_name).suffix.lower()
+    is_image = suffix in _UPLOAD_IMAGE_SUFFIXES
+    if suffix not in _UPLOAD_ALLOWED_SUFFIXES and not is_image:
+        return JSONResponse(
+            {
+                "error": (
+                    f"unsupported file extension '{suffix}'. "
+                    f"Allowed: "
+                    f"{', '.join(sorted(_UPLOAD_ALLOWED_SUFFIXES | _UPLOAD_IMAGE_SUFFIXES))}"
+                ),
+            },
+            status_code=400,
+        )
+
+    # Images get a tighter size cap because Gemini vision rejects very large
+    # payloads and it keeps us honest about phone-camera screenshots.
+    size_cap = _IMAGE_MAX_BYTES if is_image else _UPLOAD_MAX_BYTES
+
+    staging_dir = (
+        project_path
+        / "target"
+        / "ask_ingest"
+        / "_staging"
+        / tenant_id
+        / _uuid.uuid4().hex[:12]
+    )
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    staged_path = staging_dir / original_name
+
+    total = 0
+    try:
+        with staged_path.open("wb") as fh:
+            while True:
+                chunk = await upload.read(1024 * 1024)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > size_cap:
+                    fh.close()
+                    staged_path.unlink(missing_ok=True)
+                    cap_mb = size_cap / 1024 / 1024
+                    return JSONResponse(
+                        {"error": f"file exceeds {cap_mb:.0f} MB limit"},
+                        status_code=413,
+                    )
+                fh.write(chunk)
+    except Exception as exc:
+        staged_path.unlink(missing_ok=True)
+        return JSONResponse({"error": f"failed to stage upload: {exc}"}, status_code=500)
+    finally:
+        try:
+            await upload.close()
+        except Exception:
+            pass
+
+    return JSONResponse(
+        {
+            "path": str(staged_path),
+            "filename": original_name,
+            "size": total,
+            "kind": "image" if is_image else "tabular",
+            "next": (
+                "POST /record with {\"text\": \"ingest the image at "
+                f"{staged_path}\"}} to route into the record-entry skill."
+                if is_image
+                else "Pass the path to read_tabular / write_ingested_table via "
+                "the ask agent."
+            ),
+        }
+    )
+
+
+async def post_record(request: Request) -> JSONResponse:
+    """Accept a free-form record text (or image-path prompt) and run the agent.
+
+    Payload: {"text": "/record fitra, 1 mie ayam", "session_id": "..."}
+
+    The agent will route the request through the ``record-entry`` skill —
+    parsing the text with ``parse_record`` or reading any image path via
+    ``extract_from_image``, then asking the user until the draft is
+    complete, then writing via ``write_ingested_table``.
+    """
+    tenant_id, err = _safe_resolve_tenant(request)
+    if err:
+        return err
+
+    project_path_raw = getattr(request.app.state, "project_path", None)
+    if not project_path_raw:
+        return JSONResponse(
+            {"error": "record requires gateway started with --project"},
+            status_code=503,
+        )
+
+    try:
+        body = await request.json()
+    except Exception as exc:
+        return JSONResponse({"error": f"invalid JSON: {exc}"}, status_code=400)
+
+    text = (body.get("text") or "").strip()
+    session_id = body.get("session_id", "default")
+    if not text:
+        return JSONResponse({"error": "text is required"}, status_code=400)
+    if not _validate_session_id(session_id):
+        return JSONResponse({"error": "invalid session_id"}, status_code=400)
+
+    project_path = Path(project_path_raw)
+    prompt = (
+        "The user wants to record an event. Load the 'record-entry' skill "
+        "and walk through parse → propose_record_table → ask_user (strict) "
+        "→ write_ingested_table.\n\nUser input:\n"
+        f"{text}"
+    )
+
+    events: list = []
+    answer = ""
+    async for event in _run_agent_streaming(
+        project_path, session_id, prompt, tenant_id=tenant_id,
+    ):
+        events.append(event)
+        if event["type"] == "answer":
+            answer = event["data"]
+
+    return JSONResponse({"answer": answer, "events": events})
+
+
 async def publish_event_callback(request: Request) -> JSONResponse:
     """Receive streaming chunk from on-prem worker and publish to SSE.
 
@@ -682,6 +856,8 @@ def create_gateway_app(
     # is configured. In backend-only mode the client must use /temporal/start.
     if not backend_only:
         routes.insert(4, Route("/ask", ask_oneshot, methods=["POST"]))
+        routes.append(Route("/upload", upload_file, methods=["POST"]))
+        routes.append(Route("/record", post_record, methods=["POST"]))
         routes.append(WebSocketRoute("/ws/{session_id}", websocket_endpoint))
 
     # Mount static files if directory exists

--- a/src/seeknal/cli/gateway.py
+++ b/src/seeknal/cli/gateway.py
@@ -211,6 +211,8 @@ def gateway_start(
     typer.echo(f"  GET  /health")
     typer.echo(f"  GET  /sessions")
     typer.echo(f"  POST /ask")
+    typer.echo(f"  POST /upload")
+    typer.echo(f"  POST /record")
     typer.echo(f"  POST /temporal/start")
     typer.echo(f"  POST /internal/events/{{session_id}}/publish")
     typer.echo(f"  WS   /ws/{{session_id}}")

--- a/src/seeknal/cli/repl.py
+++ b/src/seeknal/cli/repl.py
@@ -196,6 +196,12 @@ class REPL:
         except Exception as e:
             warnings.warn(f"REPL: Failed to attach Iceberg catalogs: {e}")
 
+        # Phase 1c: Register ask-ingested parquets
+        try:
+            self._register_ask_ingest()
+        except Exception as e:
+            warnings.warn(f"REPL: Failed to register ask-ingested tables: {e}")
+
     def _register_parquets(self) -> None:
         """Phase 1: Register intermediate parquets as DuckDB views.
 
@@ -260,6 +266,30 @@ class REPL:
                 registered_names.add(view_name)
             except Exception:
                 pass  # Skip files that can't be read
+
+    def _register_ask_ingest(self) -> None:
+        """Phase 1c: Register ask-ingested parquets as DuckDB views.
+
+        Scans target/ask_ingest/ for parquet files and registers each as
+        'ingest_{stem}' view. Uses glob() (non-recursive) to deliberately
+        exclude the _staging/ subdirectory from auto-registration.
+        """
+        if not self.project_path:
+            return
+        ingest_dir = self.project_path / "target" / "ask_ingest"
+        if not ingest_dir.exists():
+            return
+        for parquet_file in ingest_dir.glob("*.parquet"):
+            view_name = f"ingest_{parquet_file.stem}"
+            safe_path = str(parquet_file.resolve()).replace("'", "''")
+            try:
+                self.conn.execute(
+                    f'CREATE OR REPLACE VIEW "{view_name}" AS '
+                    f"SELECT * FROM read_parquet('{safe_path}')"
+                )
+                self._registered_parquets += 1
+            except Exception:
+                pass
 
     def _register_consolidated_entities(self) -> None:
         """Phase 1b: Register consolidated entity parquets as DuckDB views.

--- a/tests/ask/test_check_drift.py
+++ b/tests/ask/test_check_drift.py
@@ -1,0 +1,93 @@
+"""Tests for check_ingestion_drift tool."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import duckdb
+import pytest
+
+from seeknal.ask.agents.tools._context import ToolContext, set_tool_context
+from seeknal.ask.agents.tools.check_ingestion_drift import check_ingestion_drift
+from seeknal.ask.agents.tools.write_ingested_table import write_ingested_table
+
+
+class _REPLStub:
+    def __init__(self) -> None:
+        self.conn = duckdb.connect(":memory:")
+
+
+@pytest.fixture
+def ctx(tmp_path: Path) -> ToolContext:
+    context = ToolContext(
+        repl=_REPLStub(),
+        artifact_discovery=MagicMock(),
+        project_path=tmp_path,
+    )
+    set_tool_context(context)
+    return context
+
+
+def _csv(path: Path, header: str, rows: list[str]) -> None:
+    path.write_text(header + "\n" + "\n".join(rows) + "\n", encoding="utf-8")
+
+
+def _seed_existing(tmp_path: Path) -> None:
+    src = tmp_path / "jan.csv"
+    _csv(src, "invoice_id,date,amount",
+         ["1,2025-01-01,100", "2,2025-01-02,200", "3,2025-01-03,300"])
+    write_ingested_table(str(src), "acme_sales", "invoice_id", mode="create")
+
+
+def test_no_existing_table_returns_friendly_message(tmp_path, ctx):
+    src = tmp_path / "feb.csv"
+    _csv(src, "invoice_id,date,amount", ["1,2025-02-01,10"])
+    out = check_ingestion_drift(str(src), "acme_sales", "invoice_id")
+    assert "No existing table" in out
+    assert "first ingestion" in out
+
+
+def test_duplicate_count(tmp_path, ctx):
+    _seed_existing(tmp_path)
+    feb = tmp_path / "feb.csv"
+    _csv(feb, "invoice_id,date,amount",
+         ["2,2025-01-02,200", "3,2025-01-03,300", "4,2025-02-01,400"])
+    out = check_ingestion_drift(str(feb), "acme_sales", "invoice_id")
+    assert "Duplicate business-key rows: **2" in out
+
+
+def test_no_drift_message(tmp_path, ctx):
+    _seed_existing(tmp_path)
+    feb = tmp_path / "feb.csv"
+    _csv(feb, "invoice_id,date,amount", ["4,2025-02-01,400", "5,2025-02-02,500"])
+    out = check_ingestion_drift(str(feb), "acme_sales", "invoice_id")
+    assert "Schema match" in out
+    assert "Duplicate business-key rows: **0" in out
+
+
+def test_schema_drift_missing_and_extra(tmp_path, ctx):
+    _seed_existing(tmp_path)
+    feb = tmp_path / "feb.csv"
+    # Replaces `date` with `event_time`, adds `region`
+    _csv(
+        feb,
+        "invoice_id,event_time,amount,region",
+        ["4,2025-02-01T00:00:00,400,APAC"],
+    )
+    out = check_ingestion_drift(str(feb), "acme_sales", "invoice_id")
+    assert "Missing from new file" in out
+    assert "`date`" in out
+    assert "New columns not in existing table" in out
+    assert "`event_time`" in out or "`region`" in out
+
+
+def test_invalid_table_name_rejected(ctx):
+    out = check_ingestion_drift("/tmp/whatever.csv", "bad;name", "invoice_id")
+    assert out.startswith("Error:")
+
+
+def test_missing_source_rejected(tmp_path, ctx):
+    _seed_existing(tmp_path)
+    out = check_ingestion_drift(str(tmp_path / "nope.csv"), "acme_sales", "invoice_id")
+    assert out.startswith("Error:")

--- a/tests/ask/test_extract_from_image.py
+++ b/tests/ask/test_extract_from_image.py
@@ -1,0 +1,131 @@
+"""Tests for extract_from_image (Gemini vision OCR) with a mocked model."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import duckdb
+import pytest
+
+from seeknal.ask.agents.tools._context import ToolContext, set_tool_context
+from seeknal.ask.agents.tools.extract_from_image import extract_from_image
+
+
+class _REPLStub:
+    def __init__(self) -> None:
+        self.conn = duckdb.connect(":memory:")
+
+
+@pytest.fixture
+def ctx(tmp_path: Path) -> ToolContext:
+    context = ToolContext(
+        repl=_REPLStub(),
+        artifact_discovery=MagicMock(),
+        project_path=tmp_path,
+    )
+    set_tool_context(context)
+    return context
+
+
+def _fake_image(path: Path, size: int = 2048) -> Path:
+    # Minimal valid PNG header + padding — we only care about file size and suffix.
+    header = bytes.fromhex(
+        "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489"
+    )
+    path.write_bytes(header + b"\x00" * (size - len(header)))
+    return path
+
+
+def _patch_call_gemini(payload):
+    """Context manager that patches _call_gemini to return a fixed payload."""
+    return patch(
+        "seeknal.ask.agents.tools.extract_from_image._call_gemini",
+        return_value=payload,
+    )
+
+
+def test_extract_transfer_happy_path(tmp_path, ctx):
+    img = _fake_image(tmp_path / "proof.jpg")
+    payload = {
+        "kind": "transfer",
+        "amount": 1500000,
+        "currency": "IDR",
+        "sender_name": "FITRA K",
+        "recipient_name": "BUDI S",
+        "bank": "BCA",
+        "transaction_date": "2026-04-17",
+        "reference_number": "TRX-77",
+        "note": "rent",
+        "raw_text": "BCA mobile — transfer berhasil",
+    }
+    with _patch_call_gemini(payload):
+        out = extract_from_image(str(img))
+
+    assert "Extracted draft from image" in out
+    assert "1500000" in out
+    assert "BCA" in out
+    # Source path stashed on ctx
+    assert ctx.last_read_staging_path == str(img)
+
+
+def test_extract_markdown_fence_stripped(tmp_path, ctx):
+    # _call_gemini already parses JSON; this test exercises _parse_json_output
+    # directly via the private helper to prove fence-stripping works.
+    from seeknal.ask.agents.tools.extract_from_image import _parse_json_output
+
+    fence = "```json\n" + json.dumps({"kind": "other", "amount": 123}) + "\n```"
+    parsed = _parse_json_output(fence)
+    assert parsed["amount"] == 123
+    assert parsed["kind"] == "other"
+
+
+def test_unsupported_suffix_rejected(tmp_path, ctx):
+    bad = tmp_path / "bad.pdf"
+    bad.write_bytes(b"%PDF")
+    out = extract_from_image(str(bad))
+    assert out.startswith("Error:")
+    assert "unsupported" in out.lower()
+
+
+def test_missing_file_rejected(tmp_path, ctx):
+    out = extract_from_image(str(tmp_path / "nope.jpg"))
+    assert out.startswith("Error:")
+    assert "not found" in out.lower()
+
+
+def test_oversized_image_rejected(tmp_path, ctx, monkeypatch):
+    big = _fake_image(tmp_path / "big.jpg", size=1024)
+    monkeypatch.setattr(
+        "seeknal.ask.agents.tools.extract_from_image._MAX_IMAGE_BYTES", 10
+    )
+    out = extract_from_image(str(big))
+    assert out.startswith("Error:")
+    assert "exceeds" in out.lower()
+
+
+def test_non_json_response_reports_error(tmp_path, ctx):
+    img = _fake_image(tmp_path / "proof.jpg")
+    with patch(
+        "seeknal.ask.agents.tools.extract_from_image._call_gemini",
+        side_effect=ValueError("Gemini returned non-JSON output: …"),
+    ):
+        out = extract_from_image(str(img))
+    assert out.startswith("Error:")
+    assert "non-json" in out.lower() or "could not parse" in out.lower()
+
+
+def test_missing_required_fields_flagged(tmp_path, ctx):
+    img = _fake_image(tmp_path / "proof.jpg")
+    payload = {
+        "kind": "transfer",
+        "amount": None,
+        "recipient_name": "BUDI",
+        "transaction_date": "2026-04-17",
+    }
+    with _patch_call_gemini(payload):
+        out = extract_from_image(str(img))
+    assert "Required fields not yet resolved" in out
+    assert "amount" in out.lower()

--- a/tests/ask/test_gateway_record.py
+++ b/tests/ask/test_gateway_record.py
@@ -1,0 +1,90 @@
+"""Tests for the gateway POST /record endpoint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("starlette")
+from starlette.testclient import TestClient
+
+from seeknal.ask.gateway.server import create_gateway_app
+
+
+async def _fake_stream_single_answer(*args, **kwargs):
+    # Minimal async generator that emits a single answer event — mimics the
+    # shape of _run_agent_streaming without spinning up a real agent.
+    yield {"type": "answer", "data": "Recorded one row into ingest_orders."}
+
+
+def test_post_record_happy_path(tmp_path):
+    app = create_gateway_app(project_path=tmp_path)
+    with TestClient(app) as client, patch(
+        "seeknal.ask.gateway.server._run_agent_streaming",
+        side_effect=_fake_stream_single_answer,
+    ):
+        res = client.post(
+            "/record",
+            json={"text": "/record fitra, 1 mie ayam", "session_id": "t1"},
+        )
+    assert res.status_code == 200, res.text
+    payload = res.json()
+    assert "Recorded" in payload["answer"]
+    assert any(e["type"] == "answer" for e in payload["events"])
+
+
+def test_post_record_rejects_missing_text(tmp_path):
+    app = create_gateway_app(project_path=tmp_path)
+    with TestClient(app) as client:
+        res = client.post("/record", json={"session_id": "t1"})
+    assert res.status_code == 400
+    assert "text" in res.json()["error"]
+
+
+def test_post_record_rejects_bad_session_id(tmp_path):
+    app = create_gateway_app(project_path=tmp_path)
+    with TestClient(app) as client:
+        res = client.post(
+            "/record",
+            json={"text": "/record x", "session_id": "has spaces!!"},
+        )
+    assert res.status_code == 400
+
+
+def test_post_record_backend_only_returns_404(tmp_path):
+    # Backend-only mode does not register /record
+    app = create_gateway_app(project_path=None, sessions_dir=tmp_path)
+    with TestClient(app) as client:
+        res = client.post("/record", json={"text": "x"})
+    assert res.status_code in (404, 405)
+
+
+def test_upload_image_returns_kind_image(tmp_path):
+    app = create_gateway_app(project_path=tmp_path)
+    body = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+    with TestClient(app) as client:
+        res = client.post(
+            "/upload",
+            files={"file": ("proof.png", body, "image/png")},
+        )
+    assert res.status_code == 200, res.text
+    payload = res.json()
+    assert payload["kind"] == "image"
+    assert payload["filename"] == "proof.png"
+    assert "POST /record" in payload["next"]
+    assert Path(payload["path"]).exists()
+
+
+def test_upload_image_over_limit_rejected(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "seeknal.ask.gateway.server._IMAGE_MAX_BYTES", 32
+    )
+    app = create_gateway_app(project_path=tmp_path)
+    with TestClient(app) as client:
+        res = client.post(
+            "/upload",
+            files={"file": ("huge.jpg", b"x" * 1024, "image/jpeg")},
+        )
+    assert res.status_code == 413

--- a/tests/ask/test_gateway_upload.py
+++ b/tests/ask/test_gateway_upload.py
@@ -1,0 +1,72 @@
+"""Tests for the gateway POST /upload endpoint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("starlette")
+
+from starlette.testclient import TestClient
+
+from seeknal.ask.gateway.server import create_gateway_app
+
+
+def _app(project_path: Path):
+    return create_gateway_app(project_path=project_path)
+
+
+def test_upload_multipart_roundtrip(tmp_path):
+    app = _app(tmp_path)
+    with TestClient(app) as client:
+        body = b"invoice_id,date,amount\n1,2025-01-01,100\n"
+        res = client.post(
+            "/upload",
+            files={"file": ("jan.csv", body, "text/csv")},
+        )
+    assert res.status_code == 200, res.text
+    payload = res.json()
+    assert payload["filename"] == "jan.csv"
+    assert payload["size"] == len(body)
+
+    staged = Path(payload["path"])
+    assert staged.exists()
+    assert staged.read_bytes() == body
+    assert staged.is_relative_to(tmp_path / "target" / "ask_ingest" / "_staging")
+
+
+def test_upload_rejects_unsupported_extension(tmp_path):
+    app = _app(tmp_path)
+    with TestClient(app) as client:
+        res = client.post(
+            "/upload",
+            files={"file": ("evil.exe", b"MZ", "application/octet-stream")},
+        )
+    assert res.status_code == 400
+    assert "unsupported" in res.json()["error"].lower()
+
+
+def test_upload_size_limit(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "seeknal.ask.gateway.server._UPLOAD_MAX_BYTES", 16
+    )
+    app = _app(tmp_path)
+    with TestClient(app) as client:
+        res = client.post(
+            "/upload",
+            files={"file": ("big.csv", b"x" * 1024, "text/csv")},
+        )
+    assert res.status_code == 413
+    assert "200 MB" in res.json()["error"] or "limit" in res.json()["error"]
+
+
+def test_upload_rejects_when_backend_only(tmp_path):
+    app = create_gateway_app(project_path=None, sessions_dir=tmp_path)
+    with TestClient(app) as client:
+        res = client.post(
+            "/upload",
+            files={"file": ("jan.csv", b"a,b\n1,2\n", "text/csv")},
+        )
+    # backend-only mode does not register /upload; Starlette returns 404
+    assert res.status_code in (404, 405)

--- a/tests/ask/test_ingest_e2e.py
+++ b/tests/ask/test_ingest_e2e.py
@@ -1,0 +1,280 @@
+"""End-to-end ship-blocker tests for the data-ingest workflow.
+
+These exercise the full SKILL.md phase sequence through the 4 new tools
+plus the REPL auto-registration path. Exercising the live LLM agent here
+would be non-deterministic and expensive; instead each test drives the
+tools directly in the order the SKILL.md prose mandates, which is the
+same control flow the agent follows when the skill is loaded.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import duckdb
+import pytest
+
+from seeknal.ask.agents.tools._context import ToolContext, set_tool_context
+from seeknal.ask.agents.tools.check_ingestion_drift import check_ingestion_drift
+from seeknal.ask.agents.tools.read_tabular import read_tabular
+from seeknal.ask.agents.tools.save_ingestion_skill import save_ingestion_skill
+from seeknal.ask.agents.tools.write_ingested_table import write_ingested_table
+from seeknal.cli.repl import REPL
+
+
+class _REPLStub:
+    """Minimal REPL-like object used by the tools during a 'session'."""
+
+    def __init__(self) -> None:
+        self.conn = duckdb.connect(":memory:")
+
+    def execute_oneshot(self, sql: str, limit=None):
+        res = self.conn.execute(sql)
+        cols = [d[0] for d in res.description] if res.description else []
+        return cols, res.fetchall()
+
+
+def _fresh_ctx(project_path: Path) -> ToolContext:
+    ctx = ToolContext(
+        repl=_REPLStub(),
+        artifact_discovery=MagicMock(),
+        project_path=project_path,
+    )
+    set_tool_context(ctx)
+    return ctx
+
+
+@pytest.fixture
+def jan_xlsx(tmp_path: Path) -> Path:
+    pytest.importorskip("openpyxl")
+    import pandas as pd
+
+    path = tmp_path / "raw" / "acme_sales_jan.xlsx"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame(
+        {
+            "invoice_id": [1, 2, 3, 4, 5],
+            "date": ["2025-01-01", "2025-01-02", "2025-01-03", "2025-01-04", "2025-01-05"],
+            "amount": [100, 150, 200, 250, 300],
+            "month": ["January"] * 5,
+        }
+    )
+    df.to_excel(path, index=False, engine="openpyxl")
+    return path
+
+
+@pytest.fixture
+def feb_xlsx(tmp_path: Path) -> Path:
+    pytest.importorskip("openpyxl")
+    import pandas as pd
+
+    path = tmp_path / "raw" / "acme_sales_feb.xlsx"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame(
+        {
+            "invoice_id": [6, 7, 8],
+            "date": ["2025-02-01", "2025-02-02", "2025-02-03"],
+            "amount": [120, 180, 240],
+            "month": ["February"] * 3,
+        }
+    )
+    df.to_excel(path, index=False, engine="openpyxl")
+    return path
+
+
+@pytest.fixture
+def feb_with_overlap_xlsx(tmp_path: Path) -> Path:
+    pytest.importorskip("openpyxl")
+    import pandas as pd
+
+    path = tmp_path / "raw" / "acme_sales_feb_overlap.xlsx"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame(
+        {
+            # invoice_id=5 duplicates the Jan run
+            "invoice_id": [5, 6, 7],
+            "date": ["2025-01-05", "2025-02-02", "2025-02-03"],
+            "amount": [999, 180, 240],  # 999 is the tweaked duplicate value
+            "month": ["February", "February", "February"],
+        }
+    )
+    df.to_excel(path, index=False, engine="openpyxl")
+    return path
+
+
+def _count(parquet: Path) -> int:
+    con = duckdb.connect(":memory:")
+    try:
+        (n,) = con.execute(f"SELECT COUNT(*) FROM read_parquet('{parquet}')").fetchone()
+        return int(n)
+    finally:
+        con.close()
+
+
+def test_two_session_replay(tmp_path, jan_xlsx, feb_xlsx):
+    """AC-1: Ingest Jan in Session A, save skill, ingest Feb in a fresh Session B."""
+    project = tmp_path / "project"
+    project.mkdir()
+
+    # --- Session A ---
+    _fresh_ctx(project)
+    read_tabular(str(jan_xlsx))
+    write_ingested_table(
+        source_path="",  # resolves from ctx.last_read_staging_path
+        table_name="acme_sales",
+        business_key="invoice_id",
+        mode="create",
+    )
+    save_ingestion_skill(
+        skill_name="ingest-acme-sales",
+        table_name="acme_sales",
+        business_key="invoice_id",
+        columns_json=json.dumps(
+            [
+                {"name": "invoice_id", "type": "BIGINT"},
+                {"name": "date", "type": "VARCHAR"},
+                {"name": "amount", "type": "BIGINT"},
+                {"name": "month", "type": "VARCHAR"},
+            ]
+        ),
+        description="Monthly ACME sales upload",
+    )
+
+    parquet = project / "target/ask_ingest/acme_sales.parquet"
+    prov = project / "target/ask_ingest/acme_sales_provenance.json"
+    skill = project / "seeknal/skills/ingest-acme-sales/SKILL.md"
+
+    assert parquet.exists()
+    assert prov.exists()
+    assert skill.exists()
+
+    skill_md = skill.read_text()
+    assert 'business_key: ["invoice_id"]' in skill_md
+    assert _count(parquet) == 5
+
+    # --- Session B: fresh REPL should auto-register ingest_acme_sales ---
+    repl = REPL(project_path=project, skip_history=True)
+    view_rows = repl.conn.execute(
+        "SELECT table_name FROM information_schema.tables "
+        "WHERE table_catalog='memory' AND table_schema='main'"
+    ).fetchall()
+    assert "ingest_acme_sales" in {r[0] for r in view_rows}
+
+    # Replace tool context with one pointing at the fresh REPL (new session).
+    _fresh_ctx(project)
+    # Copy the view-registered conn state by keeping the live REPL's connection
+    # for downstream tool calls.
+    ctx_b = ToolContext(repl=repl, artifact_discovery=MagicMock(), project_path=project)
+    set_tool_context(ctx_b)
+
+    read_tabular(str(feb_xlsx))
+    confirmed = write_ingested_table(
+        source_path="",
+        table_name="acme_sales",
+        business_key="invoice_id",
+        mode="append",
+        user_confirmed=True,
+        dedup_strategy="skip",
+    )
+    assert "Appended" in confirmed
+
+    assert _count(parquet) == 5 + 3  # no overlap
+
+    updated_prov = json.loads(prov.read_text())
+    assert updated_prov["rows_before"] == 5
+    assert updated_prov["rows_after"] == 8
+    assert updated_prov["rows_inserted"] == 3
+    assert updated_prov["rows_deduped"] == 0
+
+
+def test_single_session_analytics(tmp_path, jan_xlsx):
+    """AC-2: Ingest + analytical SQL in the same session via execute_sql path."""
+    project = tmp_path / "project"
+    project.mkdir()
+    ctx = _fresh_ctx(project)
+
+    read_tabular(str(jan_xlsx))
+    write_ingested_table(
+        source_path="",
+        table_name="acme_sales",
+        business_key="invoice_id",
+        mode="create",
+    )
+
+    # Query the registered view directly via the REPL connection — same
+    # connection execute_sql would use.
+    (total,) = ctx.repl.conn.execute(
+        "SELECT CAST(SUM(amount) AS DOUBLE) "
+        "FROM ingest_acme_sales WHERE month = 'January'"
+    ).fetchone()
+    assert total == 100 + 150 + 200 + 250 + 300
+
+
+def test_critical_agent_dedup(tmp_path, jan_xlsx, feb_with_overlap_xlsx):
+    """AC-3: Dry-run drift + dedup count surfaced before any append write."""
+    project = tmp_path / "project"
+    project.mkdir()
+
+    # Session A: create
+    _fresh_ctx(project)
+    read_tabular(str(jan_xlsx))
+    write_ingested_table(
+        source_path="",
+        table_name="acme_sales",
+        business_key="invoice_id",
+        mode="create",
+    )
+    parquet = project / "target/ask_ingest/acme_sales.parquet"
+    rows_before = _count(parquet)
+
+    # Session B: ingest overlap file
+    _fresh_ctx(project)
+    read_tabular(str(feb_with_overlap_xlsx))
+
+    # Phase 2b: drift check (agent-visible summary)
+    drift_report = check_ingestion_drift(
+        source_path="",
+        table_name="acme_sales",
+        business_key="invoice_id",
+    )
+    assert "Duplicate business-key rows: **1" in drift_report
+    assert "skip" in drift_report.lower() and "replace" in drift_report.lower()
+
+    # Phase 2b: self-defending drift-mode append (user_confirmed=False) → must
+    # NOT write and must surface the duplicate count.
+    dry = write_ingested_table(
+        source_path="",
+        table_name="acme_sales",
+        business_key="invoice_id",
+        mode="append",
+        user_confirmed=False,
+    )
+    assert "No data was written" in dry
+    assert "Duplicate business-key rows: **1" in dry
+    assert _count(parquet) == rows_before  # parquet unchanged by the dry run
+
+    # User chose "Skip duplicates" → confirmed append with skip
+    confirmed = write_ingested_table(
+        source_path="",
+        table_name="acme_sales",
+        business_key="invoice_id",
+        mode="append",
+        user_confirmed=True,
+        dedup_strategy="skip",
+    )
+    assert "Rows deduped: 1" in confirmed
+
+    # rows_before=5, new file=3, 1 dup → final=7
+    assert _count(parquet) == rows_before + 3 - 1
+
+    # The duplicate invoice_id=5 should keep its existing amount (300), not 999.
+    con = duckdb.connect(":memory:")
+    try:
+        row = con.execute(
+            f"SELECT amount FROM read_parquet('{parquet}') WHERE invoice_id = 5"
+        ).fetchone()
+    finally:
+        con.close()
+    assert row[0] == 300

--- a/tests/ask/test_parse_record.py
+++ b/tests/ask/test_parse_record.py
@@ -1,0 +1,121 @@
+"""Tests for parse_record."""
+
+from __future__ import annotations
+
+import json
+import re
+
+from seeknal.ask.agents.tools.parse_record import parse_record
+
+
+def _payload(markdown: str) -> dict:
+    match = re.search(r"```json\n(.+?)\n```", markdown, flags=re.DOTALL)
+    assert match, f"no JSON block in output:\n{markdown}"
+    return json.loads(match.group(1))
+
+
+def test_person_plus_items():
+    out = parse_record("/record fitra, 1 mie ayam, 1 mineral water")
+    draft = _payload(out)
+    assert draft["person"] == "fitra"
+    assert draft["items"] == [
+        {"quantity": 1, "name": "mie ayam"},
+        {"quantity": 1, "name": "mineral water"},
+    ]
+    assert draft["amount"] is None
+    # No "required fields" language — parse_record reports hints only.
+    assert "Detected hints" in out
+    assert "kind_hint" in out
+
+
+def test_amount_with_thousands_separator():
+    out = parse_record("/record transfer ke budi Rp 1.500.000 via BCA")
+    draft = _payload(out)
+    assert draft["amount"] == 1_500_000
+    assert draft["bank"] == "BCA"
+
+
+def test_amount_shorthand_rb():
+    out = parse_record("/record 2 nasi goreng, 1 es teh, total 45rb")
+    draft = _payload(out)
+    assert draft["amount"] == 45_000
+    assert draft["items"] == [
+        {"quantity": 2, "name": "nasi goreng"},
+        {"quantity": 1, "name": "es teh"},
+    ]
+
+
+def test_amount_shorthand_juta():
+    out = parse_record("/record saham, 1.5jt, broker XYZ")
+    draft = _payload(out)
+    assert draft["amount"] == 1_500_000
+
+
+def test_ewallet_detected():
+    out = parse_record("record: 3 kopi, 75rb, dana")
+    draft = _payload(out)
+    assert draft["bank"] == "DANA"
+    assert draft["amount"] == 75_000
+
+
+def test_meeting_kind_hint():
+    out = parse_record("/record meeting budi pagi")
+    draft = _payload(out)
+    assert draft["kind_hint"] == "meeting"
+    # No "required" language — the agent decides what's required for a meeting.
+    assert "Required fields" not in out
+
+
+def test_transfer_kind_hint_with_qris():
+    out = parse_record("/record transfer 500000 qris")
+    draft = _payload(out)
+    assert draft["amount"] == 500_000
+    assert draft["bank"] == "QRIS"
+    assert draft["kind_hint"] == "transfer"
+
+
+def test_activity_kind_hint():
+    out = parse_record("/record workout, 30 min running, 10 pushups")
+    draft = _payload(out)
+    assert draft["kind_hint"] == "activity"
+    assert draft["amount"] is None  # amount is not required for activities
+
+
+def test_health_kind_hint():
+    out = parse_record("/record weight 72.5 kg, bp 120/80")
+    draft = _payload(out)
+    assert draft["kind_hint"] == "health"
+
+
+def test_note_kind_hint_for_freeform():
+    out = parse_record("/record just a random thought")
+    draft = _payload(out)
+    assert draft["kind_hint"] == "note"
+
+
+def test_strips_prefix_variants():
+    for prefix in ("/record ", "record: ", "/r "):
+        out = parse_record(f"{prefix}budi, 10000")
+        draft = _payload(out)
+        assert draft["person"] == "budi"
+        assert draft["amount"] == 10_000
+
+
+def test_empty_input():
+    out = parse_record("")
+    assert json.loads(out) == {"error": "empty record"}
+
+
+def test_qty_above_99_is_treated_as_amount():
+    # "2500 mineral" is weird — lean toward item with qty; but "2500, mineral"
+    # hits separate tokens and 2500 becomes the amount.
+    out = parse_record("/record 2500, mineral water")
+    draft = _payload(out)
+    assert draft["amount"] == 2500
+
+
+def test_raw_text_preserved():
+    msg = "/record fitra, 1 mie ayam"
+    out = parse_record(msg)
+    draft = _payload(out)
+    assert draft["raw_text"] == "fitra, 1 mie ayam"

--- a/tests/ask/test_propose_record_table.py
+++ b/tests/ask/test_propose_record_table.py
@@ -1,0 +1,177 @@
+"""Tests for propose_record_table."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import duckdb
+import pytest
+
+from seeknal.ask.agents.tools._context import ToolContext, set_tool_context
+from seeknal.ask.agents.tools.propose_record_table import propose_record_table
+
+
+class _REPLStub:
+    def __init__(self) -> None:
+        self.conn = duckdb.connect(":memory:")
+
+
+@pytest.fixture
+def ctx(tmp_path: Path) -> ToolContext:
+    context = ToolContext(
+        repl=_REPLStub(),
+        artifact_discovery=MagicMock(),
+        project_path=tmp_path,
+    )
+    set_tool_context(context)
+    return context
+
+
+def _seed_view(ctx: ToolContext, view_name: str, schema_sql: str) -> None:
+    ctx.repl.conn.execute(f"CREATE TABLE {view_name}_t AS {schema_sql}")
+    ctx.repl.conn.execute(f'CREATE OR REPLACE VIEW "{view_name}" AS SELECT * FROM {view_name}_t')
+
+
+def test_no_existing_tables_proposes_new_orders(ctx):
+    draft = json.dumps(
+        {"person": "fitra", "items": [{"quantity": 1, "name": "mie ayam"}],
+         "amount": 20000, "currency": "IDR"}
+    )
+    out = propose_record_table(draft)
+    assert "New: create `ingest_orders`" in out
+    assert "entered_at,merchant" in out or "entered_at,person" in out
+    # Schema table present
+    assert "`amount` | BIGINT" in out
+
+
+def test_no_existing_tables_proposes_new_transfers(ctx):
+    draft = json.dumps(
+        {"kind": "transfer", "amount": 1500000, "recipient_name": "Budi",
+         "bank": "BCA", "reference_number": "TRX-42"}
+    )
+    out = propose_record_table(draft)
+    assert "New: create `ingest_transfers`" in out
+    assert "reference_number" in out
+
+
+def test_existing_table_match_scores_high(ctx):
+    # Seed an existing orders table whose schema covers the draft fields
+    _seed_view(
+        ctx,
+        "ingest_orders",
+        "SELECT CAST(NULL AS TIMESTAMP) AS entered_at, "
+        "CAST(NULL AS VARCHAR) AS person, CAST(NULL AS BIGINT) AS amount, "
+        "CAST(NULL AS VARCHAR) AS currency, CAST(NULL AS VARCHAR) AS bank, "
+        "CAST(NULL AS JSON) AS items, CAST(NULL AS VARCHAR) AS note, "
+        "CAST(NULL AS VARCHAR) AS raw_text WHERE false",
+    )
+    draft = json.dumps(
+        {"person": "fitra", "items": [{"quantity": 1, "name": "mie ayam"}],
+         "amount": 20000, "currency": "IDR", "bank": None}
+    )
+    out = propose_record_table(draft)
+    assert "Match: append to `ingest_orders`" in out
+    assert "mode='append'" in out
+    assert "user_confirmed=False" in out
+
+
+def test_hint_table_name_overrides_default(ctx):
+    draft = json.dumps({"person": "fitra", "amount": 20000})
+    out = propose_record_table(draft, hint_table_name="daily_expenses")
+    assert "ingest_daily_expenses" in out
+
+
+def test_hint_rejected_if_invalid(ctx):
+    # "123-bad;name" sanitizes to "123_bad_name" which fails the
+    # [a-zA-Z_][a-zA-Z0-9_]* SQL-identifier guard, so the proposer falls back
+    # to a kind-derived slug. Draft has no item/transfer markers so kind="other".
+    draft = json.dumps({"person": "fitra", "amount": 20000})
+    out = propose_record_table(draft, hint_table_name="123-bad;name")
+    assert "ingest_records" in out  # "other" kind default
+    assert "123" not in out  # invalid hint must not leak into the slug
+
+
+def test_invalid_draft_json_rejected(ctx):
+    out = propose_record_table("not-json")
+    assert out.startswith("Error:")
+
+
+def test_empty_draft_rejected(ctx):
+    out = propose_record_table("")
+    assert out.startswith("Error:")
+
+
+def test_activity_kind_template(ctx):
+    draft = json.dumps({"kind": "activity", "activity": "workout",
+                        "exercises": [{"name": "running", "duration_min": 30}]})
+    out = propose_record_table(draft)
+    assert "`ingest_records" in out or "`activity`" in out.lower()
+    # Activity template uses duration_min and exercises
+    assert "exercises" in out
+    assert "duration_min" in out
+    # Business key does not require amount
+    assert "entered_at,person" in out
+
+
+def test_meeting_kind_template(ctx):
+    draft = json.dumps({"kind": "meeting", "attendees": ["budi"],
+                        "summary": "Q2 plan"})
+    out = propose_record_table(draft)
+    assert "attendees" in out
+    assert "action_items" in out
+    assert "entered_at,title" in out
+
+
+def test_health_kind_template(ctx):
+    draft = json.dumps({"kind": "health",
+                        "metrics": {"weight_kg": 72.5, "bp": "120/80"}})
+    out = propose_record_table(draft)
+    assert "`metrics` | JSON" in out
+
+
+def test_columns_override_wins(ctx):
+    draft = json.dumps({
+        "kind": "custom",
+        "_columns": [
+            {"name": "sku", "type": "VARCHAR"},
+            {"name": "on_hand", "type": "INTEGER"},
+            {"name": "counted_by", "type": "VARCHAR"},
+        ],
+        "sku": "ABC",
+        "on_hand": 12,
+        "counted_by": "fitra",
+    })
+    out = propose_record_table(draft, hint_table_name="inventory_check")
+    assert "`sku` | VARCHAR" in out
+    assert "`on_hand` | INTEGER" in out
+    assert "`counted_by` | VARCHAR" in out
+    # Audit columns auto-added
+    assert "`entered_at` | TIMESTAMP" in out
+    assert "`raw_text` | VARCHAR" in out
+    assert "ingest_inventory_check" in out
+
+
+def test_kind_hint_respected_when_no_explicit_kind(ctx):
+    # parse_record would set kind_hint="activity"; propose_record_table honors it
+    draft = json.dumps({"kind_hint": "activity", "note": "morning run"})
+    out = propose_record_table(draft)
+    assert "exercises" in out
+
+
+def test_collision_avoided_when_default_slug_exists(ctx):
+    # Seed a totally unrelated view also named ingest_orders, so the proposer
+    # wants kind-default "orders" but must dodge the collision.
+    _seed_view(
+        ctx,
+        "ingest_orders",
+        "SELECT CAST(NULL AS VARCHAR) AS unrelated WHERE false",
+    )
+    # Draft shaped like an order (has items) so kind="order" -> base slug "orders".
+    draft = json.dumps(
+        {"items": [{"quantity": 1, "name": "mie ayam"}], "amount": 20000}
+    )
+    out = propose_record_table(draft)
+    # Either a _2 suffix OR a match decision — we only require no collision.
+    assert "ingest_orders_2" in out or "Match: append to `ingest_orders`" in out

--- a/tests/ask/test_read_tabular.py
+++ b/tests/ask/test_read_tabular.py
@@ -1,0 +1,223 @@
+"""Tests for read_tabular tool."""
+
+from __future__ import annotations
+
+import http.server
+import json
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import duckdb
+import pytest
+
+from seeknal.ask.agents.tools._context import ToolContext, set_tool_context
+from seeknal.ask.agents.tools.read_tabular import read_tabular
+
+
+class _REPLStub:
+    def __init__(self) -> None:
+        self.conn = duckdb.connect(":memory:")
+
+
+@pytest.fixture
+def ctx(tmp_path: Path) -> ToolContext:
+    context = ToolContext(
+        repl=_REPLStub(),
+        artifact_discovery=MagicMock(),
+        project_path=tmp_path,
+    )
+    set_tool_context(context)
+    return context
+
+
+def _write_csv(path: Path) -> int:
+    path.write_text(
+        "invoice_id,date,amount\n1,2025-01-01,100\n2,2025-01-02,200\n",
+        encoding="utf-8",
+    )
+    return 2
+
+
+def _write_tsv(path: Path) -> int:
+    path.write_text(
+        "a\tb\tc\n1\t2\t3\n4\t5\t6\n",
+        encoding="utf-8",
+    )
+    return 2
+
+
+def _write_json(path: Path) -> int:
+    rows = [{"id": 1, "v": "a"}, {"id": 2, "v": "b"}, {"id": 3, "v": "c"}]
+    path.write_text(json.dumps(rows), encoding="utf-8")
+    return len(rows)
+
+
+def test_csv_parse(tmp_path, ctx):
+    csv = tmp_path / "sales.csv"
+    _write_csv(csv)
+
+    result = read_tabular(str(csv))
+    assert "## Preview: sales.csv" in result
+    assert "**Rows:** 2" in result
+    assert "invoice_id" in result
+    assert ctx.last_read_staging_path == str(csv.resolve())
+
+
+def test_tsv_parse(tmp_path, ctx):
+    tsv = tmp_path / "sample.tsv"
+    _write_tsv(tsv)
+
+    result = read_tabular(str(tsv))
+    assert "**Rows:** 2" in result
+    assert "## Preview: sample.tsv" in result
+
+
+def test_json_parse(tmp_path, ctx):
+    j = tmp_path / "items.json"
+    _write_json(j)
+
+    result = read_tabular(str(j))
+    assert "## Preview: items.json" in result
+    assert "**Rows:** 3" in result
+
+
+def test_xlsx_parse(tmp_path, ctx):
+    openpyxl = pytest.importorskip("openpyxl")
+    import pandas as pd
+
+    xlsx = tmp_path / "monthly.xlsx"
+    df = pd.DataFrame({"id": [1, 2, 3], "amount": [10.0, 20.0, 30.0]})
+    df.to_excel(xlsx, index=False, engine="openpyxl")
+
+    result = read_tabular(str(xlsx))
+    assert "## Preview: monthly.xlsx" in result
+    assert "**Rows:** 3" in result
+    # xlsx is converted to a staging parquet, so parsed path differs
+    assert "Parsed as parquet at:" in result
+
+
+def test_unsupported_format(tmp_path, ctx):
+    pdf = tmp_path / "bad.pdf"
+    pdf.write_bytes(b"%PDF-1.4 not really a pdf")
+    out = read_tabular(str(pdf))
+    assert out.startswith("Error:")
+    assert ".pdf" in out
+
+
+def test_file_not_found(tmp_path, ctx):
+    out = read_tabular(str(tmp_path / "missing.csv"))
+    assert out.startswith("Error:")
+    assert "not found" in out
+
+
+def test_file_size_limit(tmp_path, ctx, monkeypatch):
+    csv = tmp_path / "big.csv"
+    csv.write_text("a,b\n1,2\n", encoding="utf-8")
+
+    # Pretend the file is huge
+    monkeypatch.setattr(
+        "seeknal.ask.agents.tools.read_tabular._MAX_FILE_BYTES", 1
+    )
+    out = read_tabular(str(csv))
+    assert out.startswith("Error:")
+    assert "200 MB" in out
+
+
+def test_url_rejects_private_ip(tmp_path, ctx):
+    # 127.0.0.1 is loopback and must be rejected by the SSRF guard.
+    out = read_tabular("http://127.0.0.1:1/file.csv")
+    assert out.startswith("Error:")
+    assert "non-public" in out or "refusing" in out
+
+
+def test_url_rejects_link_local_metadata(tmp_path, ctx):
+    # AWS/GCP IMDS endpoint — must be refused.
+    out = read_tabular("http://169.254.169.254/latest/meta-data/")
+    assert out.startswith("Error:")
+    assert "non-public" in out or "refusing" in out
+
+
+def test_url_download(tmp_path, ctx):
+    body = b"invoice_id,date,amount\n10,2025-01-01,99\n11,2025-01-02,100\n"
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            self.send_response(200)
+            self.send_header("Content-Type", "text/csv")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args, **kwargs):
+            return
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    # Patch the SSRF guard to allow 127.0.0.1 just for this test. The guard's
+    # production-time purpose is to block metadata / internal services; we
+    # exercise the full download path over loopback.
+    import seeknal.ask.agents.tools.read_tabular as mod
+    real_reject = mod._reject_if_private
+    mod._reject_if_private = lambda host: None
+    try:
+        url = f"http://127.0.0.1:{port}/download.csv"
+        result = read_tabular(url)
+        assert "**Rows:** 2" in result
+        # staging path should exist under target/ask_ingest/_staging/
+        assert "target/ask_ingest/_staging" in ctx.last_read_staging_path
+    finally:
+        mod._reject_if_private = real_reject
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+def test_content_disposition_path_traversal_blocked(tmp_path, ctx, monkeypatch):
+    """A malicious server returning filename="../../.env" must not escape staging."""
+    body = b"invoice_id,date,amount\n10,2025-01-01,99\n"
+
+    class _EvilHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            self.send_response(200)
+            self.send_header("Content-Type", "text/csv")
+            # Attacker-controlled filename with traversal
+            self.send_header(
+                "Content-Disposition",
+                'attachment; filename="../../../../etc/passwd.csv"',
+            )
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args, **kwargs):
+            return
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _EvilHandler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    import seeknal.ask.agents.tools.read_tabular as mod
+    monkeypatch.setattr(mod, "_reject_if_private", lambda host: None)
+    try:
+        url = f"http://127.0.0.1:{port}/download.csv"
+        result = read_tabular(url)
+        # Either way the request must succeed — but the staged file must live
+        # under the UUID staging dir, never at ../../etc/passwd.csv on disk.
+        assert "**Rows:** 1" in result
+        staged = Path(ctx.last_read_staging_path)
+        # The staged path must be inside the project tree
+        assert staged.is_relative_to(tmp_path / "target" / "ask_ingest" / "_staging"), (
+            f"traversal escaped containment: {staged}"
+        )
+        # The dangerous absolute path must not have been created
+        assert not Path("/etc/passwd.csv").exists() or (
+            Path("/etc/passwd.csv").exists()
+            and Path("/etc/passwd.csv").stat().st_size != len(body)
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)

--- a/tests/ask/test_repl_ingest.py
+++ b/tests/ask/test_repl_ingest.py
@@ -1,0 +1,70 @@
+"""Tests for REPL auto-registration of target/ask_ingest/*.parquet."""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from seeknal.cli.repl import REPL
+
+
+def _write_parquet(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = duckdb.connect(":memory:")
+    try:
+        con.execute(
+            f"COPY (SELECT 1 AS id, 'a' AS name UNION ALL SELECT 2, 'b') "
+            f"TO '{path}' (FORMAT PARQUET)"
+        )
+    finally:
+        con.close()
+
+
+def _views(repl: REPL) -> set[str]:
+    rows = repl.conn.execute(
+        "SELECT table_name FROM information_schema.tables "
+        "WHERE table_catalog='memory' AND table_schema='main' AND table_type='VIEW'"
+    ).fetchall()
+    return {r[0] for r in rows}
+
+
+def test_auto_register_ask_ingest(tmp_path):
+    _write_parquet(tmp_path / "target" / "ask_ingest" / "acme_sales.parquet")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        repl = REPL(project_path=tmp_path, skip_history=True)
+
+    assert "ingest_acme_sales" in _views(repl)
+    (n,) = repl.conn.execute(
+        'SELECT COUNT(*) FROM "ingest_acme_sales"'
+    ).fetchone()
+    assert n == 2
+
+
+def test_staging_parquets_not_registered(tmp_path):
+    _write_parquet(tmp_path / "target" / "ask_ingest" / "real.parquet")
+    _write_parquet(
+        tmp_path / "target" / "ask_ingest" / "_staging" / "abc123" / "temp.parquet"
+    )
+
+    repl = REPL(project_path=tmp_path, skip_history=True)
+
+    views = _views(repl)
+    assert "ingest_real" in views
+    # Staging parquets must never be auto-registered
+    assert "ingest_temp" not in views
+
+
+def test_empty_ask_ingest_graceful(tmp_path):
+    # No parquet present; REPL startup must not raise.
+    (tmp_path / "target" / "ask_ingest").mkdir(parents=True)
+    REPL(project_path=tmp_path, skip_history=True)
+
+
+def test_no_ask_ingest_dir_graceful(tmp_path):
+    # Directory doesn't exist; REPL startup must not raise.
+    REPL(project_path=tmp_path, skip_history=True)

--- a/tests/ask/test_save_skill.py
+++ b/tests/ask/test_save_skill.py
@@ -1,0 +1,130 @@
+"""Tests for save_ingestion_skill tool."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import duckdb
+import pytest
+
+from seeknal.ask.agents.tools._context import ToolContext, set_tool_context
+from seeknal.ask.agents.tools.save_ingestion_skill import save_ingestion_skill
+
+
+class _REPLStub:
+    def __init__(self) -> None:
+        self.conn = duckdb.connect(":memory:")
+
+
+@pytest.fixture
+def ctx(tmp_path: Path) -> ToolContext:
+    context = ToolContext(
+        repl=_REPLStub(),
+        artifact_discovery=MagicMock(),
+        project_path=tmp_path,
+    )
+    set_tool_context(context)
+    return context
+
+
+def _cols_json() -> str:
+    return json.dumps(
+        [
+            {"name": "invoice_id", "type": "BIGINT"},
+            {"name": "date", "type": "DATE"},
+            {"name": "amount", "type": "BIGINT"},
+        ]
+    )
+
+
+def test_skill_md_generation(tmp_path, ctx):
+    out = save_ingestion_skill(
+        skill_name="ingest-acme-sales",
+        table_name="acme_sales",
+        business_key="invoice_id",
+        columns_json=_cols_json(),
+        description="Monthly ACME sales upload",
+    )
+    assert "Saved ingestion skill" in out
+
+    skill = tmp_path / "seeknal/skills/ingest-acme-sales/SKILL.md"
+    assert skill.exists()
+    content = skill.read_text()
+    # Frontmatter
+    assert content.startswith("---\n")
+    assert "name: ingest-acme-sales" in content
+    assert 'business_key: ["invoice_id"]' in content
+    # Schema table
+    assert "| `invoice_id` | BIGINT |" in content
+    # Phase structure mirrors report-generation canonical
+    assert "## Phase 1" in content
+    assert "## Critical-analyst rules" in content
+
+
+def test_skill_discovery_via_resolve(tmp_path, ctx):
+    save_ingestion_skill(
+        skill_name="ingest-acme-sales",
+        table_name="acme_sales",
+        business_key="invoice_id",
+        columns_json=_cols_json(),
+    )
+
+    from seeknal.ask.agents.agent import _resolve_skill_directories
+
+    dirs = _resolve_skill_directories(tmp_path)
+    # Local skills dir must be on the search path; saved SKILL.md must be under it.
+    assert any(str(tmp_path / "seeknal" / "skills") in d for d in dirs)
+    assert (tmp_path / "seeknal" / "skills" / "ingest-acme-sales" / "SKILL.md").exists()
+
+
+def test_invalid_skill_name_rejected(ctx):
+    out = save_ingestion_skill(
+        skill_name="Bad Name!",
+        table_name="acme_sales",
+        business_key="invoice_id",
+        columns_json=_cols_json(),
+    )
+    assert out.startswith("Error:")
+    assert "invalid skill_name" in out
+
+
+def test_invalid_table_name_rejected(ctx):
+    out = save_ingestion_skill(
+        skill_name="ingest-acme",
+        table_name="bad;name",
+        business_key="invoice_id",
+        columns_json=_cols_json(),
+    )
+    assert out.startswith("Error:")
+
+
+def test_invalid_columns_json_rejected(ctx):
+    out = save_ingestion_skill(
+        skill_name="ingest-acme",
+        table_name="acme",
+        business_key="invoice_id",
+        columns_json="not a json",
+    )
+    assert out.startswith("Error:")
+
+
+def test_overwrites_existing_skill(tmp_path, ctx):
+    save_ingestion_skill(
+        skill_name="ingest-acme",
+        table_name="acme",
+        business_key="invoice_id",
+        columns_json=_cols_json(),
+        description="v1",
+    )
+    save_ingestion_skill(
+        skill_name="ingest-acme",
+        table_name="acme",
+        business_key="invoice_id",
+        columns_json=_cols_json(),
+        description="v2",
+    )
+    content = (tmp_path / "seeknal/skills/ingest-acme/SKILL.md").read_text()
+    assert "v2" in content
+    assert "v1" not in content

--- a/tests/ask/test_temporal_integration.py
+++ b/tests/ask/test_temporal_integration.py
@@ -275,9 +275,27 @@ class TestTemporalWorkerFactory:
     """Test worker and client factory functions."""
 
     def test_create_worker(self):
-        from seeknal.ask.gateway.temporal import create_temporal_worker
+        # Newer temporalio versions reject non-bridge clients in the Worker
+        # constructor, so patch Worker to capture the factory's argument
+        # wiring without constructing a real Worker.
+        from unittest.mock import patch
+
+        from seeknal.ask.gateway.temporal import (
+            AgentWorkflow,
+            create_temporal_worker,
+            run_agent_activity,
+        )
 
         mock_client = MagicMock()
-        worker = create_temporal_worker(mock_client, task_queue="test-queue")
-        # Worker should be created without error
+        with patch(
+            "seeknal.ask.gateway.temporal.Worker"
+        ) as mock_worker_cls:
+            mock_worker_cls.return_value = MagicMock(name="worker")
+            worker = create_temporal_worker(mock_client, task_queue="test-queue")
+
         assert worker is not None
+        mock_worker_cls.assert_called_once()
+        _, kwargs = mock_worker_cls.call_args
+        assert kwargs["task_queue"] == "test-queue"
+        assert AgentWorkflow in kwargs["workflows"]
+        assert run_agent_activity in kwargs["activities"]

--- a/tests/ask/test_write_ingested.py
+++ b/tests/ask/test_write_ingested.py
@@ -1,0 +1,254 @@
+"""Tests for write_ingested_table tool (self-defending writes + provenance)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import duckdb
+import pytest
+
+from seeknal.ask.agents.tools._context import ToolContext, set_tool_context
+from seeknal.ask.agents.tools.write_ingested_table import write_ingested_table
+
+
+class _REPLStub:
+    def __init__(self) -> None:
+        self.conn = duckdb.connect(":memory:")
+
+
+@pytest.fixture
+def ctx(tmp_path: Path) -> ToolContext:
+    context = ToolContext(
+        repl=_REPLStub(),
+        artifact_discovery=MagicMock(),
+        project_path=tmp_path,
+    )
+    set_tool_context(context)
+    return context
+
+
+def _csv(path: Path, rows: list[tuple]) -> None:
+    lines = ["invoice_id,date,amount"]
+    for invoice_id, date, amount in rows:
+        lines.append(f"{invoice_id},{date},{amount}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _count_rows(parquet: Path) -> int:
+    con = duckdb.connect(":memory:")
+    try:
+        (n,) = con.execute(
+            f"SELECT COUNT(*) FROM read_parquet('{parquet}')"
+        ).fetchone()
+        return int(n)
+    finally:
+        con.close()
+
+
+def test_create_mode_writes_parquet_and_registers_view(tmp_path, ctx):
+    src = tmp_path / "jan.csv"
+    _csv(src, [(1, "2025-01-01", 100), (2, "2025-01-02", 200)])
+
+    result = write_ingested_table(str(src), "acme_sales", "invoice_id", mode="create")
+    parquet = tmp_path / "target/ask_ingest/acme_sales.parquet"
+    prov = tmp_path / "target/ask_ingest/acme_sales_provenance.json"
+
+    assert parquet.exists()
+    assert prov.exists()
+    assert "Rows inserted: 2" in result
+
+    payload = json.loads(prov.read_text())
+    for key in (
+        "source_file_sha256", "ingested_at", "rows_before", "rows_after",
+        "rows_inserted", "rows_deduped", "drift_decisions",
+    ):
+        assert key in payload
+    assert payload["rows_before"] == 0
+    assert payload["rows_after"] == 2
+
+    # View registered on the REPL conn
+    names = {
+        r[0]
+        for r in ctx.repl.conn.execute(
+            "SELECT table_name FROM information_schema.tables"
+        ).fetchall()
+    }
+    assert "ingest_acme_sales" in names
+
+
+def test_create_mode_rejects_duplicate_table(tmp_path, ctx):
+    src = tmp_path / "jan.csv"
+    _csv(src, [(1, "2025-01-01", 100)])
+    write_ingested_table(str(src), "acme_sales", "invoice_id", mode="create")
+
+    out = write_ingested_table(str(src), "acme_sales", "invoice_id", mode="create")
+    assert out.startswith("Error:")
+    assert "already exists" in out
+
+
+def test_silent_insert_blocked_in_append_mode(tmp_path, ctx):
+    # Create
+    src = tmp_path / "jan.csv"
+    _csv(src, [(1, "2025-01-01", 100), (2, "2025-01-02", 200)])
+    write_ingested_table(str(src), "acme_sales", "invoice_id", mode="create")
+    parquet = tmp_path / "target/ask_ingest/acme_sales.parquet"
+    mtime_before = parquet.stat().st_mtime_ns
+    size_before = parquet.stat().st_size
+
+    # Append attempt without confirmation: must return drift report, not write
+    feb = tmp_path / "feb.csv"
+    _csv(feb, [(2, "2025-01-02", 200), (3, "2025-02-01", 300)])
+    out = write_ingested_table(
+        str(feb), "acme_sales", "invoice_id", mode="append", user_confirmed=False,
+    )
+
+    assert "No data was written" in out
+    assert "Duplicate business-key rows" in out
+    # Parquet untouched
+    assert parquet.stat().st_mtime_ns == mtime_before
+    assert parquet.stat().st_size == size_before
+    assert _count_rows(parquet) == 2
+
+
+def test_append_dedup_skip_keeps_existing(tmp_path, ctx):
+    src = tmp_path / "jan.csv"
+    _csv(src, [(1, "2025-01-01", 100), (2, "2025-01-02", 200)])
+    write_ingested_table(str(src), "acme_sales", "invoice_id", mode="create")
+
+    feb = tmp_path / "feb.csv"
+    # Overlap on invoice_id=2 (different amount — existing 200 should stay)
+    _csv(feb, [(2, "2025-01-02", 999), (3, "2025-02-01", 300)])
+    out = write_ingested_table(
+        str(feb), "acme_sales", "invoice_id",
+        mode="append", user_confirmed=True, dedup_strategy="skip",
+    )
+    assert "Appended to `ingest_acme_sales`" in out
+
+    parquet = tmp_path / "target/ask_ingest/acme_sales.parquet"
+    assert _count_rows(parquet) == 3  # 1 + 2 + 3
+
+    con = duckdb.connect(":memory:")
+    try:
+        row = con.execute(
+            f"SELECT amount FROM read_parquet('{parquet}') WHERE invoice_id = 2"
+        ).fetchone()
+    finally:
+        con.close()
+    # existing wins
+    assert row[0] == 200
+
+
+def test_append_dedup_replace_keeps_new(tmp_path, ctx):
+    src = tmp_path / "jan.csv"
+    _csv(src, [(1, "2025-01-01", 100), (2, "2025-01-02", 200)])
+    write_ingested_table(str(src), "acme_sales", "invoice_id", mode="create")
+
+    feb = tmp_path / "feb.csv"
+    _csv(feb, [(2, "2025-01-02", 999), (3, "2025-02-01", 300)])
+    write_ingested_table(
+        str(feb), "acme_sales", "invoice_id",
+        mode="append", user_confirmed=True, dedup_strategy="replace",
+    )
+
+    parquet = tmp_path / "target/ask_ingest/acme_sales.parquet"
+    assert _count_rows(parquet) == 3
+
+    con = duckdb.connect(":memory:")
+    try:
+        row = con.execute(
+            f"SELECT amount FROM read_parquet('{parquet}') WHERE invoice_id = 2"
+        ).fetchone()
+    finally:
+        con.close()
+    # new wins
+    assert row[0] == 999
+
+
+def test_invalid_table_name_rejected(tmp_path, ctx):
+    src = tmp_path / "j.csv"
+    _csv(src, [(1, "2025-01-01", 10)])
+    out = write_ingested_table(str(src), "DROP;--", "invoice_id", mode="create")
+    assert out.startswith("Error:")
+    assert "invalid table_name" in out
+
+
+def test_invalid_business_key_rejected(tmp_path, ctx):
+    src = tmp_path / "j.csv"
+    _csv(src, [(1, "2025-01-01", 10)])
+    out = write_ingested_table(str(src), "acme_sales", "id;--", mode="create")
+    assert out.startswith("Error:")
+
+
+def test_append_without_existing_table_errors(tmp_path, ctx):
+    feb = tmp_path / "feb.csv"
+    _csv(feb, [(3, "2025-02-01", 300)])
+    out = write_ingested_table(
+        str(feb), "acme_sales", "invoice_id", mode="append", user_confirmed=True,
+    )
+    assert out.startswith("Error:")
+    assert "no existing table" in out
+
+
+def test_provenance_written_on_create_and_append(tmp_path, ctx):
+    src = tmp_path / "jan.csv"
+    _csv(src, [(1, "2025-01-01", 100)])
+    write_ingested_table(str(src), "acme_sales", "invoice_id", mode="create")
+
+    feb = tmp_path / "feb.csv"
+    _csv(feb, [(2, "2025-02-01", 200)])
+    write_ingested_table(
+        str(feb), "acme_sales", "invoice_id",
+        mode="append", user_confirmed=True, dedup_strategy="skip",
+    )
+
+    prov = json.loads(
+        (tmp_path / "target/ask_ingest/acme_sales_provenance.json").read_text()
+    )
+    assert prov["rows_before"] == 1
+    assert prov["rows_after"] == 2
+    assert prov["rows_inserted"] == 1
+    assert prov["rows_deduped"] == 0
+    assert prov["drift_decisions"]
+
+
+def test_missing_business_key_column_on_create(tmp_path, ctx):
+    src = tmp_path / "j.csv"
+    _csv(src, [(1, "2025-01-01", 10)])
+    out = write_ingested_table(str(src), "acme_sales", "nonexistent", mode="create")
+    assert out.startswith("Error:")
+    assert "not present in source" in out
+
+
+def test_xlsx_source_auto_converted(tmp_path, ctx):
+    """write_ingested_table should accept an xlsx path directly (no prior read_tabular)."""
+    pytest.importorskip("openpyxl")
+    import pandas as pd
+
+    xlsx = tmp_path / "menu.xlsx"
+    df = pd.DataFrame(
+        {
+            "invoice_id": [1, 2, 3],
+            "date": ["2025-01-01", "2025-01-02", "2025-01-03"],
+            "amount": [100, 150, 200],
+        }
+    )
+    df.to_excel(xlsx, index=False, engine="openpyxl")
+
+    result = write_ingested_table(
+        str(xlsx), "menu", "invoice_id", mode="create"
+    )
+    assert "Created table `ingest_menu`" in result
+    parquet = tmp_path / "target/ask_ingest/menu.parquet"
+    assert parquet.exists()
+    assert _count_rows(parquet) == 3
+
+
+def test_resolves_staging_path_from_context(tmp_path, ctx):
+    src = tmp_path / "j.csv"
+    _csv(src, [(1, "2025-01-01", 10)])
+    ctx.last_read_staging_path = str(src)
+
+    out = write_ingested_table("", "acme_sales", "invoice_id", mode="create")
+    assert "Created table" in out

--- a/uv.lock
+++ b/uv.lock
@@ -867,6 +867,15 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2144,6 +2153,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]
@@ -4041,7 +4062,7 @@ wheels = [
 
 [[package]]
 name = "seeknal"
-version = "2.6.0"
+version = "2.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },
@@ -4092,6 +4113,7 @@ all = [
 ]
 ask = [
     { name = "ddgs" },
+    { name = "openpyxl" },
     { name = "pydantic-ai-slim", extra = ["google"] },
     { name = "pydantic-deep" },
     { name = "redis" },
@@ -4149,6 +4171,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "libsql-experimental", specifier = ">=0.0.41" },
     { name = "mack", specifier = ">=0.5.0" },
+    { name = "openpyxl", marker = "extra == 'ask'", specifier = ">=3.1" },
     { name = "orjson", specifier = ">=3.11.6" },
     { name = "pandas", specifier = ">=1.3.0" },
     { name = "pendulum", specifier = ">=3.0.0" },


### PR DESCRIPTION
## Summary

Two new conversational flows for `seeknal ask`, both driven by fat SKILL.md prose + thin Python tools:

- **data-ingest** — hand the agent a `.xlsx / .csv / .tsv / .json` file or a direct-download URL and it walks schema preview → business key confirmation → parquet write → auto-registered DuckDB view → reusable SKILL.md. Re-runs surface a self-defending drift/dedup report before any append write.
- **record-entry** — `/record fitra, 1 mie ayam, 1 mineral water` or a BCA/Mandiri/GoPay/OVO/DANA fund-transfer screenshot becomes one row in a kind-appropriate `ingest_*` table. Parser is kind-aware (transfer / order / activity / meeting / health / note / expense / custom) — it emits *hints*, the LLM classifies. Strict `ask_user` clarification until every required field is resolved.

## Surfaces wired

- **Telegram**: `filters.Document.ALL` → data-ingest · `filters.PHOTO` → record-entry, both with live status updates via `edit_text`.
- **Gateway**: `POST /upload` (tabular + image — returns `kind` + `next` hint, tenant-scoped staging) · `POST /record` (text input, runs the skill via SSE stream).
- **REPL**: new Phase 1c auto-registers `target/ask_ingest/*.parquet` as `ingest_{stem}` views on startup (non-recursive `glob` deliberately excludes `_staging/`).
- **CLI chat**: no code change — SKILL.md discovery handles it.

## Security

Phase 4 review findings were all addressed before landing:

- **SSRF** — `read_tabular` rejects private / loopback / link-local / reserved IPs (incl. 169.254.169.254 IMDS) and disables HTTP redirect following.
- **Path traversal** — Content-Disposition filename normalised via `Path(...).name`; tenant + UUID prefix on staging directories.
- **fs_lock** — parquet + provenance writes serialised against sibling file-writing tools.
- **Write allowlist** — `target/` added to `WRITABLE_DIRS` with sanitizer + containment check preserved.
- **Self-defending write** — `write_ingested_table(mode='append', user_confirmed=False)` returns the drift report without touching disk; bypasses the `reset_report_approval()` per-turn flag reset entirely.

## Test plan

- [x] `pytest tests/ask/` → **778 passed, 14 warnings in 50.9s**
- [x] 39 data-ingest tests (`test_read_tabular`, `test_write_ingested`, `test_save_skill`, `test_check_drift`, `test_gateway_upload`, `test_repl_ingest`)
- [x] 32 record-entry tests (`test_parse_record`, `test_extract_from_image` with mocked `_call_gemini`, `test_propose_record_table`, `test_gateway_record`)
- [x] 3 ship-blocker E2E tests (`test_ingest_e2e`): two-session replay, single-session analytics, critical-agent dedup
- [x] Regression: full ask suite green, including pre-existing `test_temporal_integration` (test-side fix bundled — patch `Worker` at call site for newer temporalio)
- [ ] Manual Telegram smoke: send a CSV and a BCA transfer screenshot, walk through the ask_user gates, verify `target/ask_ingest/*.parquet` appear

## Demo scenario

A simulation project is committed-friendly at `~/seeknal-demo/`:

- `~/seeknal-demo/project/` — empty `seeknal init`'d project with a cafe-themed `SEEKNAL_ASK.md`
- `~/seeknal-demo/incoming/` — `orders_jan.csv`, `orders_feb.csv` (2 duplicates for dedup demo), `customers.tsv`, `menu.xlsx`

Spin up `seeknal gateway start --project ~/seeknal-demo/project --telegram` and exercise the full bootstrap loop end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)