### PR TITLE
feat(release): 2.7.1 — pairing, execute_uv_script, pipeline runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ trees/
 .claude/specs/task-analysis.json
 /specs/
 .gstack/
+.omx/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.1] - 2026-04-18
+
+Combined parallel session work with 2.7.0 — additive merge, two aligned conflicts.
+
+### Added
+
+- **Gateway pairing** — `FilePairingStore`, `TelegramLinkStore`, `PublicSessionStore` wired into the app lifespan. New Telegram `/pair` command redeems admin-generated one-time codes; expired-code cleanup runs on the eviction loop.
+- **`execute_uv_script`** — Ask tool to run uv-managed Python scripts from the agent.
+- **Pipeline runtime helpers**:
+  - `ctx.llm` — Ask-aligned text/JSON generation inside `@transform` functions
+  - `ctx.state` — lightweight per-node persistent state keyed to the run
+- **Config discovery** — `find_agent_config_path()` locates `seeknal_agent.yml` under both project root and `seeknal/`.
+- **Draft normalisation** — `normalize_python_deps()` preserves user order, deduplicates, and ensures `seeknal` is present first so generated Python drafts can import the local package when executed via `uv run`.
+- Tests: `test_gateway_pairing`, `test_telegram_channel`, `test_execute_uv_script`, `test_apply_draft`, `test_draft_node`, `test_session_cli`, `test_pipeline_runtime_helpers`, `test_python_executor_runtime_context`.
+
+### Changed
+
+- Gateway startup banner prints plain-string endpoints (no unnecessary f-strings).
+- `test_create_worker` consolidates both fix styles: compact `return_value=` patch plus full-kwargs assertions against `task_queue`, `workflows`, and `activities`.
+
 ## [2.7.0] - 2026-04-18
 
 ### Added

--- a/docs/guides/python-pipelines.md
+++ b/docs/guides/python-pipelines.md
@@ -590,6 +590,12 @@ def regional_user_metrics(ctx, df: pd.DataFrame) -> pd.DataFrame:
 
 The `PipelineContext` object (`ctx`) is passed to all decorated functions (except sources) and provides access to:
 
+- `ctx.ref(...)` for upstream outputs
+- `ctx.duckdb` for DuckDB SQL
+- `ctx.params` / `ctx.get_param(...)` for resolved node parameters
+- `ctx.state` for lightweight per-node persistent state
+- `ctx.llm` for Ask-aligned text/JSON generation
+
 ### ctx.ref(node_reference)
 
 Reference upstream node outputs.
@@ -638,6 +644,47 @@ def duckdb -> duckdb.DuckDBPyConnection
 ```
 
 **Returns:**
+
+---
+
+### ctx.params / ctx.get_param(name, default=None)
+
+Access resolved node parameters at runtime.
+
+```python
+@transform(
+    name="fetch_pages",
+    params={"timeout_seconds": 20},
+)
+def fetch_pages(ctx):
+    timeout_seconds = ctx.get_param("timeout_seconds", 10)
+    return pd.DataFrame([{"timeout_seconds": timeout_seconds}])
+```
+
+---
+
+### ctx.state
+
+Access a tiny JSON-backed per-node state store under `target/pipeline_state/`.
+
+```python
+etag = ctx.state.get("etag")
+ctx.state.set("etag", "abc123")
+```
+
+---
+
+### ctx.llm
+
+Use the same provider/model defaults as Seeknal Ask for LLM-backed transforms.
+
+```python
+summary = ctx.llm.generate_text("Summarize the latest pricing changes.")
+payload = ctx.llm.generate_json(
+    "Return a JSON summary of this signal.",
+    {"type": "object"},
+)
+```
 - DuckDB connection object
 
 **Examples:**

--- a/docs/tutorials/seeknal-ask-agent.md
+++ b/docs/tutorials/seeknal-ask-agent.md
@@ -160,6 +160,7 @@ The agent uses a **thin tools + fat skills** architecture. 16 thin tools handle 
 |------|-------------|
 | `execute_sql` | Runs read-only DuckDB SQL queries (with auto-retry on errors) |
 | `execute_python` | Runs Python code in a sandboxed subprocess with `pandas`, `numpy`, `scipy`, and `matplotlib` pre-loaded |
+| `execute_uv_script` | Runs prototype Python scripts through `uv run` with custom PEP 723 dependencies |
 | `query_metric` | Queries business metrics from the semantic layer |
 
 #### Project Understanding

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "seeknal"
-version = "2.7.0"
+version = "2.7.1"
 description = "All-in-one platform for data and AI/ML engineering"
 authors = [
     {name = "Fitra Kacamarga"}

--- a/src/seeknal/ask/agents/providers.py
+++ b/src/seeknal/ask/agents/providers.py
@@ -9,6 +9,37 @@ import os
 from typing import Optional
 
 
+def resolve_provider_config(
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> dict[str, Optional[str]]:
+    """Resolve provider/model credentials using Seeknal Ask defaults."""
+    resolved_provider = provider or os.environ.get("SEEKNAL_ASK_LLM_PROVIDER", "google")
+
+    if resolved_provider == "google":
+        return {
+            "provider": resolved_provider,
+            "model": model or os.environ.get("SEEKNAL_ASK_MODEL", "gemini-2.5-flash"),
+            "api_key": api_key or os.environ.get("GOOGLE_API_KEY"),
+            "base_url": None,
+        }
+
+    if resolved_provider == "ollama":
+        return {
+            "provider": resolved_provider,
+            "model": model or os.environ.get("SEEKNAL_ASK_MODEL", "llama3.1"),
+            "api_key": None,
+            "base_url": base_url or os.environ.get("SEEKNAL_ASK_OLLAMA_URL"),
+        }
+
+    raise ValueError(
+        f"Unsupported LLM provider: '{resolved_provider}'. "
+        f"Supported: 'google', 'ollama'."
+    )
+
+
 def get_model_string(
     provider: Optional[str] = None,
     model: Optional[str] = None,
@@ -34,17 +65,16 @@ def get_model_string(
     Raises:
         ValueError: If provider is unsupported or required config is missing.
     """
-    provider = provider or os.environ.get("SEEKNAL_ASK_LLM_PROVIDER", "google")
+    resolved = resolve_provider_config(
+        provider=provider,
+        model=model,
+        api_key=api_key,
+        base_url=base_url,
+    )
 
-    if provider == "google":
-        return _google_model_string(model, api_key)
-    elif provider == "ollama":
-        return _ollama_model_string(model, base_url)
-    else:
-        raise ValueError(
-            f"Unsupported LLM provider: '{provider}'. "
-            f"Supported: 'google', 'ollama'."
-        )
+    if resolved["provider"] == "google":
+        return _google_model_string(resolved["model"], resolved["api_key"])
+    return _ollama_model_string(resolved["model"], resolved["base_url"])
 
 
 def _google_model_string(

--- a/src/seeknal/ask/agents/tools/apply_draft.py
+++ b/src/seeknal/ask/agents/tools/apply_draft.py
@@ -10,7 +10,13 @@ _KIND_DIR_MAP = {
     "transform": "transforms",
     "feature_group": "feature_groups",
     "model": "models",
+    "aggregation": "aggregations",
     "second_order_aggregation": "second_order_aggregations",
+    "rule": "rules",
+    "profile": "profiles",
+    "exposure": "exposures",
+    "semantic_model": "semantic_models",
+    "metric": "metrics",
 }
 
 

--- a/src/seeknal/ask/agents/tools/draft_node.py
+++ b/src/seeknal/ask/agents/tools/draft_node.py
@@ -1,7 +1,12 @@
 """Draft node tool — creates a new pipeline node draft file."""
 
 
-async def draft_node(node_type: str, name: str, python: bool = False) -> str:
+async def draft_node(
+    node_type: str,
+    name: str,
+    python: bool = False,
+    deps: list[str] | None = None,
+) -> str:
     """Generate a pipeline-node draft template under .seeknal/drafts/.
 
     See the `build-pipeline-node` skill for the full draft → validate → apply
@@ -12,6 +17,7 @@ async def draft_node(node_type: str, name: str, python: bool = False) -> str:
             profile, exposure, semantic_model, metric (snake_case or hyphen).
         name: Alphanumeric + underscores only, ≤128 chars.
         python: True for a Python file template, False for YAML.
+        deps: Optional Python dependencies for PEP 723 metadata.
     """
     from seeknal.ask.agents.tools._context import get_tool_context
     from seeknal.ask.agents.tools._write_security import get_drafts_dir
@@ -51,7 +57,14 @@ async def draft_node(node_type: str, name: str, python: bool = False) -> str:
 
     try:
         env = get_template_env()
-        content = render_template(env, normalized, name, description=None, python=python)
+        content = render_template(
+            env,
+            normalized,
+            name,
+            description=None,
+            python=python,
+            deps=deps,
+        )
 
         with ctx.fs_lock:
             filepath.write_text(content)

--- a/src/seeknal/ask/agents/tools/execute_uv_script.py
+++ b/src/seeknal/ask/agents/tools/execute_uv_script.py
@@ -1,0 +1,247 @@
+"""Execute Python via uv with optional PEP 723 dependencies."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from seeknal.ask.agents.tools._context import get_tool_context
+
+
+def _find_seeknal_src() -> str:
+    import seeknal
+
+    return str(Path(seeknal.__file__).parent.parent)
+
+
+def _normalize_deps(deps: list[str] | None) -> list[str]:
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for dep in deps or []:
+        value = dep.strip()
+        if not value or value in seen:
+            continue
+        normalized.append(value)
+        seen.add(value)
+    return normalized
+
+
+def _pep723_header(deps: list[str]) -> str:
+    lines = [
+        "# /// script",
+        '# requires-python = ">=3.11"',
+        "# dependencies = [",
+    ]
+    for dep in deps:
+        lines.append(f'#     "{dep}",')
+    lines.extend(["# ]", "# ///", ""])
+    return "\n".join(lines)
+
+
+_RUNNER_TEMPLATE = """\
+{pep723_header}import ast
+import json
+import os
+import sys
+import traceback
+from io import StringIO
+from pathlib import Path
+
+sys.path.insert(0, {seeknal_src!r})
+sys.path.insert(0, {project_path!r})
+
+
+def load_project_data(project_path: str):
+    import duckdb
+
+    conn = duckdb.connect(":memory:")
+    root = Path(project_path)
+    intermediate = root / "target" / "intermediate"
+    if intermediate.exists():
+        for pq in intermediate.rglob("*.parquet"):
+            safe_path = str(pq.resolve()).replace("'", "''")
+            try:
+                conn.execute(
+                    f'CREATE VIEW "{{pq.stem}}" AS SELECT * FROM read_parquet(\'{{safe_path}}\')'
+                )
+            except Exception:
+                pass
+    return conn
+
+
+def split_last_expression(code: str):
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return code, None
+
+    if not tree.body:
+        return code, None
+
+    last_node = tree.body[-1]
+    if not isinstance(last_node, ast.Expr):
+        return code, None
+
+    body = tree.body[:-1]
+    body_code = None
+    if body:
+        body_module = ast.Module(body=body, type_ignores=[])
+        ast.fix_missing_locations(body_module)
+        body_code = compile(body_module, "<agent>", "exec")
+
+    expr_node = ast.Expression(body=last_node.value)
+    ast.fix_missing_locations(expr_node)
+    expr_code = compile(expr_node, "<agent>", "eval")
+    return body_code, expr_code
+
+
+def capture_plots(plot_dir: str):
+    try:
+        import matplotlib.pyplot as plt
+    except Exception:
+        return []
+    paths = []
+    for i, fig_num in enumerate(plt.get_fignums()):
+        fig = plt.figure(fig_num)
+        path = os.path.join(plot_dir, f"plot_{{i}}.png")
+        fig.savefig(path, dpi=150, bbox_inches="tight", facecolor="white")
+        paths.append(path)
+    plt.close("all")
+    return paths
+
+
+plot_dir = {plot_dir!r}
+os.makedirs(plot_dir, exist_ok=True)
+agent_code = {code!r}
+conn = load_project_data({project_path!r})
+
+try:
+    import pandas as pd
+except Exception:
+    pd = None
+
+try:
+    import numpy as np
+except Exception:
+    np = None
+
+try:
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+except Exception:
+    matplotlib = None
+    plt = None
+
+namespace = {{
+    "conn": conn,
+    "pd": pd,
+    "np": np,
+    "plt": plt,
+    "matplotlib": matplotlib,
+}}
+
+captured = StringIO()
+namespace["print"] = lambda *a, **kw: print(*a, file=captured, **kw)
+value = None
+error = None
+
+body_code, expr_code = split_last_expression(agent_code)
+try:
+    if isinstance(body_code, str):
+        exec(compile(body_code, "<agent>", "exec"), namespace)
+    else:
+        if body_code is not None:
+            exec(body_code, namespace)
+        if expr_code is not None:
+            value = eval(expr_code, namespace)
+except Exception:
+    error = traceback.format_exc()
+
+plots = capture_plots(plot_dir)
+result = {{
+    "stdout": captured.getvalue(),
+    "value": value if isinstance(value, (str, int, float, bool, type(None), list, dict)) else repr(value),
+    "error": error,
+    "plots": plots,
+}}
+json.dump(result, sys.stdout)
+"""
+
+
+def _format_result(payload: dict[str, Any]) -> str:
+    parts: list[str] = []
+    if payload.get("stdout"):
+        parts.append(str(payload["stdout"]).rstrip())
+    if payload.get("error"):
+        parts.append(f"Error:\n{payload['error']}")
+    elif payload.get("value") not in (None, ""):
+        parts.append(str(payload["value"]))
+    if payload.get("plots"):
+        parts.append("Plots saved:\n" + "\n".join(f"- {p}" for p in payload["plots"]))
+    return "\n\n".join(parts) if parts else "Code executed successfully (no output)."
+
+
+async def execute_uv_script(code: str, deps: list[str] | None = None) -> str:
+    """Run Python via ``uv run`` with optional PEP 723 dependencies.
+
+    The script receives:
+    - ``conn``: DuckDB connection with project parquet views registered
+    - ``pd`` / ``np`` / ``plt`` when available
+    - Jupyter-style last-expression capture
+    """
+    if not code.strip():
+        return "No code provided."
+    if shutil.which("uv") is None:
+        return "uv is required for execute_uv_script but was not found on PATH."
+
+    ctx = get_tool_context()
+    project_path = ctx.project_path.resolve()
+    session_id = ctx.session_id
+    deps = _normalize_deps(deps)
+
+    base_dir = project_path / "target" / f".ask_uvscript_{session_id}"
+    base_dir.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(dir=base_dir) as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        plot_dir = tmpdir_path / "plots"
+        script_path = tmpdir_path / "runner.py"
+        script_path.write_text(
+            _RUNNER_TEMPLATE.format(
+                pep723_header=_pep723_header(deps),
+                seeknal_src=_find_seeknal_src(),
+                project_path=str(project_path),
+                plot_dir=str(plot_dir),
+                code=code,
+            )
+        )
+
+        try:
+            result = subprocess.run(
+                ["uv", "run", str(script_path)],
+                cwd=str(project_path),
+                capture_output=True,
+                text=True,
+                timeout=120,
+                env=os.environ.copy(),
+            )
+        except subprocess.TimeoutExpired:
+            return "Execution timed out after 120 seconds."
+
+        if result.returncode != 0:
+            stderr = result.stderr.strip() or result.stdout.strip()
+            return f"uv script failed (exit {result.returncode}):\n{stderr}"
+
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            return result.stdout.strip() or "uv script executed but returned no structured output."
+
+        return _format_result(payload)
+

--- a/src/seeknal/ask/agents/tools/toolset.py
+++ b/src/seeknal/ask/agents/tools/toolset.py
@@ -12,6 +12,7 @@ from seeknal.ask.agents.tools.dry_run_draft import dry_run_draft
 from seeknal.ask.agents.tools.edit_node import edit_node
 from seeknal.ask.agents.tools.edit_proof_document import edit_proof_document
 from seeknal.ask.agents.tools.execute_python import execute_python
+from seeknal.ask.agents.tools.execute_uv_script import execute_uv_script
 from seeknal.ask.agents.tools.execute_sql import execute_sql
 from seeknal.ask.agents.tools.extract_from_image import extract_from_image
 from seeknal.ask.agents.tools.generate_report import generate_report
@@ -59,6 +60,7 @@ def create_ask_toolset() -> FunctionToolset:
             read_project_file,
             # Analysis & reporting
             execute_python,
+            execute_uv_script,
             generate_report,
             open_in_browser,
             save_report_exposure,

--- a/src/seeknal/ask/builtin_skills/build-pipeline-node/SKILL.md
+++ b/src/seeknal/ask/builtin_skills/build-pipeline-node/SKILL.md
@@ -25,6 +25,10 @@ You will also use the THIN primitives `read_pipeline`, `search_pipelines`,
 `search_project_files`, `read_project_file`, `inspect_output`, and `plan_pipeline`
 to discover existing structure and verify outputs.
 
+For Python-heavy ingestion/transformation work, you may first prototype code
+with `execute_uv_script(code=..., deps=[...])` before committing it to a
+drafted node.
+
 ## Supported node types
 
 `source`, `transform`, `feature_group` (alias `feature-group`), `model`,
@@ -90,6 +94,7 @@ Call `draft_node(node_type=..., name=..., python=False)`:
 - `node_type`: one of the supported types above (snake_case or hyphen)
 - `name`: alphanumeric + underscores only, ≤128 chars
 - `python`: `True` for a Python file (transforms / models only), `False` for YAML
+- `deps`: optional Python dependency list for PEP 723 metadata when `python=True`
 
 The draft is written to `.seeknal/drafts/draft_<type>_<name>.{yml|py}`. The
 tool returns the rendered template content for you to inspect.

--- a/src/seeknal/ask/config.py
+++ b/src/seeknal/ask/config.py
@@ -12,6 +12,19 @@ from pathlib import Path
 from typing import Any, Optional
 
 _CONFIG_FILENAME = "seeknal_agent.yml"
+_CONFIG_CANDIDATES = (
+    Path(_CONFIG_FILENAME),
+    Path("seeknal") / _CONFIG_FILENAME,
+)
+
+
+def find_agent_config_path(project_path: Path) -> Optional[Path]:
+    """Return the first existing ask config path for a project."""
+    for candidate in _CONFIG_CANDIDATES:
+        config_path = project_path / candidate
+        if config_path.exists():
+            return config_path
+    return None
 
 
 def load_agent_config(project_path: Path) -> dict[str, Any]:
@@ -19,8 +32,8 @@ def load_agent_config(project_path: Path) -> dict[str, Any]:
 
     Returns an empty dict when the file does not exist.
     """
-    config_path = project_path / _CONFIG_FILENAME
-    if not config_path.exists():
+    config_path = find_agent_config_path(project_path)
+    if config_path is None:
         return {}
 
     try:
@@ -36,6 +49,45 @@ def load_agent_config(project_path: Path) -> dict[str, Any]:
         data = yaml.safe_load(f)
 
     return data if isinstance(data, dict) else {}
+
+
+def get_agent_settings(config: dict[str, Any]) -> dict[str, Any]:
+    """Return the nested ``agent`` settings map, if present."""
+    agent = config.get("agent", {})
+    return agent if isinstance(agent, dict) else {}
+
+
+def get_agent_profile_instructions(config: dict[str, Any]) -> Optional[str]:
+    """Build dynamic prompt instructions from the ``agent`` section."""
+    agent = get_agent_settings(config)
+    if not agent:
+        return None
+
+    lines: list[str] = []
+
+    name = agent.get("name")
+    if name:
+        lines.append(f"## Project Agent Profile\n\n- Agent name: **{name}**")
+
+    description = agent.get("description")
+    if description:
+        if not lines:
+            lines.append("## Project Agent Profile")
+        lines.append(f"- Description: {str(description).strip()}")
+
+    skills = agent.get("skills")
+    if isinstance(skills, list) and skills:
+        if not lines:
+            lines.append("## Project Agent Profile")
+        skill_list = ", ".join(f"`{skill}`" for skill in skills)
+        lines.append(f"- Preferred project skills: {skill_list}")
+
+    system_prompt = agent.get("system_prompt")
+    if system_prompt:
+        lines.append("\n## Project-Specific Instructions\n")
+        lines.append(str(system_prompt).strip())
+
+    return "\n".join(lines).strip() or None
 
 
 # ---------------------------------------------------------------------------

--- a/src/seeknal/ask/gateway/channels/telegram.py
+++ b/src/seeknal/ask/gateway/channels/telegram.py
@@ -16,6 +16,13 @@ import re
 from pathlib import Path
 from typing import Any
 
+from seeknal.ask.gateway.pairing import (
+    PairCodeExpiredError,
+    PairCodeInvalidError,
+    PairCodeUsedError,
+)
+from seeknal.ask.gateway.tenant import DEFAULT_TENANT
+
 logger = logging.getLogger(__name__)
 
 # Telegram message size limit
@@ -101,6 +108,21 @@ class TelegramChannel:
         self._project_path = project_path
         self._token = token or os.environ.get("TELEGRAM_BOT_TOKEN", "")
         self._app: Any = None
+        self._pairing_store: Any = None
+        self._link_store: Any = None
+        self._public_session_store: Any = None
+
+    def set_pairing_store(self, pairing_store: Any) -> None:
+        """Inject a pairing store shared with the gateway app."""
+        self._pairing_store = pairing_store
+
+    def set_link_store(self, link_store: Any) -> None:
+        """Inject a Telegram chat -> session mapping store."""
+        self._link_store = link_store
+
+    def set_public_session_store(self, public_session_store: Any) -> None:
+        """Inject a public-session store for unpaired Telegram access."""
+        self._public_session_store = public_session_store
 
     async def start(self) -> None:
         """Initialize the Telegram bot application."""
@@ -124,6 +146,7 @@ class TelegramChannel:
         )
 
         self._app.add_handler(CommandHandler("start", self._handle_start))
+        self._app.add_handler(CommandHandler("pair", self._handle_pair))
         self._app.add_handler(
             MessageHandler(filters.TEXT & ~filters.COMMAND, self._handle_message)
         )
@@ -188,6 +211,57 @@ class TelegramChannel:
             "Hi! Send me a question and I'll analyze it for you."
         )
 
+    async def _handle_pair(self, update: Any, context: Any) -> None:
+        """Redeem an admin-generated one-time pair code."""
+        if self._pairing_store is None or self._link_store is None:
+            await update.message.reply_text(
+                "Pairing is not available right now. Please try again later."
+            )
+            return
+
+        chat_id = str(update.effective_chat.id)
+        args = list(getattr(context, "args", []) or [])
+        if not args:
+            await update.message.reply_text(
+                "Ask the admin for a pair code, then send it here as /pair <code>."
+            )
+            return
+
+        try:
+            record = await self._pairing_store.redeem_pair_code(
+                " ".join(args),
+                tenant_id=DEFAULT_TENANT,
+            )
+        except (PairCodeInvalidError, PairCodeExpiredError, PairCodeUsedError) as exc:
+            await update.message.reply_text(str(exc))
+            return
+        self._link_store.link_chat(
+            chat_id,
+            record.session_id,
+            tenant_id=DEFAULT_TENANT,
+        )
+
+        await update.message.reply_text(
+            "Paired successfully. This Telegram chat is now connected to session "
+            f"{record.session_id}."
+        )
+
+    def _session_id_for_chat(self, chat_id: str) -> str | None:
+        if self._link_store is not None:
+            linked_session = self._link_store.get_session_id(
+                chat_id,
+                tenant_id=DEFAULT_TENANT,
+            )
+            if linked_session:
+                return linked_session
+        if self._public_session_store is not None:
+            public_session = self._public_session_store.get_session_id(
+                tenant_id=DEFAULT_TENANT,
+            )
+            if public_session:
+                return public_session
+        return None
+
     async def _handle_message(self, update: Any, context: Any) -> None:
         """Handle incoming text messages — run agent and stream response."""
         from telegram.constants import ChatAction
@@ -197,7 +271,13 @@ class TelegramChannel:
             return
 
         chat_id = str(update.effective_chat.id)
-        session_id = f"telegram-{chat_id}"
+        session_id = self._session_id_for_chat(chat_id)
+        if not session_id:
+            await update.message.reply_text(
+                "This Telegram chat is not paired yet. Ask the admin for a pair code, "
+                "then send /pair <code> first."
+            )
+            return
         logger.info("[telegram] message from chat_id=%s: %s", chat_id, question[:80])
 
         # Show typing indicator and a single status message (edited in-place)

--- a/src/seeknal/ask/gateway/pairing.py
+++ b/src/seeknal/ask/gateway/pairing.py
@@ -1,0 +1,477 @@
+"""Pairing helpers for linking Telegram chats to gateway sessions."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from dataclasses import asdict, dataclass, replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from seeknal.ask.gateway.tenant import DEFAULT_TENANT
+from seeknal.ask.sessions import generate_session_name
+
+_CODE_RE = re.compile(r"[a-z0-9]+")
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def normalize_pair_code(code: str) -> str:
+    """Normalize user-entered pair codes."""
+    parts = _CODE_RE.findall((code or "").lower())
+    return "-".join(parts)
+
+
+def generate_pair_code() -> str:
+    """Generate a human-readable pairing code with enough entropy for invites."""
+    return generate_session_name()
+
+
+@dataclass(frozen=True)
+class PairingRecord:
+    code: str
+    session_id: str
+    tenant_id: str
+    created_at: datetime
+    expires_at: datetime
+    used_at: datetime | None = None
+
+
+class PairingError(Exception):
+    """Base class for pairing failures."""
+
+
+class PairCodeInvalidError(PairingError):
+    """Pair code was not found."""
+
+
+class PairCodeExpiredError(PairingError):
+    """Pair code has expired."""
+
+
+class PairCodeUsedError(PairingError):
+    """Pair code has already been redeemed."""
+
+
+class FilePairingStore:
+    """Filesystem-backed pairing store shared between CLI and gateway."""
+
+    def __init__(
+        self,
+        project_path: Path | None = None,
+        *,
+        base_dir: Path | None = None,
+    ) -> None:
+        if base_dir is not None:
+            self._base = base_dir / "pairing"
+        elif project_path is not None:
+            self._base = project_path / ".seeknal" / "pairing"
+        else:
+            raise ValueError("FilePairingStore requires project_path or base_dir")
+        self._base.mkdir(parents=True, exist_ok=True)
+        self._lock = asyncio.Lock()
+
+    def _tenant_dir(self, tenant_id: str) -> Path:
+        tenant_dir = self._base / tenant_id
+        tenant_dir.mkdir(parents=True, exist_ok=True)
+        return tenant_dir
+
+    def _record_path(self, tenant_id: str, code: str) -> Path:
+        return self._tenant_dir(tenant_id) / f"{normalize_pair_code(code)}.json"
+
+    async def create_pair_code(
+        self,
+        session_id: str,
+        *,
+        tenant_id: str = DEFAULT_TENANT,
+        ttl_seconds: int = 600,
+    ) -> PairingRecord:
+        async with self._lock:
+            await self.cleanup_expired_codes()
+            for _ in range(64):
+                code = generate_pair_code()
+                path = self._record_path(tenant_id, code)
+                if not path.exists():
+                    now = _utcnow()
+                    record = PairingRecord(
+                        code=code,
+                        session_id=session_id,
+                        tenant_id=tenant_id,
+                        created_at=now,
+                        expires_at=now + timedelta(seconds=ttl_seconds),
+                    )
+                    path.write_text(self._serialize(record), encoding="utf-8")
+                    return record
+            raise RuntimeError("Failed to allocate a unique file pair code after 64 attempts")
+
+    async def redeem_pair_code(
+        self,
+        code: str,
+        *,
+        tenant_id: str = DEFAULT_TENANT,
+    ) -> PairingRecord:
+        async with self._lock:
+            path = self._record_path(tenant_id, code)
+            if not path.exists():
+                raise PairCodeInvalidError("Pair code is invalid.")
+
+            record = self._deserialize(path.read_text(encoding="utf-8"))
+            if self._is_expired(record):
+                path.unlink(missing_ok=True)
+                raise PairCodeExpiredError("Pair code has expired.")
+            if record.used_at is not None:
+                raise PairCodeUsedError("Pair code has already been used.")
+
+            updated = replace(record, used_at=_utcnow())
+            path.write_text(self._serialize(updated), encoding="utf-8")
+            return updated
+
+    async def cleanup_expired_codes(self) -> int:
+        removed = 0
+        for tenant_dir in self._base.glob("*"):
+            if not tenant_dir.is_dir():
+                continue
+            for path in tenant_dir.glob("*.json"):
+                try:
+                    record = self._deserialize(path.read_text(encoding="utf-8"))
+                except Exception:
+                    path.unlink(missing_ok=True)
+                    removed += 1
+                    continue
+                if self._is_expired(record):
+                    path.unlink(missing_ok=True)
+                    removed += 1
+        return removed
+
+    @staticmethod
+    def _is_expired(record: PairingRecord) -> bool:
+        return record.expires_at <= _utcnow()
+
+    @staticmethod
+    def _serialize(record: PairingRecord) -> str:
+        payload = asdict(record)
+        for key in ("created_at", "expires_at", "used_at"):
+            value = payload[key]
+            payload[key] = value.isoformat() if value is not None else None
+        return json.dumps(payload)
+
+    @staticmethod
+    def _deserialize(raw: str) -> PairingRecord:
+        data = json.loads(raw)
+        for key in ("created_at", "expires_at", "used_at"):
+            if data.get(key):
+                data[key] = datetime.fromisoformat(data[key])
+            else:
+                data[key] = None
+        return PairingRecord(**data)
+
+
+class InMemoryPairingStore:
+    """Simple in-process pairing store for single-replica gateways."""
+
+    def __init__(self) -> None:
+        self._codes: dict[str, dict[str, PairingRecord]] = {}
+        self._lock = asyncio.Lock()
+
+    async def create_pair_code(
+        self,
+        session_id: str,
+        *,
+        tenant_id: str = DEFAULT_TENANT,
+        ttl_seconds: int = 600,
+    ) -> PairingRecord:
+        async with self._lock:
+            self._cleanup_expired_locked()
+            tenant_codes = self._codes.setdefault(tenant_id, {})
+
+            for _ in range(64):
+                code = generate_pair_code()
+                record = tenant_codes.get(code)
+                if record is None or self._is_expired(record):
+                    now = _utcnow()
+                    created = PairingRecord(
+                        code=code,
+                        session_id=session_id,
+                        tenant_id=tenant_id,
+                        created_at=now,
+                        expires_at=now + timedelta(seconds=ttl_seconds),
+                    )
+                    tenant_codes[code] = created
+                    return created
+
+            raise RuntimeError("Failed to allocate a unique pair code after 64 attempts")
+
+    async def redeem_pair_code(
+        self,
+        code: str,
+        *,
+        tenant_id: str = DEFAULT_TENANT,
+    ) -> PairingRecord:
+        normalized = normalize_pair_code(code)
+        async with self._lock:
+            tenant_codes = self._codes.setdefault(tenant_id, {})
+            record = tenant_codes.get(normalized)
+            if record is None:
+                raise PairCodeInvalidError("Pair code is invalid.")
+            if self._is_expired(record):
+                del tenant_codes[normalized]
+                raise PairCodeExpiredError("Pair code has expired.")
+            if record.used_at is not None:
+                raise PairCodeUsedError("Pair code has already been used.")
+
+            updated = replace(record, used_at=_utcnow())
+            tenant_codes[normalized] = updated
+            return updated
+
+    async def cleanup_expired_codes(self) -> int:
+        async with self._lock:
+            return self._cleanup_expired_locked()
+
+    def _cleanup_expired_locked(self) -> int:
+        removed = 0
+        for tenant_id, codes in list(self._codes.items()):
+            stale = [code for code, record in codes.items() if self._is_expired(record)]
+            for code in stale:
+                del codes[code]
+                removed += 1
+            if not codes:
+                del self._codes[tenant_id]
+        return removed
+
+    @staticmethod
+    def _is_expired(record: PairingRecord) -> bool:
+        return record.expires_at <= _utcnow()
+
+
+class TelegramLinkStore:
+    """Filesystem-backed Telegram chat -> session mapping."""
+
+    def __init__(
+        self,
+        project_path: Path | None = None,
+        *,
+        base_dir: Path | None = None,
+    ) -> None:
+        if base_dir is not None:
+            self._base = base_dir / "telegram-links"
+        elif project_path is not None:
+            self._base = project_path / ".seeknal" / "telegram-links"
+        else:
+            raise ValueError("TelegramLinkStore requires project_path or base_dir")
+        self._base.mkdir(parents=True, exist_ok=True)
+
+    def _tenant_dir(self, tenant_id: str) -> Path:
+        tenant_dir = self._base / tenant_id
+        tenant_dir.mkdir(parents=True, exist_ok=True)
+        return tenant_dir
+
+    def _chat_path(self, tenant_id: str, chat_id: str) -> Path:
+        return self._tenant_dir(tenant_id) / f"{chat_id}.json"
+
+    def link_chat(
+        self,
+        chat_id: str,
+        session_id: str,
+        *,
+        tenant_id: str = DEFAULT_TENANT,
+    ) -> None:
+        payload = {
+            "chat_id": chat_id,
+            "session_id": session_id,
+            "tenant_id": tenant_id,
+            "linked_at": _utcnow().isoformat(),
+        }
+        self._chat_path(tenant_id, chat_id).write_text(
+            json.dumps(payload),
+            encoding="utf-8",
+        )
+
+    def get_session_id(
+        self,
+        chat_id: str,
+        *,
+        tenant_id: str = DEFAULT_TENANT,
+    ) -> str | None:
+        path = self._chat_path(tenant_id, chat_id)
+        if not path.exists():
+            return None
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data.get("session_id")
+
+    def list_links(
+        self,
+        *,
+        tenant_id: str = DEFAULT_TENANT,
+        session_id: str | None = None,
+    ) -> list[dict[str, str]]:
+        """List paired Telegram chat/device ids for a tenant."""
+        links: list[dict[str, str]] = []
+        for path in sorted(self._tenant_dir(tenant_id).glob("*.json")):
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            if session_id and data.get("session_id") != session_id:
+                continue
+            links.append(data)
+        links.sort(key=lambda item: item.get("linked_at", ""), reverse=True)
+        return links
+
+
+class PublicSessionStore:
+    """Filesystem-backed public session config for Telegram access."""
+
+    def __init__(
+        self,
+        project_path: Path | None = None,
+        *,
+        base_dir: Path | None = None,
+    ) -> None:
+        if base_dir is not None:
+            self._base = base_dir / "telegram-public"
+        elif project_path is not None:
+            self._base = project_path / ".seeknal" / "telegram-public"
+        else:
+            raise ValueError("PublicSessionStore requires project_path or base_dir")
+        self._base.mkdir(parents=True, exist_ok=True)
+
+    def _tenant_dir(self, tenant_id: str) -> Path:
+        tenant_dir = self._base / tenant_id
+        tenant_dir.mkdir(parents=True, exist_ok=True)
+        return tenant_dir
+
+    def _config_path(self, tenant_id: str) -> Path:
+        return self._tenant_dir(tenant_id) / "public-session.json"
+
+    def set_session(
+        self,
+        session_id: str,
+        *,
+        tenant_id: str = DEFAULT_TENANT,
+    ) -> None:
+        payload = {
+            "session_id": session_id,
+            "tenant_id": tenant_id,
+            "updated_at": _utcnow().isoformat(),
+        }
+        self._config_path(tenant_id).write_text(
+            json.dumps(payload),
+            encoding="utf-8",
+        )
+
+    def get_session_id(
+        self,
+        *,
+        tenant_id: str = DEFAULT_TENANT,
+    ) -> str | None:
+        path = self._config_path(tenant_id)
+        if not path.exists():
+            return None
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data.get("session_id")
+
+    def clear(
+        self,
+        *,
+        tenant_id: str = DEFAULT_TENANT,
+    ) -> bool:
+        path = self._config_path(tenant_id)
+        if not path.exists():
+            return False
+        path.unlink()
+        return True
+
+
+class RedisPairingStore:
+    """Redis-backed pairing store for multi-replica gateways."""
+
+    KEY_PREFIX = "seeknal:pair:"
+
+    def __init__(self, redis_client: Any) -> None:
+        self._redis = redis_client
+
+    def _key(self, tenant_id: str, code: str) -> str:
+        if tenant_id == DEFAULT_TENANT:
+            return f"{self.KEY_PREFIX}{code}"
+        return f"{self.KEY_PREFIX}{tenant_id}:{code}"
+
+    async def create_pair_code(
+        self,
+        session_id: str,
+        *,
+        tenant_id: str = DEFAULT_TENANT,
+        ttl_seconds: int = 600,
+    ) -> PairingRecord:
+        for _ in range(64):
+            code = generate_pair_code()
+            now = _utcnow()
+            record = PairingRecord(
+                code=code,
+                session_id=session_id,
+                tenant_id=tenant_id,
+                created_at=now,
+                expires_at=now + timedelta(seconds=ttl_seconds),
+            )
+            created = await self._redis.set(
+                self._key(tenant_id, code),
+                self._serialize(record),
+                ex=ttl_seconds,
+                nx=True,
+            )
+            if created:
+                return record
+        raise RuntimeError("Failed to allocate a unique Redis pair code after 64 attempts")
+
+    async def redeem_pair_code(
+        self,
+        code: str,
+        *,
+        tenant_id: str = DEFAULT_TENANT,
+    ) -> PairingRecord:
+        normalized = normalize_pair_code(code)
+        key = self._key(tenant_id, normalized)
+        raw = await self._redis.get(key)
+        if raw is None:
+            raise PairCodeInvalidError("Pair code is invalid.")
+
+        record = self._deserialize(raw)
+        if record.expires_at <= _utcnow():
+            await self._redis.delete(key)
+            raise PairCodeExpiredError("Pair code has expired.")
+        if record.used_at is not None:
+            raise PairCodeUsedError("Pair code has already been used.")
+
+        ttl = await self._redis.ttl(key)
+        updated = replace(record, used_at=_utcnow())
+        if ttl is None or ttl <= 0:
+            ttl = max(1, int((record.expires_at - _utcnow()).total_seconds()))
+        await self._redis.set(key, self._serialize(updated), ex=ttl)
+        return updated
+
+    async def cleanup_expired_codes(self) -> int:
+        # Redis expiry handles cleanup for us.
+        return 0
+
+    @staticmethod
+    def _serialize(record: PairingRecord) -> str:
+        payload = asdict(record)
+        for key in ("created_at", "expires_at", "used_at"):
+            value = payload[key]
+            payload[key] = value.isoformat() if value is not None else None
+        return json.dumps(payload)
+
+    @staticmethod
+    def _deserialize(raw: Any) -> PairingRecord:
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        data = json.loads(raw)
+        for key in ("created_at", "expires_at", "used_at"):
+            if data.get(key):
+                data[key] = datetime.fromisoformat(data[key])
+            else:
+                data[key] = None
+        return PairingRecord(**data)

--- a/src/seeknal/ask/gateway/server.py
+++ b/src/seeknal/ask/gateway/server.py
@@ -24,6 +24,11 @@ from starlette.routing import Mount, Route, WebSocketRoute
 from starlette.staticfiles import StaticFiles
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
+from seeknal.ask.gateway.pairing import (
+    FilePairingStore,
+    PublicSessionStore,
+    TelegramLinkStore,
+)
 from seeknal.ask.gateway.session_manager import SessionManager
 from seeknal.ask.gateway.sse import SSEBroadcaster
 from seeknal.ask.gateway.tenant import (
@@ -884,16 +889,35 @@ def create_gateway_app(
             app.state.broadcaster = redis_broadcaster
             app.state.redis_client = redis_client
             app.state.redis_enabled = True
+            if project_path is not None:
+                app.state.pairing_store = FilePairingStore(Path(project_path).resolve())
+                app.state.telegram_link_store = TelegramLinkStore(Path(project_path).resolve())
+                app.state.public_session_store = PublicSessionStore(Path(project_path).resolve())
+            else:
+                pair_base = Path(app.state.sessions_dir).resolve().parent
+                app.state.pairing_store = FilePairingStore(base_dir=pair_base)
+                app.state.telegram_link_store = TelegramLinkStore(base_dir=pair_base)
+                app.state.public_session_store = PublicSessionStore(base_dir=pair_base)
             await redis_broadcaster.start_listener()
         else:
             app.state.broadcaster = sse_broadcaster
             app.state.redis_client = None
             app.state.redis_enabled = False
+            if project_path is not None:
+                app.state.pairing_store = FilePairingStore(Path(project_path).resolve())
+                app.state.telegram_link_store = TelegramLinkStore(Path(project_path).resolve())
+                app.state.public_session_store = PublicSessionStore(Path(project_path).resolve())
+            else:
+                pair_base = Path(app.state.sessions_dir).resolve().parent
+                app.state.pairing_store = FilePairingStore(base_dir=pair_base)
+                app.state.telegram_link_store = TelegramLinkStore(base_dir=pair_base)
+                app.state.public_session_store = PublicSessionStore(base_dir=pair_base)
 
         async def _eviction_loop():
             while True:
                 await asyncio.sleep(300)  # every 5 minutes
                 _evict_idle_locks()
+                await app.state.pairing_store.cleanup_expired_codes()
 
         eviction_task = asyncio.create_task(_eviction_loop())
         try:

--- a/src/seeknal/ask/gateway/static/chat.html
+++ b/src/seeknal/ask/gateway/static/chat.html
@@ -787,7 +787,6 @@ function escapeHtml(str) {
    DOM helpers
    ============================================================ */
 const messagesEl  = document.getElementById("messages");
-const emptyState  = document.getElementById("empty-state");
 const thinkingEl  = document.getElementById("thinking");
 const questionEl  = document.getElementById("question");
 const btnSend     = document.getElementById("btn-send");
@@ -796,6 +795,7 @@ const statusDot   = document.getElementById("status-dot");
 const statusLabel = document.getElementById("status-label");
 
 function hideEmpty() {
+  const emptyState = document.getElementById("empty-state");
   if (emptyState) emptyState.style.display = "none";
 }
 

--- a/src/seeknal/ask/prompt_builder.py
+++ b/src/seeknal/ask/prompt_builder.py
@@ -127,7 +127,8 @@ You have a small set of THIN data-access tools (execute_sql, list_tables,
 describe_table, get_entities, get_entity_schema, search_pipelines,
 read_pipeline, read_project_file, search_project_files, inspect_output,
 plan_pipeline, show_lineage, open_in_browser, read_proof_document, ask_user,
-submit_plan) plus a set of FAT skills loaded on demand via `load_skill`.
+submit_plan, execute_uv_script) plus a set of FAT skills loaded on demand via
+`load_skill`.
 
 When you start a multi-step workflow — generating a report, building a
 pipeline node, querying or saving a metric, publishing to Proof or to a
@@ -257,6 +258,13 @@ def _build_locale(config: dict[str, Any] | None = None, **kwargs: Any) -> str | 
     return get_locale_instructions(config)
 
 
+def _build_agent_profile(config: dict[str, Any] | None = None, **kwargs: Any) -> str | None:
+    if not config:
+        return None
+    from seeknal.ask.config import get_agent_profile_instructions
+    return get_agent_profile_instructions(config)
+
+
 def _build_environment(environment: str = "interactive", **kwargs: Any) -> str:
     lines = ["## Session Context", f"- Date: {datetime.now().strftime('%Y-%m-%d')}"]
 
@@ -316,6 +324,10 @@ def create_default_builder() -> PromptBuilder:
     builder.register(PromptSection(
         id="locale", tier=PromptTier.DYNAMIC, priority=60,
         builder=_build_locale,
+    ))
+    builder.register(PromptSection(
+        id="agent_profile", tier=PromptTier.DYNAMIC, priority=65,
+        builder=_build_agent_profile,
     ))
     builder.register(PromptSection(
         id="environment", tier=PromptTier.DYNAMIC, priority=70,

--- a/src/seeknal/ask/streaming.py
+++ b/src/seeknal/ask/streaming.py
@@ -161,7 +161,7 @@ def _show_tool_start(console: Console, name: str, args: Optional[dict] = None) -
     console.print(f"\n[bold]> {escape(name)}[/bold]")
     if args and name == "execute_sql" and "sql" in args:
         _show_sql(console, args["sql"])
-    elif args and name == "execute_python" and "code" in args:
+    elif args and name in ("execute_python", "execute_uv_script") and "code" in args:
         _show_python(console, args["code"])
     elif args and name == "generate_report" and "title" in args:
         console.print(f"  [dim]Title: {escape(args['title'])}[/dim]")
@@ -208,7 +208,7 @@ def _show_tool_end(console: Console, name: str, output: str) -> None:
         return
     if name == "execute_sql" and "|" in output:
         _show_sql_result_table(console, output)
-    elif name == "execute_python":
+    elif name in ("execute_python", "execute_uv_script"):
         _show_python_output(console, output)
     elif name == "generate_report":
         _show_report_output(console, output)

--- a/src/seeknal/cli/gateway.py
+++ b/src/seeknal/cli/gateway.py
@@ -103,7 +103,6 @@ def gateway_start(
     if temporal:
         try:
             from seeknal.ask.gateway.temporal import (
-                TEMPORAL_AVAILABLE,
                 _require_temporal,
             )
             _require_temporal()
@@ -122,6 +121,9 @@ def gateway_start(
     async def lifespan(app):
         # Startup: Telegram
         if telegram_channel is not None:
+            telegram_channel.set_pairing_store(app.state.pairing_store)
+            telegram_channel.set_link_store(app.state.telegram_link_store)
+            telegram_channel.set_public_session_store(app.state.public_session_store)
             app.state.telegram_channel = telegram_channel
             await telegram_channel.start()
 
@@ -158,7 +160,7 @@ def gateway_start(
                     ))
                 else:
                     typer.echo(typer.style(
-                        f"Temporal client-only mode (no local worker)",
+                        "Temporal client-only mode (no local worker)",
                         fg=typer.colors.GREEN,
                     ))
             else:
@@ -207,16 +209,16 @@ def gateway_start(
     typer.echo(f"Project: {project_path}")
     if redis:
         typer.echo(typer.style(f"Redis: {redis}", fg=typer.colors.GREEN))
-    typer.echo(f"Endpoints:")
-    typer.echo(f"  GET  /health")
-    typer.echo(f"  GET  /sessions")
-    typer.echo(f"  POST /ask")
-    typer.echo(f"  POST /upload")
-    typer.echo(f"  POST /record")
-    typer.echo(f"  POST /temporal/start")
-    typer.echo(f"  POST /internal/events/{{session_id}}/publish")
-    typer.echo(f"  WS   /ws/{{session_id}}")
-    typer.echo(f"  GET  /events/{{session_id}}")
+    typer.echo("Endpoints:")
+    typer.echo("  GET  /health")
+    typer.echo("  GET  /sessions")
+    typer.echo("  POST /ask")
+    typer.echo("  POST /upload")
+    typer.echo("  POST /record")
+    typer.echo("  POST /temporal/start")
+    typer.echo("  POST /internal/events/{session_id}/publish")
+    typer.echo("  WS   /ws/{session_id}")
+    typer.echo("  GET  /events/{session_id}")
 
     uvicorn.run(app, host=host, port=port, log_level="info")
 
@@ -419,7 +421,7 @@ def gateway_worker(
             max_concurrent_activities=max_activities,
         )
 
-        typer.echo(f"Seeknal worker started")
+        typer.echo("Seeknal worker started")
         typer.echo(f"  Project: {project_path}")
         typer.echo(f"  Temporal: {temporal_address}")
         typer.echo(f"  Queue: {temporal_task_queue}")

--- a/src/seeknal/cli/session.py
+++ b/src/seeknal/cli/session.py
@@ -3,6 +3,7 @@
 Manages persistent chat sessions stored in `.seeknal/sessions/`.
 """
 
+import asyncio
 from pathlib import Path
 from typing import Optional
 
@@ -13,6 +14,11 @@ from seeknal.ask.project import find_project_path
 session_app = typer.Typer(
     name="session",
     help="Manage persistent chat sessions.",
+    no_args_is_help=True,
+)
+public_app = typer.Typer(
+    name="public",
+    help="Manage a public session that Telegram can use without pairing.",
     no_args_is_help=True,
 )
 
@@ -116,3 +122,145 @@ def session_delete(
 
         store.delete(name)
         typer.echo(f"Session '{name}' deleted.")
+
+
+@session_app.command("pair")
+def session_pair(
+    name: str = typer.Argument(..., help="Existing session name to share"),
+    project: Optional[Path] = typer.Option(
+        None, "--project", help="Project path"
+    ),
+    ttl_minutes: int = typer.Option(
+        10, "--ttl-minutes", min=1, help="How long the pair code stays valid"
+    ),
+):
+    """Generate a one-time pair code for an existing session."""
+    project_path = project or find_project_path()
+
+    from seeknal.ask.gateway.pairing import FilePairingStore
+    from seeknal.ask.sessions import SessionStore
+
+    with SessionStore(project_path) as store:
+        session = store.get(name)
+
+    if session is None:
+        typer.echo(typer.style(f"Session '{name}' not found.", fg=typer.colors.RED))
+        raise typer.Exit(1)
+
+    pairing_store = FilePairingStore(project_path)
+    record = asyncio.run(
+        pairing_store.create_pair_code(
+            name,
+            ttl_seconds=ttl_minutes * 60,
+        )
+    )
+
+    typer.echo(f"Session:   {name}")
+    typer.echo(f"Pair code: {record.code}")
+    typer.echo(f"Expires:   {record.expires_at.isoformat()}")
+    typer.echo(
+        "Telegram:  "
+        + typer.style(f"/pair {record.code}", fg=typer.colors.CYAN)
+    )
+
+
+@session_app.command("paired")
+def session_paired(
+    project: Optional[Path] = typer.Option(
+        None, "--project", help="Project path"
+    ),
+    session_name: Optional[str] = typer.Option(
+        None, "--session", help="Filter by session name"
+    ),
+):
+    """List paired Telegram device/chat ids."""
+    project_path = project or find_project_path()
+
+    from seeknal.ask.gateway.pairing import TelegramLinkStore
+
+    link_store = TelegramLinkStore(project_path)
+    links = link_store.list_links(session_id=session_name)
+
+    if not links:
+        if session_name:
+            typer.echo(f"No paired Telegram device ids found for session '{session_name}'.")
+        else:
+            typer.echo("No paired Telegram device ids found.")
+        return
+
+    typer.echo(
+        f"{'Device ID':<18} {'Session':<25} {'Linked At'}"
+    )
+    typer.echo("-" * 72)
+    for item in links:
+        typer.echo(
+            f"{item.get('chat_id', ''):<18} "
+            f"{item.get('session_id', ''):<25} "
+            f"{item.get('linked_at', '')[:19]}"
+        )
+
+
+@public_app.command("set")
+def session_public_set(
+    name: str = typer.Argument(..., help="Session name to expose publicly"),
+    project: Optional[Path] = typer.Option(
+        None, "--project", help="Project path"
+    ),
+):
+    """Allow Telegram chats to use a session without pairing."""
+    project_path = project or find_project_path()
+
+    from seeknal.ask.gateway.pairing import PublicSessionStore
+    from seeknal.ask.sessions import SessionStore
+
+    with SessionStore(project_path) as store:
+        session = store.get(name)
+
+    if session is None:
+        typer.echo(typer.style(f"Session '{name}' not found.", fg=typer.colors.RED))
+        raise typer.Exit(1)
+
+    public_store = PublicSessionStore(project_path)
+    public_store.set_session(name)
+
+    typer.echo(f"Public Telegram session set to: {name}")
+
+
+@public_app.command("show")
+def session_public_show(
+    project: Optional[Path] = typer.Option(
+        None, "--project", help="Project path"
+    ),
+):
+    """Show the current public Telegram session."""
+    project_path = project or find_project_path()
+
+    from seeknal.ask.gateway.pairing import PublicSessionStore
+
+    public_store = PublicSessionStore(project_path)
+    session_id = public_store.get_session_id()
+    if not session_id:
+        typer.echo("No public Telegram session configured.")
+        return
+    typer.echo(f"Public Telegram session: {session_id}")
+
+
+@public_app.command("clear")
+def session_public_clear(
+    project: Optional[Path] = typer.Option(
+        None, "--project", help="Project path"
+    ),
+):
+    """Disable public Telegram access without pairing."""
+    project_path = project or find_project_path()
+
+    from seeknal.ask.gateway.pairing import PublicSessionStore
+
+    public_store = PublicSessionStore(project_path)
+    if public_store.clear():
+        typer.echo("Cleared public Telegram session.")
+    else:
+        typer.echo("No public Telegram session configured.")
+
+
+session_app.add_typer(public_app, name="public")

--- a/src/seeknal/pipeline/__init__.py
+++ b/src/seeknal/pipeline/__init__.py
@@ -62,6 +62,8 @@ from seeknal.pipeline.decorators import (
     clear_registry,
 )
 from seeknal.pipeline.context import PipelineContext
+from seeknal.pipeline.llm import PipelineLLM
+from seeknal.pipeline.state import PipelineState
 from seeknal.pipeline.feature_frame import FeatureFrame
 from seeknal.pipeline.materialization import (
     Materialization,
@@ -78,6 +80,8 @@ __all__ = [
     "second_order_aggregation",
     # Context
     "PipelineContext",
+    "PipelineLLM",
+    "PipelineState",
     # Feature Frame
     "FeatureFrame",
     # Materialization

--- a/src/seeknal/pipeline/context.py
+++ b/src/seeknal/pipeline/context.py
@@ -30,6 +30,10 @@ class PipelineContext:
         project_path: Path to the project root directory
         target_dir: Path to the target directory for outputs
         config: Profile configuration dict (from profiles.yml)
+        params: Resolved node parameters
+        node_id: Current node id
+        node_kind: Current node kind
+        node_meta: Current node metadata/config
         _duckdb_con: Internal DuckDB connection (lazy initialization)
         _node_outputs: Internal cache of node outputs
 
@@ -43,8 +47,14 @@ class PipelineContext:
     project_path: Path
     target_dir: Path
     config: dict
+    params: dict[str, Any] = field(default_factory=dict)
+    node_id: Optional[str] = None
+    node_kind: Optional[str] = None
+    node_meta: dict[str, Any] = field(default_factory=dict)
     _duckdb_con: Optional[Any] = field(default=None, repr=False)
     _node_outputs: dict = field(default_factory=dict, repr=False)
+    _state: Optional[Any] = field(default=None, repr=False)
+    _llm: Optional[Any] = field(default=None, repr=False)
 
     @property
     def duckdb(self) -> Any:
@@ -66,6 +76,31 @@ class PipelineContext:
             db_path = self.config.get("path", ":memory:")
             self._duckdb_con = duckdb.connect(db_path)
         return self._duckdb_con
+
+    @property
+    def state(self) -> Any:
+        """Return a per-node persistent JSON-backed state helper."""
+        if self._state is None:
+            from seeknal.pipeline.state import PipelineState
+
+            self._state = PipelineState(
+                target_dir=self.target_dir,
+                node_id=self.node_id,
+            )
+        return self._state
+
+    @property
+    def llm(self) -> Any:
+        """Return a lazily initialized Ask-aligned LLM helper."""
+        if self._llm is None:
+            from seeknal.pipeline.llm import PipelineLLM
+
+            self._llm = PipelineLLM.from_context(self)
+        return self._llm
+
+    def get_param(self, name: str, default: Any = None) -> Any:
+        """Return a node parameter with a default."""
+        return self.params.get(name, default)
 
     def ref(self, node_id: str) -> Any:
         """Reference another node's output.

--- a/src/seeknal/pipeline/llm.py
+++ b/src/seeknal/pipeline/llm.py
@@ -1,0 +1,104 @@
+"""Ask-aligned LLM helpers for Python pipelines."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+from seeknal.ask.agents.providers import resolve_provider_config
+
+
+@dataclass
+class PipelineLLM:
+    """Minimal text/JSON generation wrapper aligned with Seeknal Ask config."""
+
+    provider: str
+    model: str
+    api_key: str | None = None
+    base_url: str | None = None
+
+    @classmethod
+    def from_context(cls, ctx: Any) -> "PipelineLLM":
+        resolved = resolve_provider_config(
+            provider=ctx.get_param("llm_provider"),
+            model=ctx.get_param("llm_model"),
+            api_key=ctx.get_param("llm_api_key"),
+            base_url=ctx.get_param("llm_base_url"),
+        )
+        return cls(
+            provider=str(resolved["provider"]),
+            model=str(resolved["model"]),
+            api_key=resolved["api_key"],
+            base_url=resolved["base_url"],
+        )
+
+    def generate_text(self, prompt: str) -> str:
+        if self.provider == "google":
+            return self._generate_google_text(prompt)
+        if self.provider == "ollama":
+            return self._generate_ollama_text(prompt)
+        raise ValueError(f"Unsupported LLM provider: {self.provider}")
+
+    def generate_json(self, prompt: str, schema: type[Any] | dict[str, Any]) -> dict[str, Any]:
+        schema_instructions = self._schema_instructions(schema)
+        raw = self.generate_text(
+            f"{prompt}\n\nReturn valid JSON only.\n{schema_instructions}".strip()
+        )
+        parsed = self._parse_json_payload(raw)
+        if isinstance(schema, type) and hasattr(schema, "model_validate"):
+            return schema.model_validate(parsed).model_dump()
+        return parsed
+
+    def _generate_google_text(self, prompt: str) -> str:
+        if not self.api_key:
+            raise ValueError(
+                "Google API key required. Set GOOGLE_API_KEY or provide llm_api_key."
+            )
+        from google import genai
+
+        client = genai.Client(api_key=self.api_key)
+        response = client.models.generate_content(
+            model=self.model,
+            contents=prompt,
+        )
+        return (response.text or "").strip()
+
+    def _generate_ollama_text(self, prompt: str) -> str:
+        base_url = self.base_url or "http://localhost:11434"
+        response = httpx.post(
+            f"{base_url.rstrip('/')}/api/generate",
+            json={
+                "model": self.model,
+                "prompt": prompt,
+                "stream": False,
+            },
+            timeout=60.0,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return str(data.get("response", "")).strip()
+
+    @staticmethod
+    def _schema_instructions(schema: type[Any] | dict[str, Any]) -> str:
+        if isinstance(schema, dict):
+            return f"JSON schema: {json.dumps(schema, sort_keys=True)}"
+        if hasattr(schema, "model_json_schema"):
+            return f"JSON schema: {json.dumps(schema.model_json_schema(), sort_keys=True)}"
+        return "Return a JSON object."
+
+    @staticmethod
+    def _parse_json_payload(raw: str) -> dict[str, Any]:
+        text = raw.strip()
+        if text.startswith("```"):
+            lines = text.splitlines()
+            if lines:
+                lines = lines[1:]
+            if lines and lines[-1].strip() == "```":
+                lines = lines[:-1]
+            text = "\n".join(lines).strip()
+        parsed = json.loads(text)
+        if not isinstance(parsed, dict):
+            raise ValueError("Expected LLM to return a JSON object.")
+        return parsed

--- a/src/seeknal/pipeline/state.py
+++ b/src/seeknal/pipeline/state.py
@@ -1,0 +1,60 @@
+"""Persistent per-node state helpers for Python pipelines."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+def _default_node_key(node_id: str | None) -> str:
+    if not node_id:
+        return "adhoc"
+    return node_id.replace(".", "_")
+
+
+@dataclass
+class PipelineState:
+    """Tiny JSON-backed key-value store scoped to one pipeline node."""
+
+    target_dir: Path
+    node_id: str | None = None
+    _data: dict[str, Any] = field(default_factory=dict, repr=False)
+    _loaded: bool = field(default=False, repr=False)
+
+    @property
+    def path(self) -> Path:
+        return self.target_dir / "pipeline_state" / f"{_default_node_key(self.node_id)}.json"
+
+    def _ensure_loaded(self) -> None:
+        if self._loaded:
+            return
+        if self.path.exists():
+            try:
+                self._data = json.loads(self.path.read_text())
+            except Exception:
+                self._data = {}
+        self._loaded = True
+
+    def get(self, key: str, default: Any = None) -> Any:
+        self._ensure_loaded()
+        return self._data.get(key, default)
+
+    def set(self, key: str, value: Any) -> Any:
+        self._ensure_loaded()
+        self._data[key] = value
+        self.save()
+        return value
+
+    def delete(self, key: str) -> None:
+        self._ensure_loaded()
+        if key in self._data:
+            del self._data[key]
+            self.save()
+
+    def save(self) -> Path:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(self._data, indent=2, default=str))
+        return self.path
+

--- a/src/seeknal/workflow/draft.py
+++ b/src/seeknal/workflow/draft.py
@@ -165,6 +165,29 @@ def generate_filename(node_type: str, name: str, python: bool = False) -> str:
     return f"draft_{node_type}_{name}.{ext}"
 
 
+def normalize_python_deps(deps: Optional[list[str]] = None) -> list[str]:
+    """Normalize Python draft dependencies.
+
+    Rules:
+    - Preserve user order
+    - Remove blanks
+    - Deduplicate case-sensitively
+    - Ensure ``seeknal`` is present first so generated drafts can import the
+      local package when executed via ``uv run``
+    """
+    normalized: list[str] = []
+    seen: set[str] = set()
+
+    for dep in ["seeknal", *(deps or [])]:
+        value = dep.strip()
+        if not value or value in seen:
+            continue
+        normalized.append(value)
+        seen.add(value)
+
+    return normalized
+
+
 def render_template(template_env: Environment, node_type: str, name: str, description: Optional[str], python: bool = False, deps: Optional[list[str]] = None) -> str:
     """Render Jinja2 template.
 
@@ -193,7 +216,7 @@ def render_template(template_env: Environment, node_type: str, name: str, descri
     context = {
         "name": name,
         "description": description or f"{node_type.replace('_', ' ')} node",
-        "deps": deps or [],
+        "deps": normalize_python_deps(deps) if python else [],
     }
 
     return template.render(**context)

--- a/src/seeknal/workflow/dry_run.py
+++ b/src/seeknal/workflow/dry_run.py
@@ -707,7 +707,11 @@ def dry_run_python(file_path: Path, file_path_str: str, limit: int, timeout: int
             ctx = PipelineContext(
                 project_path=project_path,
                 target_dir=target_path,
-                config={}
+                config={},
+                params=dict(metadata.get("params", {}) or {}),
+                node_id=metadata.get("id"),
+                node_kind=metadata.get("kind"),
+                node_meta=dict(metadata),
             )
 
             # Import and execute the pipeline function

--- a/src/seeknal/workflow/executors/python_executor.py
+++ b/src/seeknal/workflow/executors/python_executor.py
@@ -379,6 +379,14 @@ class PythonExecutor(BaseExecutor):
 
         file_path = Path(self.node.file_path)
         func_name = self.node.name
+        node_kind = (
+            self.node.node_type.value
+            if hasattr(self.node.node_type, "value")
+            else str(self.node.node_type)
+        )
+        node_params = dict(self.node.config.get("params", {}))
+        if self.context.params:
+            node_params = {**node_params, **self.context.params}
 
         # Read original file to preserve PEP 723 header, but remove seeknal from deps
         # since we're adding sys.path and seeknal is a local package
@@ -407,6 +415,10 @@ ctx = PipelineContext(
     project_path=Path("{self.context.workspace_path}"),
     target_dir=Path("{self.context.target_path}"),
     config={self.node.config.get("profile_config", {})},
+    params={node_params!r},
+    node_id="{self.node.id}",
+    node_kind="{node_kind}",
+    node_meta={self.node.config!r},
 )
 
 try:

--- a/src/seeknal/workflow/executors/transform_executor.py
+++ b/src/seeknal/workflow/executors/transform_executor.py
@@ -1156,7 +1156,15 @@ class TransformExecutor(BaseExecutor):
             ctx = PipelineContext(
                 project_path=project_path,
                 target_dir=target_path,
-                config={}
+                config={},
+                params=dict(self.node.config.get("params", {})),
+                node_id=self.node.id,
+                node_kind=(
+                    self.node.node_type.value
+                    if hasattr(self.node.node_type, "value")
+                    else str(self.node.node_type)
+                ),
+                node_meta=dict(self.node.config),
             )
 
             # Execute the function

--- a/src/seeknal/workflow/semantic/models.py
+++ b/src/seeknal/workflow/semantic/models.py
@@ -88,6 +88,7 @@ class Measure:
     agg: AggregationType
     description: Optional[str] = None
     filters: list[str] = field(default_factory=list)
+    aliases: list[str] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "Measure":
@@ -109,6 +110,7 @@ class Measure:
             agg=AggregationType(agg_value),
             description=data.get("description"),
             filters=[f for f in filters if f],
+            aliases=[str(alias) for alias in data.get("aliases", []) if str(alias)],
         )
 
 
@@ -302,6 +304,7 @@ class Metric:
     type: MetricType
     description: Optional[str] = None
     filter: Optional[str] = None
+    aliases: list[str] = field(default_factory=list)
 
     # simple / cumulative
     measure: Optional[str] = None
@@ -324,6 +327,7 @@ class Metric:
             type=MetricType(data["type"]),
             description=data.get("description"),
             filter=data.get("filter"),
+            aliases=[str(alias) for alias in data.get("aliases", []) if str(alias)],
             measure=data.get("measure"),
             numerator=data.get("numerator"),
             denominator=data.get("denominator"),

--- a/tests/ask/test_apply_draft.py
+++ b/tests/ask/test_apply_draft.py
@@ -1,0 +1,51 @@
+"""Tests for apply_draft tool."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from seeknal.ask.agents.tools.apply_draft import apply_draft
+
+
+class _Lock:
+    def __enter__(self):
+        return None
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_apply_draft_semantic_model_moves_to_semantic_models(tmp_path, monkeypatch):
+    draft_dir = tmp_path / ".seeknal" / "drafts"
+    draft_dir.mkdir(parents=True)
+    draft_path = draft_dir / "draft_semantic_model_competitive_signals.yml"
+    draft_path.write_text(
+        "kind: semantic_model\n"
+        "name: competitive_signals\n"
+        "description: Test semantic model\n"
+        "model: ref('transform.signals_enriched')\n"
+    )
+
+    ctx = SimpleNamespace(
+        project_path=tmp_path,
+        fs_lock=_Lock(),
+        artifact_discovery=SimpleNamespace(refresh=lambda: None),
+    )
+    monkeypatch.setattr(
+        "seeknal.ask.agents.tools._context.get_tool_context",
+        lambda: ctx,
+    )
+    monkeypatch.setattr(
+        "seeknal.ask.agents.tools._write_security.validate_draft_path",
+        lambda file_path, project_path: draft_path,
+    )
+
+    result = asyncio.run(
+        apply_draft(str(draft_path), confirmed=True)
+    )
+
+    target = tmp_path / "seeknal" / "semantic_models" / "competitive_signals.yml"
+    assert target.exists()
+    assert "seeknal/semantic_models/competitive_signals.yml" in result
+

--- a/tests/ask/test_config.py
+++ b/tests/ask/test_config.py
@@ -5,7 +5,12 @@ from pathlib import Path
 
 import pytest
 
-from seeknal.ask.config import get_locale_instructions, load_agent_config
+from seeknal.ask.config import (
+    find_agent_config_path,
+    get_agent_profile_instructions,
+    get_locale_instructions,
+    load_agent_config,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -29,6 +34,25 @@ def test_load_valid_yaml(tmp_path: Path):
     config = load_agent_config(tmp_path)
     assert config["model"] == "gemini-3-flash-preview"
     assert config["locale"]["currency"] == "IDR"
+
+
+def test_load_nested_seeknal_yaml(tmp_path: Path):
+    nested = tmp_path / "seeknal"
+    nested.mkdir()
+    (nested / "seeknal_agent.yml").write_text("agent:\n  name: Nested config\n")
+
+    config = load_agent_config(tmp_path)
+    assert config["agent"]["name"] == "Nested config"
+
+
+def test_root_config_precedence_over_nested(tmp_path: Path):
+    (tmp_path / "seeknal_agent.yml").write_text("agent:\n  name: Root config\n")
+    nested = tmp_path / "seeknal"
+    nested.mkdir()
+    (nested / "seeknal_agent.yml").write_text("agent:\n  name: Nested config\n")
+
+    assert find_agent_config_path(tmp_path) == tmp_path / "seeknal_agent.yml"
+    assert load_agent_config(tmp_path)["agent"]["name"] == "Root config"
 
 
 def test_load_empty_yaml(tmp_path: Path):
@@ -99,3 +123,24 @@ def test_locale_full_config():
     assert "Indonesian" in result
     assert "id_ID" in result
     assert "Asia/Jakarta" in result
+
+
+def test_agent_profile_none_when_missing():
+    assert get_agent_profile_instructions({}) is None
+
+
+def test_agent_profile_instructions_from_agent_section():
+    config = {
+        "agent": {
+            "name": "CBN CI",
+            "description": "Competitive analyst",
+            "skills": ["competitive_intel"],
+            "system_prompt": "Lead with the threat matrix.",
+        }
+    }
+    result = get_agent_profile_instructions(config)
+    assert result is not None
+    assert "CBN CI" in result
+    assert "Competitive analyst" in result
+    assert "competitive_intel" in result
+    assert "Lead with the threat matrix." in result

--- a/tests/ask/test_draft_node.py
+++ b/tests/ask/test_draft_node.py
@@ -1,0 +1,70 @@
+"""Tests for ask draft_node tool."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import seeknal.ask.agents.tools.draft_node as draft_node_module
+from seeknal.workflow.draft import normalize_python_deps
+
+
+def test_normalize_python_deps_preserves_order_and_includes_seeknal():
+    assert normalize_python_deps(["httpx", "pandas"]) == [
+        "seeknal",
+        "httpx",
+        "pandas",
+    ]
+
+
+def test_normalize_python_deps_deduplicates_and_strips_blanks():
+    assert normalize_python_deps(["", "seeknal", "httpx", "httpx", " pandas "]) == [
+        "seeknal",
+        "httpx",
+        "pandas",
+    ]
+
+
+def test_draft_node_python_renders_pep723_deps(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    ctx = SimpleNamespace(project_path=tmp_path, fs_lock=SimpleNamespace(__enter__=lambda self: None, __exit__=lambda self, exc_type, exc, tb: False))
+
+    class _Lock:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    ctx.fs_lock = _Lock()
+
+    monkeypatch.setattr(
+        "seeknal.ask.agents.tools._context.get_tool_context",
+        lambda: ctx,
+    )
+    monkeypatch.setattr(
+        "seeknal.ask.agents.tools._write_security.get_drafts_dir",
+        lambda project_path: (project_path / ".seeknal" / "drafts"),
+    )
+
+    (tmp_path / ".seeknal" / "drafts").mkdir(parents=True, exist_ok=True)
+
+    result = asyncio.run(
+        draft_node_module.draft_node(
+            "transform",
+            "fetch_pages",
+            python=True,
+            deps=["httpx", "pandas", "httpx"],
+        )
+    )
+
+    draft_path = tmp_path / ".seeknal" / "drafts" / "draft_transform_fetch_pages.py"
+    assert draft_path.exists()
+    content = draft_path.read_text()
+
+    assert "Created draft: draft_transform_fetch_pages.py" in result
+    assert '#     "seeknal",' in content
+    assert '#     "httpx",' in content
+    assert '#     "pandas",' in content
+    assert content.count('"httpx"') == 1

--- a/tests/ask/test_execute_uv_script.py
+++ b/tests/ask/test_execute_uv_script.py
@@ -1,0 +1,39 @@
+"""Tests for execute_uv_script tool."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+from seeknal.ask.agents.tools.execute_uv_script import execute_uv_script
+
+
+def test_execute_uv_script_requires_uv(monkeypatch):
+    monkeypatch.setattr("seeknal.ask.agents.tools.execute_uv_script.shutil.which", lambda cmd: None)
+
+    result = asyncio.run(execute_uv_script("print('hello')"))
+    assert "uv is required" in result
+
+
+def test_execute_uv_script_formats_structured_result(monkeypatch, tmp_path):
+    monkeypatch.setattr("seeknal.ask.agents.tools.execute_uv_script.shutil.which", lambda cmd: "/usr/bin/uv")
+    monkeypatch.setattr(
+        "seeknal.ask.agents.tools.execute_uv_script.get_tool_context",
+        lambda: SimpleNamespace(project_path=tmp_path, session_id="abc123"),
+    )
+
+    class Result:
+        returncode = 0
+        stdout = json.dumps({"stdout": "hello\n", "value": {"ok": True}, "error": None, "plots": []})
+        stderr = ""
+
+    monkeypatch.setattr(
+        "seeknal.ask.agents.tools.execute_uv_script.subprocess.run",
+        lambda *args, **kwargs: Result(),
+    )
+
+    result = asyncio.run(execute_uv_script("print('hello')", deps=["httpx", "httpx"]))
+    assert "hello" in result
+    assert "{'ok': True}" in result or '"ok": true' in result.lower()
+

--- a/tests/ask/test_gateway_pairing.py
+++ b/tests/ask/test_gateway_pairing.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import asyncio
+import re
+from dataclasses import replace
+from datetime import timedelta
+from pathlib import Path
+
+from starlette.testclient import TestClient
+
+from seeknal.ask.gateway.pairing import (
+    FilePairingStore,
+    PairCodeExpiredError,
+    PairCodeUsedError,
+    PublicSessionStore,
+    TelegramLinkStore,
+    normalize_pair_code,
+)
+from seeknal.ask.gateway.server import create_gateway_app
+
+
+def test_normalize_pair_code_accepts_spaces_and_case():
+    assert normalize_pair_code(" Calm River 315 ") == "calm-river-315"
+    assert normalize_pair_code("CALM_river_315") == "calm-river-315"
+
+
+def test_file_pairing_store_creates_human_readable_code(tmp_path):
+    store = FilePairingStore(tmp_path)
+
+    record = asyncio.run(store.create_pair_code("telegram-123"))
+
+    assert re.fullmatch(r"[a-z]+-[a-z]+-\d{3}", record.code)
+    assert record.session_id == "telegram-123"
+    redeemed = asyncio.run(store.redeem_pair_code(record.code))
+    assert redeemed.session_id == "telegram-123"
+    assert redeemed.used_at is not None
+
+
+def test_file_pairing_store_rejects_expired_and_used_codes(tmp_path):
+    store = FilePairingStore(tmp_path)
+    record = asyncio.run(store.create_pair_code("telegram-123"))
+
+    asyncio.run(store.redeem_pair_code(record.code))
+    try:
+        asyncio.run(store.redeem_pair_code(record.code))
+    except PairCodeUsedError:
+        pass
+    else:
+        raise AssertionError("Expected used code redemption to fail")
+
+    fresh = asyncio.run(store.create_pair_code("telegram-456"))
+    path = store._record_path(fresh.tenant_id, fresh.code)  # noqa: SLF001
+    path.write_text(
+        store._serialize(replace(  # noqa: SLF001
+            fresh,
+            expires_at=fresh.created_at - timedelta(seconds=1),
+        )),
+        encoding="utf-8",
+    )
+    try:
+        asyncio.run(store.redeem_pair_code(fresh.code))
+    except PairCodeExpiredError:
+        pass
+    else:
+        raise AssertionError("Expected expired code redemption to fail")
+
+
+def test_telegram_link_store_persists_mapping(tmp_path):
+    store = TelegramLinkStore(tmp_path)
+    assert store.get_session_id("123") is None
+
+    store.link_chat("123", "existing-session")
+
+    assert store.get_session_id("123") == "existing-session"
+
+
+def test_telegram_link_store_lists_links(tmp_path):
+    store = TelegramLinkStore(tmp_path)
+    store.link_chat("123", "session-a")
+    store.link_chat("456", "session-b")
+
+    all_links = store.list_links()
+    assert len(all_links) == 2
+    assert {item["chat_id"] for item in all_links} == {"123", "456"}
+
+    session_a_links = store.list_links(session_id="session-a")
+    assert len(session_a_links) == 1
+    assert session_a_links[0]["chat_id"] == "123"
+
+
+def test_public_session_store_round_trip(tmp_path):
+    store = PublicSessionStore(tmp_path)
+    assert store.get_session_id() is None
+
+    store.set_session("public-session")
+    assert store.get_session_id() == "public-session"
+    assert store.clear() is True
+    assert store.get_session_id() is None
+
+
+def test_gateway_app_initializes_telegram_link_store(tmp_path):
+    app = create_gateway_app(tmp_path)
+    with TestClient(app) as client:
+        assert client.app.state.telegram_link_store is not None
+        assert client.app.state.public_session_store is not None
+
+
+def test_chat_ui_no_longer_contains_browser_pairing_controls():
+    html = Path("src/seeknal/ask/gateway/static/chat.html").read_text(encoding="utf-8")
+
+    assert 'id="btn-pair-session"' not in html
+    assert 'id="pair-code"' not in html
+    assert "/pair/redeem" not in html

--- a/tests/ask/test_prompt_builder.py
+++ b/tests/ask/test_prompt_builder.py
@@ -13,6 +13,7 @@ from seeknal.ask.prompt_builder import (
     _build_workflow,
     _build_memory,
     _build_locale,
+    _build_agent_profile,
     _build_environment,
 )
 
@@ -166,6 +167,20 @@ class TestSectionBuilders:
         assert result is not None
         assert "IDR" in result
 
+    def test_agent_profile_returns_content_with_agent_config(self):
+        config = {
+            "agent": {
+                "name": "CBN Competitive Intelligence",
+                "skills": ["competitive_intel"],
+                "system_prompt": "Focus on actionable threats.",
+            }
+        }
+        result = _build_agent_profile(config=config)
+        assert result is not None
+        assert "CBN Competitive Intelligence" in result
+        assert "competitive_intel" in result
+        assert "Focus on actionable threats." in result
+
     def test_environment_interactive(self):
         result = _build_environment(environment="interactive")
         assert "Interactive terminal" in result
@@ -193,7 +208,7 @@ class TestSectionBuilders:
 class TestDefaultBuilder:
     def test_creates_builder_with_all_sections(self):
         builder = create_default_builder()
-        assert len(builder._sections) == 6
+        assert len(builder._sections) == 7
 
     def test_interactive_includes_asking_questions(self):
         builder = create_default_builder()
@@ -226,3 +241,16 @@ class TestDefaultBuilder:
         # occurrence which is the dedicated section, not inline mentions.
         memory_section_pos = result.rindex("## Memory")
         assert memory_section_pos > boundary_pos
+
+    def test_agent_profile_section_included_when_configured(self):
+        builder = create_default_builder()
+        result = builder.build(
+            config={
+                "agent": {
+                    "name": "Custom Analyst",
+                    "system_prompt": "Prioritize pricing changes.",
+                }
+            }
+        )
+        assert "Custom Analyst" in result
+        assert "Prioritize pricing changes." in result

--- a/tests/ask/test_session_cli.py
+++ b/tests/ask/test_session_cli.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from seeknal.cli.session import session_app
+
+
+runner = CliRunner()
+
+
+def test_session_pair_generates_code_for_existing_session(tmp_path):
+    from seeknal.ask.sessions import SessionStore
+
+    with SessionStore(tmp_path) as store:
+        store.create("existing-session")
+
+    result = runner.invoke(
+        session_app,
+        ["pair", "existing-session", "--project", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0
+    assert "Pair code:" in result.output
+    assert "/pair " in result.output
+
+
+def test_session_pair_rejects_missing_session(tmp_path):
+    result = runner.invoke(
+        session_app,
+        ["pair", "missing-session", "--project", str(tmp_path)],
+    )
+
+    assert result.exit_code == 1
+    assert "not found" in result.output.lower()
+
+
+def test_session_paired_lists_device_ids(tmp_path):
+    from seeknal.ask.gateway.pairing import TelegramLinkStore
+
+    link_store = TelegramLinkStore(tmp_path)
+    link_store.link_chat("12345", "existing-session")
+
+    result = runner.invoke(
+        session_app,
+        ["paired", "--project", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0
+    assert "Device ID" in result.output
+    assert "12345" in result.output
+    assert "existing-session" in result.output
+
+
+def test_session_paired_filters_by_session(tmp_path):
+    from seeknal.ask.gateway.pairing import TelegramLinkStore
+
+    link_store = TelegramLinkStore(tmp_path)
+    link_store.link_chat("12345", "session-a")
+    link_store.link_chat("67890", "session-b")
+
+    result = runner.invoke(
+        session_app,
+        ["paired", "--project", str(tmp_path), "--session", "session-a"],
+    )
+
+    assert result.exit_code == 0
+    assert "12345" in result.output
+    assert "session-a" in result.output
+    assert "67890" not in result.output
+
+
+def test_session_public_set_show_and_clear(tmp_path):
+    from seeknal.ask.sessions import SessionStore
+
+    with SessionStore(tmp_path) as store:
+        store.create("public-session")
+
+    set_result = runner.invoke(
+        session_app,
+        ["public", "set", "public-session", "--project", str(tmp_path)],
+    )
+    assert set_result.exit_code == 0
+    assert "public-session" in set_result.output
+
+    show_result = runner.invoke(
+        session_app,
+        ["public", "show", "--project", str(tmp_path)],
+    )
+    assert show_result.exit_code == 0
+    assert "public-session" in show_result.output
+
+    clear_result = runner.invoke(
+        session_app,
+        ["public", "clear", "--project", str(tmp_path)],
+    )
+    assert clear_result.exit_code == 0
+    assert "Cleared" in clear_result.output

--- a/tests/ask/test_telegram_channel.py
+++ b/tests/ask/test_telegram_channel.py
@@ -6,6 +6,11 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+# Skip when python-telegram-bot isn't installed (seeknal[telegram] extra).
+# The handler methods under test call `from telegram.constants import ChatAction`
+# at runtime, so without the extra the tests fail mid-execution.
+pytest.importorskip("telegram")
+
 from seeknal.ask.gateway.pairing import PublicSessionStore, TelegramLinkStore
 from seeknal.ask.gateway.channels.telegram import TelegramChannel
 from seeknal.ask.gateway.tenant import DEFAULT_TENANT

--- a/tests/ask/test_telegram_channel.py
+++ b/tests/ask/test_telegram_channel.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from seeknal.ask.gateway.pairing import PublicSessionStore, TelegramLinkStore
+from seeknal.ask.gateway.channels.telegram import TelegramChannel
+from seeknal.ask.gateway.tenant import DEFAULT_TENANT
+
+
+@pytest.mark.asyncio
+async def test_handle_pair_redeems_code_and_links_chat(tmp_path):
+    channel = TelegramChannel(Path(tmp_path), token="token")
+    pairing_store = AsyncMock()
+    pairing_store.redeem_pair_code.return_value = SimpleNamespace(
+        code="calm-river-315",
+        session_id="existing-session",
+    )
+    channel.set_pairing_store(pairing_store)
+    link_store = TelegramLinkStore(tmp_path)
+    channel.set_link_store(link_store)
+
+    update = SimpleNamespace(
+        effective_chat=SimpleNamespace(id=12345),
+        message=SimpleNamespace(reply_text=AsyncMock()),
+    )
+    context = SimpleNamespace(args=["calm-river-315"])
+
+    await channel._handle_pair(update, context)
+
+    pairing_store.redeem_pair_code.assert_awaited_once_with(
+        "calm-river-315",
+        tenant_id=DEFAULT_TENANT,
+    )
+    assert link_store.get_session_id("12345") == "existing-session"
+    update.message.reply_text.assert_awaited_once()
+    assert "existing-session" in update.message.reply_text.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_handle_pair_reports_when_pairing_store_missing(tmp_path):
+    channel = TelegramChannel(Path(tmp_path), token="token")
+    update = SimpleNamespace(
+        effective_chat=SimpleNamespace(id=12345),
+        message=SimpleNamespace(reply_text=AsyncMock()),
+    )
+
+    await channel._handle_pair(update, None)
+
+    update.message.reply_text.assert_awaited_once()
+    assert "not available" in update.message.reply_text.await_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_handle_pair_requires_code_argument(tmp_path):
+    channel = TelegramChannel(Path(tmp_path), token="token")
+    channel.set_pairing_store(AsyncMock())
+    channel.set_link_store(TelegramLinkStore(tmp_path))
+    update = SimpleNamespace(
+        effective_chat=SimpleNamespace(id=12345),
+        message=SimpleNamespace(reply_text=AsyncMock()),
+    )
+
+    await channel._handle_pair(update, SimpleNamespace(args=[]))
+
+    update.message.reply_text.assert_awaited_once()
+    assert "ask the admin" in update.message.reply_text.await_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_handle_message_uses_linked_session_id(tmp_path):
+    channel = TelegramChannel(Path(tmp_path), token="token")
+    link_store = TelegramLinkStore(tmp_path)
+    link_store.link_chat("12345", "existing-session")
+    channel.set_link_store(link_store)
+    channel._run_agent = AsyncMock(return_value="done")
+
+    update = SimpleNamespace(
+        effective_chat=SimpleNamespace(id=12345, send_action=AsyncMock()),
+        message=SimpleNamespace(
+            text="hello",
+            reply_text=AsyncMock(return_value=SimpleNamespace(delete=AsyncMock(), edit_text=AsyncMock())),
+        ),
+    )
+
+    await channel._handle_message(update, None)
+
+    channel._run_agent.assert_awaited()
+    assert channel._run_agent.await_args.args[0] == "existing-session"
+
+
+@pytest.mark.asyncio
+async def test_handle_message_requires_pairing_first(tmp_path):
+    channel = TelegramChannel(Path(tmp_path), token="token")
+    channel.set_link_store(TelegramLinkStore(tmp_path))
+    channel._run_agent = AsyncMock(return_value="done")
+
+    update = SimpleNamespace(
+        effective_chat=SimpleNamespace(id=12345, send_action=AsyncMock()),
+        message=SimpleNamespace(
+            text="hello",
+            reply_text=AsyncMock(),
+        ),
+    )
+
+    await channel._handle_message(update, None)
+
+    channel._run_agent.assert_not_awaited()
+    update.effective_chat.send_action.assert_not_awaited()
+    update.message.reply_text.assert_awaited_once()
+    assert "not paired yet" in update.message.reply_text.await_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_handle_message_uses_public_session_when_configured(tmp_path):
+    channel = TelegramChannel(Path(tmp_path), token="token")
+    channel.set_link_store(TelegramLinkStore(tmp_path))
+    public_store = PublicSessionStore(tmp_path)
+    public_store.set_session("public-session")
+    channel.set_public_session_store(public_store)
+    channel._run_agent = AsyncMock(return_value="done")
+
+    update = SimpleNamespace(
+        effective_chat=SimpleNamespace(id=12345, send_action=AsyncMock()),
+        message=SimpleNamespace(
+            text="hello",
+            reply_text=AsyncMock(return_value=SimpleNamespace(delete=AsyncMock(), edit_text=AsyncMock())),
+        ),
+    )
+
+    await channel._handle_message(update, None)
+
+    channel._run_agent.assert_awaited()
+    assert channel._run_agent.await_args.args[0] == "public-session"

--- a/tests/ask/test_temporal_integration.py
+++ b/tests/ask/test_temporal_integration.py
@@ -9,11 +9,9 @@ dev server (``temporal server start-dev``).
 
 from __future__ import annotations
 
-import asyncio
 import json
 from dataclasses import asdict
-from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -22,7 +20,6 @@ from seeknal.ask.gateway.server import (
     _publish_event,
     _run_agent_streaming,
     create_gateway_app,
-    sse_broadcaster,
 )
 from seeknal.ask.gateway.sse import SSEBroadcaster
 from seeknal.ask.gateway.temporal import (
@@ -287,15 +284,16 @@ class TestTemporalWorkerFactory:
         )
 
         mock_client = MagicMock()
+        expected_worker = MagicMock()
         with patch(
-            "seeknal.ask.gateway.temporal.Worker"
-        ) as mock_worker_cls:
-            mock_worker_cls.return_value = MagicMock(name="worker")
+            "seeknal.ask.gateway.temporal.Worker",
+            return_value=expected_worker,
+        ) as worker_cls:
             worker = create_temporal_worker(mock_client, task_queue="test-queue")
 
-        assert worker is not None
-        mock_worker_cls.assert_called_once()
-        _, kwargs = mock_worker_cls.call_args
+        assert worker is expected_worker
+        worker_cls.assert_called_once()
+        _, kwargs = worker_cls.call_args
         assert kwargs["task_queue"] == "test-queue"
         assert AgentWorkflow in kwargs["workflows"]
         assert run_agent_activity in kwargs["activities"]

--- a/tests/workflow/test_pipeline_runtime_helpers.py
+++ b/tests/workflow/test_pipeline_runtime_helpers.py
@@ -1,0 +1,105 @@
+"""Tests for PipelineContext runtime helpers."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from seeknal.pipeline.context import PipelineContext
+from seeknal.pipeline.llm import PipelineLLM
+
+
+def test_context_get_param_and_metadata(tmp_path):
+    ctx = PipelineContext(
+        project_path=tmp_path,
+        target_dir=tmp_path / "target",
+        config={},
+        params={"timeout": 30},
+        node_id="transform.fetch_pages",
+        node_kind="transform",
+        node_meta={"params": {"timeout": 30}},
+    )
+
+    assert ctx.get_param("timeout") == 30
+    assert ctx.get_param("missing", "fallback") == "fallback"
+    assert ctx.node_id == "transform.fetch_pages"
+    assert ctx.node_kind == "transform"
+    assert ctx.node_meta["params"]["timeout"] == 30
+
+
+def test_pipeline_state_roundtrip(tmp_path):
+    ctx = PipelineContext(
+        project_path=tmp_path,
+        target_dir=tmp_path / "target",
+        config={},
+        node_id="transform.fetch_pages",
+    )
+
+    assert ctx.state.get("etag") is None
+    ctx.state.set("etag", "abc123")
+    assert ctx.state.get("etag") == "abc123"
+
+    state_path = tmp_path / "target" / "pipeline_state" / "transform_fetch_pages.json"
+    assert state_path.exists()
+    assert json.loads(state_path.read_text())["etag"] == "abc123"
+
+
+def test_pipeline_llm_from_context_google(monkeypatch, tmp_path):
+    monkeypatch.setenv("SEEKNAL_ASK_LLM_PROVIDER", "google")
+    monkeypatch.setenv("SEEKNAL_ASK_MODEL", "gemini-2.5-pro")
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+
+    ctx = PipelineContext(project_path=tmp_path, target_dir=tmp_path / "target", config={})
+    llm = PipelineLLM.from_context(ctx)
+
+    assert llm.provider == "google"
+    assert llm.model == "gemini-2.5-pro"
+    assert llm.api_key == "test-key"
+
+
+def test_pipeline_llm_from_context_prefers_params(monkeypatch, tmp_path):
+    monkeypatch.setenv("SEEKNAL_ASK_LLM_PROVIDER", "google")
+    monkeypatch.setenv("SEEKNAL_ASK_MODEL", "gemini-2.5-flash")
+
+    ctx = PipelineContext(
+        project_path=tmp_path,
+        target_dir=tmp_path / "target",
+        config={},
+        params={
+            "llm_provider": "ollama",
+            "llm_model": "llama3.2",
+            "llm_base_url": "http://ollama.internal:11434",
+        },
+    )
+    llm = PipelineLLM.from_context(ctx)
+
+    assert llm.provider == "ollama"
+    assert llm.model == "llama3.2"
+    assert llm.base_url == "http://ollama.internal:11434"
+
+
+def test_pipeline_llm_generate_json_strips_code_fences(monkeypatch):
+    llm = PipelineLLM(provider="ollama", model="llama3.1")
+    monkeypatch.setattr(
+        llm,
+        "generate_text",
+        lambda prompt: '```json\n{"summary":"ok","confidence":0.9}\n```',
+    )
+
+    result = llm.generate_json("hello", {"type": "object"})
+    assert result == {"summary": "ok", "confidence": 0.9}
+
+
+def test_pipeline_llm_google_requires_key(monkeypatch, tmp_path):
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    ctx = PipelineContext(
+        project_path=tmp_path,
+        target_dir=tmp_path / "target",
+        config={},
+        params={"llm_provider": "google", "llm_model": "gemini-2.5-flash"},
+    )
+    llm = PipelineLLM.from_context(ctx)
+
+    with pytest.raises(ValueError, match="Google API key required"):
+        llm.generate_text("hello")

--- a/tests/workflow/test_python_executor_runtime_context.py
+++ b/tests/workflow/test_python_executor_runtime_context.py
@@ -1,0 +1,45 @@
+"""Tests for PythonExecutor runtime context injection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from seeknal.dag.manifest import Node, NodeType
+from seeknal.workflow.executors.base import ExecutionContext
+from seeknal.workflow.executors.python_executor import PythonExecutor
+
+
+def test_generate_runner_script_injects_params_and_node_metadata(tmp_path):
+    pipeline_file = tmp_path / "fetch_pages.py"
+    pipeline_file.write_text(
+        "# /// script\n# requires-python = \">=3.11\"\n# dependencies = [\n#     \"seeknal\",\n# ]\n# ///\n"
+        "from seeknal.pipeline import transform\n\n"
+        "@transform(name='fetch_pages')\n"
+        "def fetch_pages(ctx):\n"
+        "    return []\n"
+    )
+
+    node = Node(
+        id="transform.fetch_pages",
+        name="fetch_pages",
+        node_type=NodeType.TRANSFORM,
+        config={
+            "params": {"timeout": 15},
+            "profile_config": {"path": ":memory:"},
+        },
+        file_path=str(pipeline_file),
+    )
+    context = ExecutionContext(
+        project_name="test_project",
+        workspace_path=tmp_path,
+        target_path=tmp_path / "target",
+        params={"session_name": "nightly"},
+    )
+
+    script = PythonExecutor(node, context)._generate_runner_script()
+
+    assert "params={'timeout': 15, 'session_name': 'nightly'}" in script
+    assert 'node_id="transform.fetch_pages"' in script
+    assert 'node_kind="transform"' in script
+    assert "node_meta={'params': {'timeout': 15}, 'profile_config': {'path': ':memory:'}}" in script
+

--- a/tests/workflow/test_semantic.py
+++ b/tests/workflow/test_semantic.py
@@ -1,4 +1,6 @@
 """Tests for semantic layer models, parsing, and validation."""
+from pathlib import Path
+
 import pytest
 import yaml
 
@@ -18,6 +20,7 @@ from seeknal.workflow.semantic.models import (
     parse_metric_yaml,
     parse_semantic_model_yaml,
 )
+from seeknal.workflow.semantic.loader import load_semantic_layer
 from seeknal.dag.manifest import NodeType
 from seeknal.dag.parser import ProjectParser
 
@@ -85,6 +88,14 @@ class TestMeasure:
     def test_default_expr(self):
         m = Measure.from_dict({"name": "total", "agg": "sum"})
         assert m.expr == "total"  # defaults to name
+
+    def test_measure_aliases(self):
+        m = Measure.from_dict({
+            "name": "signal_count",
+            "agg": "count",
+            "aliases": ["Signals", "Total Signals"],
+        })
+        assert m.aliases == ["Signals", "Total Signals"]
 
 
 # ── SemanticModel Tests ─────────────────────────────────────────────────────
@@ -199,10 +210,12 @@ class TestMetric:
             "type": "simple",
             "measure": "revenue",
             "filter": "status != 'refunded'",
+            "aliases": ["Revenue"],
         })
         assert m.type == MetricType.SIMPLE
         assert m.measure == "revenue"
         assert m.filter == "status != 'refunded'"
+        assert m.aliases == ["Revenue"]
 
     def test_ratio_metric(self):
         m = Metric.from_dict({
@@ -516,6 +529,47 @@ class TestYamlParsingHelpers:
         })
         assert m.name == "total_revenue"
         assert m.type == MetricType.SIMPLE
+
+
+class TestSemanticLayerLoader:
+    def test_auto_generated_metrics_handle_missing_measure_aliases(self, tmp_path: Path):
+        semantic_dir = tmp_path / "seeknal" / "semantic_models"
+        semantic_dir.mkdir(parents=True)
+        (semantic_dir / "orders.yml").write_text(yaml.safe_dump({
+            "kind": "semantic_model",
+            "name": "orders",
+            "model": "ref('transform.orders')",
+            "entities": [{"name": "order_id", "type": "primary"}],
+            "dimensions": [{"name": "region", "type": "categorical"}],
+            "measures": [{"name": "signal_count", "expr": "1", "agg": "count"}],
+        }, sort_keys=False))
+
+        models, metrics = load_semantic_layer(tmp_path)
+
+        assert len(models) == 1
+        assert len(metrics) == 1
+        assert metrics[0].name == "signal_count"
+        assert metrics[0].aliases == []
+
+    def test_auto_generated_metrics_copy_measure_aliases(self, tmp_path: Path):
+        semantic_dir = tmp_path / "seeknal" / "semantic_models"
+        semantic_dir.mkdir(parents=True)
+        (semantic_dir / "orders.yml").write_text(yaml.safe_dump({
+            "kind": "semantic_model",
+            "name": "orders",
+            "model": "ref('transform.orders')",
+            "entities": [{"name": "order_id", "type": "primary"}],
+            "dimensions": [{"name": "region", "type": "categorical"}],
+            "measures": [{
+                "name": "signal_count",
+                "expr": "1",
+                "agg": "count",
+                "aliases": ["Signals"],
+            }],
+        }, sort_keys=False))
+
+        _models, metrics = load_semantic_layer(tmp_path)
+        assert metrics[0].aliases == ["Signals"]
 
 
 # ── ProjectParser Integration Tests ────────────────────────────────────────


### PR DESCRIPTION
## Summary

Combines the parallel session's in-progress work with the 2.7.0 release (#46) and bumps to **2.7.1**. Additive merge — two small conflicts aligned (endpoint banner, worker-factory test).

## What's new

### Gateway pairing
- `FilePairingStore`, `TelegramLinkStore`, `PublicSessionStore` wired into the app lifespan
- Telegram `/pair` command redeems admin-generated one-time codes
- Expired-code cleanup runs on the existing eviction loop

### Ask tool
- `execute_uv_script` — run uv-managed Python scripts from the agent

### Pipeline runtime helpers
- `ctx.llm` — Ask-aligned text / JSON generation inside `@transform` functions
- `ctx.state` — lightweight per-node persistent state keyed to the run
- Also: `normalize_python_deps()` for generated drafts, `find_agent_config_path()` for flexible `seeknal_agent.yml` discovery

## Conflicts resolved

Two files were modified by both this branch and #46. Both resolutions keep both sides:

| File | Resolution |
|---|---|
| `src/seeknal/cli/gateway.py` | plain-string endpoint banner (from this branch) + `/upload` and `/record` lines (from #46) |
| `tests/ask/test_temporal_integration.py::test_create_worker` | compact `return_value=` patch style (from this branch) + stronger kwargs assertions on `task_queue`, `workflows`, `activities` (from #46) |

Three other overlapping files (`toolset.py`, `telegram.py`, `server.py`) auto-merged additively.

## Not in this PR

The main checkout still has uncommitted scratch left intentionally untracked:

- `.claude/skills/bmad-*/` — BMAD skill bundles
- `docker/`, `state/`, `examples/ecommerce/`, `docs/ideation/`
- Root-level `draft_*.yml` scratch files

If any of those should land, do it in a follow-up.

## Test plan

- [ ] `pytest tests/ask/` green (incl. the new pairing, channel, draft, session, execute_uv_script tests)
- [ ] `pytest tests/workflow/test_pipeline_runtime_helpers.py tests/workflow/test_python_executor_runtime_context.py` green
- [ ] Manual: send a valid pair code via `/pair` in Telegram; confirm it links the chat to the session store and expired codes get cleaned up on the next eviction tick
- [ ] Manual: run a `@transform` that uses `ctx.state.get(...)` across two pipeline runs and confirm state survives

🤖 Generated with [Claude Code](https://claude.com/claude-code)