### PR TITLE
feat(ask): 2.8.0 — OpenAI/Anthropic, execute_sql guards, preview_query, context files, preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.0] - 2026-04-18
+
+Ask agent improvements batch — addresses open issues #23, #24, #25, #26, #27.
+
+### Added
+
+- **OpenAI + Anthropic provider support** (#23) — `get_model_string()` now resolves `openai` and `anthropic` providers alongside Google and Ollama, using pydantic-ai's native `openai:<model>` / `anthropic:<model>` strings (not langchain). Custom base URLs honoured via `SEEKNAL_ASK_OPENAI_BASE_URL` and `SEEKNAL_ASK_ANTHROPIC_BASE_URL`, bridged to pydantic-ai's `OPENAI_BASE_URL` / `ANTHROPIC_BASE_URL` at factory time. Enables Azure OpenAI, Together, Groq, vLLM, LM Studio, enterprise Anthropic proxies, MiniMax — anything API-compatible.
+- **Pre-execution query safety hooks** (#27) — new `preview_query` tool runs four cheap diagnostic probes against a SELECT before `execute_sql` touches data:
+  - **Row count pre-check** — warns at ≥10k rows, blocks at ≥100k
+  - **Column count pre-check** — warns when projection exceeds 50 columns
+  - **Fan-out detection** — after a JOIN, warns when result rows exceed the primary table by ≥3×
+  - **Reachability dry-run** — surfaces unreachable tables with the set of accessible schemas before the real query runs
+
+  Pure aggregations and `LIMIT 1` queries auto-skip the probes. Callers can pass `run_hooks=False` for known-small queries.
+- **Context files + durable preferences** (#24, #25) — three new tools:
+  - `list_context_files` — scans `{project}/context/` for `.md / .yml / .yaml / .txt` files with first-line hints so the agent can pick what to load via `read_project_file`
+  - `write_project_file` — path-safe writes into `context/` with traversal/absolute-path/extension guards and a 100 KB per-file cap
+  - `save_preference` — appends durable one-line rules to `{project}/preferences.yml`; deduplicates, escapes YAML specials, and caps at 500 chars per entry
+
+  Preferences are auto-loaded and injected into the system prompt on every session start (see `load_preferences` in `agent.py`).
+
+### Changed
+
+- **`execute_sql` context-window guards** (#26) — results are now capped to prevent LLM context bloat:
+  - Row count hard cap at 500 regardless of caller's `limit` argument
+  - Column count hard cap at 50
+  - Per-cell length cap at 200 chars (with `…` ellipsis)
+  - 50 KB markdown byte budget — trailing rows dropped to fit
+  - Pipe and newline characters in cell values are now escaped so table rows stay aligned
+
+  Every truncation emits a `⚠ Result truncated:` notice explaining the cause and suggested remediation (WHERE, GROUP BY, narrower SELECT). When the hard cap clamps, a COUNT(*) round-trip populates the accurate total in the footer (`12 of 4,823 rows shown`).
+
+### Tests
+
+65 new tests across four files. 874/874 passed in 59s (up from 809/809).
+- `test_providers.py` — 21 tests (4 providers × env var resolution × happy path × failures)
+- `test_execute_sql.py` — 11 tests (hard caps, truncation notices, caller-limit pagination, SQL error passthrough)
+- `test_preview_query.py` — 12 tests (OK / WARN / BLOCK transitions, fan-out, reachability error, identifier guard)
+- `test_context_preferences.py` — 21 tests (context discovery, path-traversal / oversize / extension rejection, preferences dedup + YAML escape round-trip, malformed-file tolerance)
+
 ## [2.7.1] - 2026-04-18
 
 Combined parallel session work with 2.7.0 — additive merge, two aligned conflicts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "seeknal"
-version = "2.7.1"
+version = "2.8.0"
 description = "All-in-one platform for data and AI/ML engineering"
 authors = [
     {name = "Fitra Kacamarga"}

--- a/src/seeknal/ask/agents/agent.py
+++ b/src/seeknal/ask/agents/agent.py
@@ -130,6 +130,19 @@ def create_agent(
     builder = create_default_builder()
     instructions = builder.build(environment=environment, config=agent_config)
 
+    # Inject persistent user preferences from preferences.yml (if present)
+    # so they carry across sessions. See save_preference tool for writes.
+    from seeknal.ask.agents.tools.save_preference import load_preferences
+    _prefs = load_preferences(project_path)
+    if _prefs:
+        _pref_block = "\n\n## User preferences (persistent)\n\n" + "\n".join(
+            f"- {p}" for p in _prefs
+        ) + (
+            "\n\nThese were saved via save_preference in earlier sessions. "
+            "Apply them unless the user overrides in this session."
+        )
+        instructions = instructions + _pref_block
+
     # Resolve model string
     model_string = get_model_string(provider=provider, model=model, api_key=api_key)
 

--- a/src/seeknal/ask/agents/providers.py
+++ b/src/seeknal/ask/agents/providers.py
@@ -1,12 +1,18 @@
 """LLM provider factory for Seeknal Ask.
 
-Supports Google Gemini (primary) and Ollama (local).
-Returns pydantic-ai model strings for use with Agent() or create_deep_agent().
-Configuration via environment variables.
+Supports Google Gemini (primary), Ollama (local), OpenAI (+ any
+OpenAI-compatible endpoint via SEEKNAL_ASK_OPENAI_BASE_URL), and
+Anthropic (+ any Anthropic-compatible endpoint via
+SEEKNAL_ASK_ANTHROPIC_BASE_URL).
+
+Returns pydantic-ai model strings for use with Agent() or
+create_deep_agent(). Configuration via environment variables.
 """
 
 import os
 from typing import Optional
+
+SUPPORTED_PROVIDERS = ("google", "ollama", "openai", "anthropic")
 
 
 def resolve_provider_config(
@@ -34,9 +40,25 @@ def resolve_provider_config(
             "base_url": base_url or os.environ.get("SEEKNAL_ASK_OLLAMA_URL"),
         }
 
+    if resolved_provider == "openai":
+        return {
+            "provider": resolved_provider,
+            "model": model or os.environ.get("SEEKNAL_ASK_MODEL", "gpt-4o"),
+            "api_key": api_key or os.environ.get("OPENAI_API_KEY"),
+            "base_url": base_url or os.environ.get("SEEKNAL_ASK_OPENAI_BASE_URL"),
+        }
+
+    if resolved_provider == "anthropic":
+        return {
+            "provider": resolved_provider,
+            "model": model or os.environ.get("SEEKNAL_ASK_MODEL", "claude-sonnet-4-6"),
+            "api_key": api_key or os.environ.get("ANTHROPIC_API_KEY"),
+            "base_url": base_url or os.environ.get("SEEKNAL_ASK_ANTHROPIC_BASE_URL"),
+        }
+
     raise ValueError(
         f"Unsupported LLM provider: '{resolved_provider}'. "
-        f"Supported: 'google', 'ollama'."
+        f"Supported: {', '.join(repr(p) for p in SUPPORTED_PROVIDERS)}."
     )
 
 
@@ -54,13 +76,16 @@ def get_model_string(
     3. Default value
 
     Args:
-        provider: "google" or "ollama". Default: SEEKNAL_ASK_LLM_PROVIDER or "google".
+        provider: one of "google", "ollama", "openai", "anthropic".
+            Default: SEEKNAL_ASK_LLM_PROVIDER or "google".
         model: Model name. Default depends on provider.
         api_key: API key. Default: provider-specific env var.
-        base_url: Base URL override (mainly for Ollama).
+        base_url: Base URL override. Honoured for Ollama, OpenAI-compatible
+            and Anthropic-compatible endpoints.
 
     Returns:
-        A pydantic-ai model string (e.g. "google-gla:gemini-2.5-flash").
+        A pydantic-ai model string (e.g. "google-gla:gemini-2.5-flash",
+        "openai:gpt-4o", "anthropic:claude-sonnet-4-6").
 
     Raises:
         ValueError: If provider is unsupported or required config is missing.
@@ -72,9 +97,21 @@ def get_model_string(
         base_url=base_url,
     )
 
-    if resolved["provider"] == "google":
+    prov = resolved["provider"]
+    if prov == "google":
         return _google_model_string(resolved["model"], resolved["api_key"])
-    return _ollama_model_string(resolved["model"], resolved["base_url"])
+    if prov == "ollama":
+        return _ollama_model_string(resolved["model"], resolved["base_url"])
+    if prov == "openai":
+        return _openai_model_string(
+            resolved["model"], resolved["api_key"], resolved["base_url"]
+        )
+    if prov == "anthropic":
+        return _anthropic_model_string(
+            resolved["model"], resolved["api_key"], resolved["base_url"]
+        )
+    # resolve_provider_config already raises for unknown providers, but guard anyway.
+    raise ValueError(f"Unsupported LLM provider: '{prov}'.")
 
 
 def _google_model_string(
@@ -103,3 +140,49 @@ def _ollama_model_string(
     if base_url:
         os.environ.setdefault("OLLAMA_BASE_URL", base_url)
     return f"ollama:{model}"
+
+
+def _openai_model_string(
+    model: Optional[str],
+    api_key: Optional[str],
+    base_url: Optional[str],
+) -> str:
+    """Build an ``openai:<model>`` string for native OpenAI or any
+    OpenAI-compatible endpoint (Azure OpenAI, Together AI, Groq, vLLM,
+    LM Studio, self-hosted proxies, …).
+    """
+    model = model or os.environ.get("SEEKNAL_ASK_MODEL", "gpt-4o")
+    api_key = api_key or os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "OpenAI API key required. Set OPENAI_API_KEY environment variable "
+            "or pass api_key parameter."
+        )
+    # pydantic-ai's OpenAI provider reads OPENAI_API_KEY automatically; we
+    # validate early so the error is actionable at config resolution time.
+    os.environ.setdefault("OPENAI_API_KEY", api_key)
+    # Bridge seeknal's custom-endpoint env var to the one pydantic-ai reads.
+    if base_url:
+        os.environ.setdefault("OPENAI_BASE_URL", base_url)
+    return f"openai:{model}"
+
+
+def _anthropic_model_string(
+    model: Optional[str],
+    api_key: Optional[str],
+    base_url: Optional[str],
+) -> str:
+    """Build an ``anthropic:<model>`` string for native Anthropic or any
+    Anthropic-compatible endpoint (enterprise proxies, MiniMax, etc.).
+    """
+    model = model or os.environ.get("SEEKNAL_ASK_MODEL", "claude-sonnet-4-6")
+    api_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "Anthropic API key required. Set ANTHROPIC_API_KEY environment "
+            "variable or pass api_key parameter."
+        )
+    os.environ.setdefault("ANTHROPIC_API_KEY", api_key)
+    if base_url:
+        os.environ.setdefault("ANTHROPIC_BASE_URL", base_url)
+    return f"anthropic:{model}"

--- a/src/seeknal/ask/agents/tools/execute_sql.py
+++ b/src/seeknal/ask/agents/tools/execute_sql.py
@@ -1,4 +1,19 @@
-"""Execute SQL tool — runs read-only queries via the seeknal REPL."""
+"""Execute SQL tool — runs read-only queries via the seeknal REPL.
+
+Guards the LLM's context window by enforcing hard caps on row count,
+column count, per-cell length, and total byte size. Whenever any cap
+kicks in, an explicit ``Result truncated`` note is appended so the agent
+knows to narrow its next query.
+"""
+
+from __future__ import annotations
+
+# Hard caps — not overridable from the agent. Tune here if needed.
+_ROW_HARD_CAP = 500
+_COLUMN_HARD_CAP = 50
+_CELL_MAX_LEN = 200
+_BYTE_BUDGET = 50 * 1024  # 50 KB of markdown table (roughly ~12k tokens)
+
 
 def execute_sql(sql: str, limit: int = 100) -> str:
     """Execute a read-only SQL query against seeknal project data.
@@ -7,6 +22,16 @@ def execute_sql(sql: str, limit: int = 100) -> str:
     Only SELECT/WITH queries are allowed (read-only). Only query tables shown
     in list_tables output. Never reference file paths in SQL.
     Results are returned as a formatted table.
+
+    Result safety guards (applied silently, flagged explicitly when tripped):
+    - Row count is capped at 500 regardless of the ``limit`` argument. If
+      the underlying query has more rows, the returned markdown shows the
+      first 500 plus a note with the real total.
+    - Column count is capped at 50. Extra columns are dropped and a
+      note is appended.
+    - Each cell value is truncated to 200 chars with an ellipsis.
+    - If the assembled markdown exceeds 50 KB, trailing rows are dropped
+      with a note. Narrow the query (WHERE / GROUP BY) to recover detail.
 
     DuckDB SQL dialect notes:
     - Do NOT include trailing semicolons in queries
@@ -25,7 +50,9 @@ def execute_sql(sql: str, limit: int = 100) -> str:
 
     Args:
         sql: A DuckDB-compatible SELECT query.
-        limit: Maximum rows to return (default 100).
+        limit: Maximum rows to return (default 100). Capped at 500
+            regardless of what is passed — use WHERE/GROUP BY to narrow
+            beyond that, not a larger limit.
     """
     from seeknal.ask.agents.tools._context import get_tool_context
 
@@ -36,9 +63,18 @@ def execute_sql(sql: str, limit: int = 100) -> str:
 
     # SQL validation is handled by the PRE_TOOL_USE hook (see hooks.py)
 
+    # Clamp caller-supplied limit to the hard cap. Fetch one extra row so we
+    # can detect "there are more rows beyond this page".
+    try:
+        asked = max(1, int(limit))
+    except (TypeError, ValueError):
+        asked = 100
+    effective_limit = min(asked, _ROW_HARD_CAP)
+    fetch_limit = effective_limit + 1
+
     try:
         with ctx.db_lock:
-            columns, rows = ctx.repl.execute_oneshot(sql, limit=limit)
+            columns, rows = ctx.repl.execute_oneshot(sql, limit=fetch_limit)
     except Exception as e:
         from seeknal.ask.agents.tools.errors import (
             classify_duckdb_error,
@@ -50,14 +86,161 @@ def execute_sql(sql: str, limit: int = 100) -> str:
     if not columns:
         return "Query executed successfully but returned no results."
 
-    # Format as markdown table
-    header = "| " + " | ".join(columns) + " |"
-    separator = "| " + " | ".join("---" for _ in columns) + " |"
-    body_lines = []
+    has_more_rows = len(rows) > effective_limit
+    trimmed_rows = rows[:effective_limit]
+
+    # Resolve the real total only when we actually hit the cap — saves the
+    # round-trip for normal-sized results.
+    total_rows: int | None = None
+    if has_more_rows:
+        try:
+            total_rows = _count_total(ctx, sql)
+        except Exception:
+            total_rows = None
+
+    return _format_table(
+        columns=columns,
+        rows=trimmed_rows,
+        total_rows=total_rows,
+        has_more_rows=has_more_rows,
+        requested_limit=asked,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _count_total(ctx, sql: str) -> int | None:
+    """Return the true row count of ``sql`` by wrapping it in COUNT(*).
+
+    Returns None on any parse / execution failure so the caller can fall
+    back to ``"many rows"`` without crashing the tool.
+    """
+    wrapped = f"SELECT CAST(COUNT(*) AS BIGINT) AS c FROM ({sql}) AS _seek_q"
+    with ctx.db_lock:
+        _cols, rows = ctx.repl.execute_oneshot(wrapped, limit=1)
+    if rows and rows[0] and rows[0][0] is not None:
+        try:
+            return int(rows[0][0])
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _truncate_cell(value) -> tuple[str, bool]:
+    """Stringify and cap cell content. Returns (text, was_truncated)."""
+    if value is None:
+        return "NULL", False
+    text = str(value)
+    truncated = False
+    if len(text) > _CELL_MAX_LEN:
+        text = text[: _CELL_MAX_LEN - 1] + "…"
+        truncated = True
+    # Pipes and newlines break markdown rows.
+    if "|" in text:
+        text = text.replace("|", "\\|")
+    if "\n" in text:
+        text = text.replace("\n", " ")
+    return text, truncated
+
+
+def _format_table(
+    columns: list[str],
+    rows: list[tuple],
+    total_rows: int | None,
+    has_more_rows: bool,
+    requested_limit: int,
+) -> str:
+    notices: list[str] = []
+
+    # Column cap
+    original_column_count = len(columns)
+    columns_truncated = False
+    if original_column_count > _COLUMN_HARD_CAP:
+        columns = columns[:_COLUMN_HARD_CAP]
+        columns_truncated = True
+        notices.append(
+            f"Result truncated: showing {_COLUMN_HARD_CAP} of "
+            f"{original_column_count} columns. Use SELECT col1, col2, ... to "
+            "narrow the projection."
+        )
+
+    # Build rows with cell-length truncation applied.
+    any_cell_truncated = False
+    body_lines: list[str] = []
     for row in rows:
-        cells = [str(v) if v is not None else "NULL" for v in row]
+        slice_row = row[: len(columns)] if columns_truncated else row
+        cells = []
+        for value in slice_row:
+            text, was_truncated = _truncate_cell(value)
+            if was_truncated:
+                any_cell_truncated = True
+            cells.append(text)
         body_lines.append("| " + " | ".join(cells) + " |")
 
-    result = f"{header}\n{separator}\n" + "\n".join(body_lines)
-    result += f"\n\n({len(rows)} row{'s' if len(rows) != 1 else ''})"
+    if any_cell_truncated:
+        notices.append(
+            f"Result truncated: long cell values capped at "
+            f"{_CELL_MAX_LEN} chars. Query specific columns or use "
+            "substring/length filters if you need full values."
+        )
+
+    header = "| " + " | ".join(columns) + " |"
+    separator = "| " + " | ".join("---" for _ in columns) + " |"
+
+    # Byte budget — drop rows from the end until the markdown fits.
+    rows_dropped_for_budget = 0
+    while body_lines:
+        assembled = "\n".join([header, separator, *body_lines])
+        if len(assembled.encode("utf-8")) <= _BYTE_BUDGET:
+            break
+        body_lines.pop()
+        rows_dropped_for_budget += 1
+
+    if rows_dropped_for_budget > 0:
+        notices.append(
+            f"Result truncated: output exceeded {_BYTE_BUDGET // 1024} KB; "
+            f"dropped {rows_dropped_for_budget} trailing row(s). Narrow the "
+            "query (WHERE / GROUP BY / aggregate) to see more."
+        )
+
+    shown_rows = len(body_lines)
+    # The hard cap actually clamps only when the caller requested more than it.
+    hard_cap_hit = requested_limit > _ROW_HARD_CAP
+    if has_more_rows:
+        if total_rows is not None:
+            footer = f"({shown_rows:,} of {total_rows:,} rows shown)"
+        else:
+            footer = f"({shown_rows:,} of many rows shown)"
+        # Only warn loudly when the hard cap is the reason we truncated; the
+        # caller's own limit doing its job isn't "truncation", just pagination.
+        if hard_cap_hit:
+            if total_rows is not None:
+                notices.append(
+                    f"Result truncated: returned {shown_rows:,} of "
+                    f"{total_rows:,} total rows (hard cap {_ROW_HARD_CAP}). "
+                    "Use WHERE, GROUP BY, or LIMIT with pagination to see others."
+                )
+            else:
+                notices.append(
+                    f"Result truncated: returned {shown_rows:,} rows; the full "
+                    "result set is larger (exact count unavailable). Use "
+                    "WHERE or aggregation to narrow."
+                )
+    else:
+        footer = f"({shown_rows:,} row{'s' if shown_rows != 1 else ''})"
+        if hard_cap_hit:
+            notices.append(
+                f"Note: requested limit {requested_limit} was clamped to "
+                f"{_ROW_HARD_CAP}; full result set fit within the cap."
+            )
+
+    result = "\n".join([header, separator, *body_lines, "", footer])
+    if notices:
+        result += "\n\n" + "\n".join(f"⚠ {n}" for n in notices)
     return result
+
+
+__all__ = ["execute_sql"]

--- a/src/seeknal/ask/agents/tools/list_context_files.py
+++ b/src/seeknal/ask/agents/tools/list_context_files.py
@@ -1,0 +1,112 @@
+"""List context files tool — discovers project-specific domain knowledge.
+
+Scans ``{project}/context/`` for ``.md / .yml / .yaml / .txt`` files and
+returns their relative paths plus a one-line hint so the agent knows
+which file to load via ``read_project_file``.
+
+Keeps the agent's context lean by *listing* rather than *embedding* —
+the system prompt stays small, files load on demand when relevant.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_SUPPORTED_SUFFIXES = {".md", ".yml", ".yaml", ".txt"}
+_MAX_FILES_SHOWN = 50
+_HINT_MAX_LEN = 140
+
+
+def list_context_files() -> str:
+    """List domain-knowledge files under ``{project}/context/``.
+
+    Returns a markdown list of relative paths plus a short hint pulled
+    from each file's first non-empty line. Use this before writing SQL
+    against tables with encoded values, or when answering questions
+    about business metrics / glossary terms — then call
+    ``read_project_file`` on the specific file.
+
+    Extensions scanned: .md, .yml, .yaml, .txt. Returns a clear message
+    when ``context/`` does not exist or is empty.
+    """
+    from seeknal.ask.agents.tools._context import get_tool_context
+
+    ctx = get_tool_context()
+    context_dir = ctx.project_path / "context"
+
+    if not context_dir.exists():
+        return (
+            f"No `context/` directory at {ctx.project_path}. "
+            "Ask the data team to add glossaries, join patterns, or metric "
+            "definitions there (see `write_project_file`), then call this "
+            "again."
+        )
+    if not context_dir.is_dir():
+        return f"`{context_dir}` exists but is not a directory."
+
+    entries = []
+    for path in sorted(context_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        if path.suffix.lower() not in _SUPPORTED_SUFFIXES:
+            continue
+        # Skip hidden / dotfiles
+        if any(part.startswith(".") for part in path.relative_to(context_dir).parts):
+            continue
+        rel = path.relative_to(ctx.project_path)
+        hint = _first_line_hint(path)
+        entries.append((rel, hint))
+
+    if not entries:
+        return (
+            f"`{context_dir}` is empty. Supported extensions: "
+            f"{', '.join(sorted(_SUPPORTED_SUFFIXES))}. Use "
+            "`write_project_file(path='context/glossary.md', content=...)` "
+            "to create one."
+        )
+
+    lines = [f"## Context files ({len(entries)} available)", ""]
+    for rel, hint in entries[:_MAX_FILES_SHOWN]:
+        if hint:
+            lines.append(f"- `{rel}` — {hint}")
+        else:
+            lines.append(f"- `{rel}`")
+    if len(entries) > _MAX_FILES_SHOWN:
+        lines.append("")
+        lines.append(
+            f"(showing {_MAX_FILES_SHOWN} of {len(entries)}; narrow the "
+            "scan by descending into a subdirectory via `read_project_file`.)"
+        )
+    lines.append("")
+    lines.append(
+        "Load a file's full content via `read_project_file('<path>')`."
+    )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _first_line_hint(path: Path) -> str:
+    """Read the first non-empty, non-comment-only line of a text file."""
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as fh:
+            for raw in fh:
+                line = raw.strip()
+                if not line:
+                    continue
+                # Strip leading markdown heading markers for readability
+                line = line.lstrip("#").strip()
+                if not line:
+                    continue
+                if len(line) > _HINT_MAX_LEN:
+                    line = line[: _HINT_MAX_LEN - 1] + "…"
+                return line
+    except Exception:
+        return ""
+    return ""
+
+
+__all__ = ["list_context_files"]

--- a/src/seeknal/ask/agents/tools/preview_query.py
+++ b/src/seeknal/ask/agents/tools/preview_query.py
@@ -1,0 +1,302 @@
+"""Preview query tool — cheap pre-execution hooks to steer the agent.
+
+Runs four diagnostic probes against a SELECT before the real query
+executes:
+
+1. **Row count pre-check** — ``SELECT COUNT(*) FROM (sql) AS _q``.
+   If the count is huge, block execution and return guidance only; if
+   large, warn but allow.
+2. **Column count pre-check** — ``DESCRIBE SELECT * FROM (sql) AS _q``.
+   Warns when the projection is wide.
+3. **Fan-out detection** — when the query has a JOIN, compare the
+   estimated result rows to the primary table's rows. If it multiplies
+   beyond a threshold, warn.
+4. **Schema/reachability dry-run** — run ``DESCRIBE`` first; if it fails
+   the table is unreachable and we surface that cleanly with the list
+   of currently registered schemas.
+
+The tool is **opt-out-able** via ``run_hooks=False`` for known-small
+queries (e.g. aggregations, LIMIT 1). Pure aggregations without row
+output (``COUNT(*)``, ``SUM(...)`` at top level) and ``LIMIT 1`` queries
+auto-skip the row-count check since it would cost more than it saves.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Thresholds — tuneable but not per-call configurable on purpose.
+_ROW_WARN_THRESHOLD = 10_000
+_ROW_BLOCK_THRESHOLD = 100_000
+_COLUMN_WARN_THRESHOLD = 50
+_FANOUT_RATIO_THRESHOLD = 3.0  # result rows / primary rows
+_FANOUT_MIN_ROWS = 1_000  # don't flag small queries
+
+# Precompiled helpers
+_LIMIT_1_RE = re.compile(r"\bLIMIT\s+1\s*$", re.IGNORECASE)
+_PURE_AGG_RE = re.compile(
+    r"""
+    ^\s*SELECT\s+                   # SELECT
+    (?:                             # one-or-more aggregate expressions
+        (?:COUNT|SUM|AVG|MIN|MAX|MEDIAN|STDDEV|VARIANCE)\s*\([^)]*\)
+        (?:\s+AS\s+[\w_]+)?
+        \s*,?\s*
+    )+
+    \s+FROM\s                       # then FROM
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+_FROM_TABLE_RE = re.compile(r"\bFROM\s+([\"\w\.]+)", re.IGNORECASE)
+_HAS_JOIN_RE = re.compile(r"\bJOIN\b", re.IGNORECASE)
+
+
+def preview_query(sql: str, run_hooks: bool = True) -> str:
+    """Dry-run diagnostics for a SELECT before executing it.
+
+    Returns a markdown report with a ``decision`` line:
+
+    - ``OK`` — safe to execute as-is
+    - ``WARN`` — large but fetchable; proceed with caution
+    - ``BLOCK`` — would exceed the hard cap; refine the query first
+    - ``ERROR`` — the query could not be analyzed (unreachable table, etc.)
+
+    Use this before ``execute_sql`` when you're unsure how big a result
+    will be, when a query spans JOINs, or when the user asks about a
+    brand-new table.
+
+    Args:
+        sql: A DuckDB-compatible SELECT query (same dialect as execute_sql).
+        run_hooks: If False, returns ``OK`` immediately without any probes.
+            Use for known-small queries to save a round trip.
+    """
+    from seeknal.ask.agents.tools._context import get_tool_context
+
+    ctx = get_tool_context()
+
+    trimmed = sql.strip().rstrip(";").strip()
+    if not trimmed:
+        return "ERROR: empty SQL."
+
+    if not run_hooks:
+        return "OK (hooks skipped by caller)."
+
+    # Hooks are cheap for pure aggregations and LIMIT 1 queries — skip them.
+    if _is_pure_aggregation(trimmed) or _LIMIT_1_RE.search(trimmed):
+        return "OK (aggregation / LIMIT 1 — hooks skipped)."
+
+    notices: list[str] = []
+    decision = "OK"
+    total_rows: int | None = None
+    column_count: int | None = None
+
+    # ── Hook 4: reachability dry-run ──
+    schema_err = _dry_run_describe(ctx, trimmed)
+    if schema_err is not None:
+        return _format_report("ERROR", [schema_err], row_count=None, column_count=None)
+
+    # ── Hook 2: column count ──
+    try:
+        column_count = _describe_columns(ctx, trimmed)
+    except Exception as exc:
+        notices.append(f"Column introspection failed: {exc}")
+
+    if column_count is not None and column_count > _COLUMN_WARN_THRESHOLD:
+        notices.append(
+            f"Query projects {column_count} columns (>{_COLUMN_WARN_THRESHOLD}). "
+            "Use `SELECT col1, col2, ...` to narrow. Call "
+            "`describe_table('table_name')` to identify the columns you need."
+        )
+        decision = _escalate(decision, "WARN")
+
+    # ── Hook 1: row count pre-check ──
+    try:
+        total_rows = _count_rows(ctx, trimmed)
+    except Exception as exc:
+        notices.append(f"Row pre-check failed: {exc}")
+
+    if total_rows is not None:
+        if total_rows >= _ROW_BLOCK_THRESHOLD:
+            notices.append(
+                f"Query would return {total_rows:,} rows "
+                f"(>={_ROW_BLOCK_THRESHOLD:,}). Execution blocked. "
+                "Add a WHERE clause to filter, or use GROUP BY to aggregate."
+            )
+            decision = "BLOCK"
+        elif total_rows >= _ROW_WARN_THRESHOLD:
+            notices.append(
+                f"Query would return {total_rows:,} rows "
+                f"(>={_ROW_WARN_THRESHOLD:,}). Consider a tighter WHERE or "
+                "GROUP BY before calling `execute_sql`."
+            )
+            decision = _escalate(decision, "WARN")
+
+    # ── Hook 3: fan-out detection ──
+    if (
+        decision != "BLOCK"
+        and total_rows is not None
+        and total_rows >= _FANOUT_MIN_ROWS
+        and _HAS_JOIN_RE.search(trimmed)
+    ):
+        primary_rows = _primary_table_row_count(ctx, trimmed)
+        if (
+            primary_rows is not None
+            and primary_rows > 0
+            and total_rows / primary_rows >= _FANOUT_RATIO_THRESHOLD
+        ):
+            notices.append(
+                f"JOIN appears to multiply rows: primary table has "
+                f"{primary_rows:,} rows but the result has {total_rows:,} "
+                f"(ratio {total_rows / primary_rows:.1f}x). This may indicate "
+                "a many-to-many join without deduplication. Verify the join keys."
+            )
+            decision = _escalate(decision, "WARN")
+
+    return _format_report(decision, notices, row_count=total_rows, column_count=column_count)
+
+
+# ---------------------------------------------------------------------------
+# Probe helpers
+# ---------------------------------------------------------------------------
+
+
+def _dry_run_describe(ctx, sql: str) -> str | None:
+    """Return an error string if the query doesn't describe, else None."""
+    wrapped = f"DESCRIBE SELECT * FROM ({sql}) AS _seek_q"
+    try:
+        with ctx.db_lock:
+            ctx.repl.execute_oneshot(wrapped, limit=1)
+    except Exception as exc:
+        schemas = _list_schemas(ctx)
+        schema_hint = (
+            f" Accessible schemas: {', '.join(schemas)}."
+            if schemas
+            else ""
+        )
+        return (
+            f"The query references something DuckDB can't resolve: {exc}."
+            + schema_hint
+            + " Call `list_tables()` to see available tables/views."
+        )
+    return None
+
+
+def _describe_columns(ctx, sql: str) -> int:
+    wrapped = f"DESCRIBE SELECT * FROM ({sql}) AS _seek_q"
+    with ctx.db_lock:
+        _cols, rows = ctx.repl.execute_oneshot(wrapped, limit=10_000)
+    return len(rows)
+
+
+def _count_rows(ctx, sql: str) -> int | None:
+    wrapped = f"SELECT CAST(COUNT(*) AS BIGINT) AS c FROM ({sql}) AS _seek_q"
+    with ctx.db_lock:
+        _cols, rows = ctx.repl.execute_oneshot(wrapped, limit=1)
+    if rows and rows[0] and rows[0][0] is not None:
+        try:
+            return int(rows[0][0])
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _primary_table_row_count(ctx, sql: str) -> int | None:
+    """Extract the table immediately after FROM and COUNT(*) it."""
+    match = _FROM_TABLE_RE.search(sql)
+    if not match:
+        return None
+    table = match.group(1)
+    if not _is_safe_identifier(table):
+        return None
+    wrapped = f"SELECT CAST(COUNT(*) AS BIGINT) AS c FROM {table}"
+    try:
+        with ctx.db_lock:
+            _cols, rows = ctx.repl.execute_oneshot(wrapped, limit=1)
+    except Exception:
+        return None
+    if rows and rows[0] and rows[0][0] is not None:
+        try:
+            return int(rows[0][0])
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _list_schemas(ctx) -> list[str]:
+    try:
+        with ctx.db_lock:
+            _cols, rows = ctx.repl.execute_oneshot(
+                "SELECT DISTINCT table_schema FROM information_schema.tables "
+                "WHERE table_catalog = 'memory' ORDER BY 1",
+                limit=20,
+            )
+    except Exception:
+        return []
+    return [row[0] for row in rows if row and row[0]]
+
+
+# ---------------------------------------------------------------------------
+# Utility
+# ---------------------------------------------------------------------------
+
+_IDENT_RE = re.compile(r'^[\"\w][\"\w\.]*$')
+
+
+def _is_safe_identifier(ident: str) -> bool:
+    """Guard against SQL injection via FROM-clause interpolation.
+
+    Only quoted or unquoted identifiers (plus dotted qualifiers) pass.
+    Anything with spaces, parens, or quotes beyond the anchors is rejected.
+    """
+    return bool(_IDENT_RE.match(ident))
+
+
+def _is_pure_aggregation(sql: str) -> bool:
+    """Rough check: every projected expression is an aggregate function."""
+    return bool(_PURE_AGG_RE.match(sql))
+
+
+def _escalate(current: str, new: str) -> str:
+    order = {"OK": 0, "WARN": 1, "BLOCK": 2, "ERROR": 3}
+    return new if order[new] > order[current] else current
+
+
+# ---------------------------------------------------------------------------
+# Report formatting
+# ---------------------------------------------------------------------------
+
+
+def _format_report(
+    decision: str,
+    notices: list[str],
+    row_count: int | None,
+    column_count: int | None,
+) -> str:
+    lines = [f"## Preview query: {decision}"]
+    if row_count is not None:
+        lines.append(f"- Estimated rows: **{row_count:,}**")
+    if column_count is not None:
+        lines.append(f"- Columns in projection: **{column_count}**")
+    if notices:
+        lines.append("")
+        lines.append("### Findings")
+        for n in notices:
+            lines.append(f"- ⚠ {n}")
+    lines.append("")
+    if decision == "OK":
+        lines.append("Safe to execute via `execute_sql`.")
+    elif decision == "WARN":
+        lines.append(
+            "Fetchable, but narrow the query if you can. Call `execute_sql` "
+            "when ready."
+        )
+    elif decision == "BLOCK":
+        lines.append(
+            "**Do not call `execute_sql` with this query as-is.** Refine "
+            "first (WHERE, GROUP BY, LIMIT) and preview again."
+        )
+    elif decision == "ERROR":
+        lines.append("Fix the query above before calling `execute_sql`.")
+    return "\n".join(lines)
+
+
+__all__ = ["preview_query"]

--- a/src/seeknal/ask/agents/tools/save_preference.py
+++ b/src/seeknal/ask/agents/tools/save_preference.py
@@ -1,0 +1,130 @@
+"""Save preference tool — append a durable user preference to preferences.yml.
+
+Preferences are one-line statements that are auto-loaded into the
+system prompt at every session start. Use when the user says things
+like *"always filter test accounts"*, *"remember that revenue = gmv"*,
+or *"from now on, prefer GROUP BY over DISTINCT"*.
+"""
+
+from __future__ import annotations
+
+import re
+
+_PREF_MAX_LEN = 500
+_PREF_MIN_LEN = 4
+_PREFERENCES_FILENAME = "preferences.yml"
+
+
+def save_preference(preference: str) -> str:
+    """Append a user preference to ``{project}/preferences.yml``.
+
+    The preference persists across sessions and is injected into the
+    system prompt next run. Use only for statements the user explicitly
+    asked to remember.
+
+    Args:
+        preference: One short sentence describing the preference. E.g.
+            "Always join orders to customers via orders.customer_id =
+            customers.id" or "Revenue means gmv column, not the revenue
+            column".
+    """
+    from seeknal.ask.agents.tools._context import get_tool_context
+
+    ctx = get_tool_context()
+
+    if not preference or not isinstance(preference, str):
+        return "Error: preference is required."
+    cleaned = preference.strip()
+    if len(cleaned) < _PREF_MIN_LEN:
+        return f"Error: preference too short (minimum {_PREF_MIN_LEN} characters)."
+    if len(cleaned) > _PREF_MAX_LEN:
+        return (
+            f"Error: preference is {len(cleaned)} chars, exceeds "
+            f"{_PREF_MAX_LEN} limit. Write a focused domain rule, not a "
+            "conversation summary."
+        )
+
+    # YAML safety: escape backslashes and quotes; strip newlines.
+    cleaned = cleaned.replace("\\", "\\\\").replace('"', '\\"').replace("\n", " ")
+
+    path = ctx.project_path / _PREFERENCES_FILENAME
+    existing = _read_existing(path)
+    # Dedupe — preferences should be idempotent.
+    if any(cleaned == line.strip() for line in existing):
+        return f"Preference already present; skipped duplicate:\n  {cleaned}"
+
+    existing.append(cleaned)
+
+    with ctx.fs_lock:
+        _write_preferences(path, existing)
+
+    return (
+        f"Saved to `{_PREFERENCES_FILENAME}` ({len(existing)} preferences "
+        "total). Will be injected into the system prompt on the next "
+        "session start."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Loader used both by this tool and by create_agent() at session init
+# ---------------------------------------------------------------------------
+
+
+def load_preferences(project_path) -> list[str]:
+    """Read preferences.yml from a project path. Returns [] if missing or bad."""
+    from pathlib import Path as _Path
+
+    path = _Path(project_path) / _PREFERENCES_FILENAME
+    return _read_existing(path)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — minimal YAML I/O, no ruamel dependency
+# ---------------------------------------------------------------------------
+
+
+_PREF_LINE_RE = re.compile(r'^\s*-\s*["\']?(.*?)["\']?\s*$')
+
+
+def _read_existing(path) -> list[str]:
+    """Parse the bulleted list under ``preferences:`` — tolerates minor drift."""
+    if not path.exists() or not path.is_file():
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception:
+        return []
+    out: list[str] = []
+    in_block = False
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        if stripped.startswith("preferences:"):
+            in_block = True
+            continue
+        if in_block:
+            if not stripped:
+                continue
+            if not stripped.startswith("-"):
+                # Any other top-level key ends the block.
+                if not raw.startswith(" ") and not raw.startswith("\t"):
+                    break
+                continue
+            m = _PREF_LINE_RE.match(raw)
+            if m:
+                val = m.group(1).strip()
+                # Unescape basic sequences we wrote out
+                val = val.replace('\\"', '"').replace("\\\\", "\\")
+                if val:
+                    out.append(val)
+    return out
+
+
+def _write_preferences(path, entries: list[str]) -> None:
+    lines = ["preferences:"]
+    for entry in entries:
+        lines.append(f'  - "{entry}"')
+    # Trailing newline — YAML convention.
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+__all__ = ["save_preference", "load_preferences"]

--- a/src/seeknal/ask/agents/tools/toolset.py
+++ b/src/seeknal/ask/agents/tools/toolset.py
@@ -19,10 +19,12 @@ from seeknal.ask.agents.tools.generate_report import generate_report
 from seeknal.ask.agents.tools.get_entities import get_entities
 from seeknal.ask.agents.tools.get_entity_schema import get_entity_schema
 from seeknal.ask.agents.tools.inspect_output import inspect_output
+from seeknal.ask.agents.tools.list_context_files import list_context_files
 from seeknal.ask.agents.tools.list_tables import list_tables
 from seeknal.ask.agents.tools.open_in_browser import open_in_browser
 from seeknal.ask.agents.tools.parse_record import parse_record
 from seeknal.ask.agents.tools.plan_pipeline import plan_pipeline
+from seeknal.ask.agents.tools.preview_query import preview_query
 from seeknal.ask.agents.tools.profile_data import profile_data
 from seeknal.ask.agents.tools.propose_record_table import propose_record_table
 from seeknal.ask.agents.tools.publish_to_proof import publish_to_proof
@@ -35,12 +37,14 @@ from seeknal.ask.agents.tools.read_project_file import read_project_file
 from seeknal.ask.agents.tools.run_pipeline import run_pipeline
 from seeknal.ask.agents.tools.save_ingestion_skill import save_ingestion_skill
 from seeknal.ask.agents.tools.save_metric import save_metric
+from seeknal.ask.agents.tools.save_preference import save_preference
 from seeknal.ask.agents.tools.save_report_exposure import save_report_exposure
 from seeknal.ask.agents.tools.search_pipelines import search_pipelines
 from seeknal.ask.agents.tools.search_project_files import search_project_files
 from seeknal.ask.agents.tools.show_lineage import show_lineage
 from seeknal.ask.agents.tools.submit_plan import submit_plan
 from seeknal.ask.agents.tools.write_ingested_table import write_ingested_table
+from seeknal.ask.agents.tools.write_project_file import write_project_file
 
 
 def create_ask_toolset() -> FunctionToolset:
@@ -49,6 +53,7 @@ def create_ask_toolset() -> FunctionToolset:
         tools=[
             # Data discovery & querying
             execute_sql,
+            preview_query,
             list_tables,
             describe_table,
             get_entities,
@@ -58,6 +63,10 @@ def create_ask_toolset() -> FunctionToolset:
             search_pipelines,
             search_project_files,
             read_project_file,
+            # Context files & durable preferences
+            list_context_files,
+            write_project_file,
+            save_preference,
             # Analysis & reporting
             execute_python,
             execute_uv_script,

--- a/src/seeknal/ask/agents/tools/write_project_file.py
+++ b/src/seeknal/ask/agents/tools/write_project_file.py
@@ -1,0 +1,115 @@
+"""Write project file tool — persist agent-authored domain knowledge.
+
+Scope: writes are restricted to ``{project}/context/`` to keep pipeline
+code and agent output strictly separated. Path traversal and oversized
+content are rejected. Use this for glossaries, join-pattern notes,
+metric definitions, lessons-learned summaries — anything the agent
+should be able to re-read in a future session.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_SUPPORTED_SUFFIXES = {".md", ".yml", ".yaml", ".txt"}
+_MAX_CONTENT_BYTES = 100 * 1024  # 100 KB per file
+_SAFE_SEGMENT_RE = re.compile(r"^[a-zA-Z0-9_\-. ]+$")
+
+
+def write_project_file(path: str, content: str) -> str:
+    """Write ``content`` to ``{project}/context/{path}``.
+
+    Use this to persist domain knowledge the agent discovered this
+    session — a glossary entry, a newly-understood join pattern, a
+    summarized lessons-learned doc. The next session's
+    ``list_context_files`` will surface it automatically.
+
+    Args:
+        path: Path relative to ``context/`` (e.g. ``glossary.md`` or
+            ``metric_definitions/revenue.md``). Must contain only
+            letters, digits, underscores, dots, hyphens, spaces, and
+            directory separators. No leading slashes, no ``..``.
+        content: Text to write. Capped at 100 KB.
+
+    Returns:
+        A confirmation with the final absolute path, or an ``Error: ...``
+        line on validation failure.
+    """
+    from seeknal.ask.agents.tools._context import get_tool_context
+
+    ctx = get_tool_context()
+
+    if not path or not isinstance(path, str):
+        return "Error: path is required."
+
+    raw = path.strip()
+    if not raw:
+        return "Error: path is required."
+
+    # Reject absolute paths BEFORE any normalisation — "/etc/passwd.md" must
+    # not be silently coerced into a relative path by stripping the leading
+    # slash.
+    if raw.startswith("/") or raw.startswith("\\") or Path(raw).is_absolute():
+        return f"Error: path '{path}' must be relative to context/."
+
+    normalised = raw
+
+    # Reject path traversal.
+    if ".." in normalised.split("/") or ".." in normalised.split("\\"):
+        return f"Error: path '{path}' contains '..' — traversal not allowed."
+
+    parts = Path(normalised).parts
+    for part in parts:
+        if not _SAFE_SEGMENT_RE.match(part):
+            return (
+                f"Error: invalid path segment '{part}'. Use letters, digits, "
+                "dots, hyphens, underscores, or spaces."
+            )
+
+    candidate = Path(normalised)
+    if candidate.suffix.lower() not in _SUPPORTED_SUFFIXES:
+        return (
+            f"Error: unsupported extension '{candidate.suffix}'. "
+            f"Supported: {', '.join(sorted(_SUPPORTED_SUFFIXES))}."
+        )
+
+    if content is None:
+        return "Error: content is required."
+    if not isinstance(content, str):
+        return "Error: content must be a string."
+    if not content.strip():
+        return "Error: content is empty."
+    body = content.encode("utf-8")
+    if len(body) > _MAX_CONTENT_BYTES:
+        return (
+            f"Error: content is {len(body)} bytes, exceeds "
+            f"{_MAX_CONTENT_BYTES} byte limit."
+        )
+
+    context_root = ctx.project_path / "context"
+    try:
+        context_root.mkdir(parents=True, exist_ok=True)
+    except Exception as exc:
+        return f"Error: cannot create context/ directory: {exc}"
+
+    target = (context_root / normalised).resolve()
+    # Defense in depth: confirm the resolved path is still under context/.
+    try:
+        target.relative_to(context_root.resolve())
+    except ValueError:
+        return f"Error: resolved path escapes context/: {target}"
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with ctx.fs_lock:
+        target.write_text(content, encoding="utf-8")
+
+    rel = target.relative_to(ctx.project_path)
+    return (
+        f"Wrote `{rel}` ({len(body):,} bytes). "
+        "Available to future sessions via `list_context_files` and "
+        "`read_project_file`."
+    )
+
+
+__all__ = ["write_project_file"]

--- a/tests/ask/test_context_preferences.py
+++ b/tests/ask/test_context_preferences.py
@@ -1,0 +1,217 @@
+"""Tests for list_context_files, write_project_file, save_preference, and
+the session-startup preferences loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import duckdb
+import pytest
+
+from seeknal.ask.agents.tools._context import ToolContext, set_tool_context
+from seeknal.ask.agents.tools.list_context_files import list_context_files
+from seeknal.ask.agents.tools.save_preference import (
+    load_preferences,
+    save_preference,
+)
+from seeknal.ask.agents.tools.write_project_file import write_project_file
+
+
+class _REPLStub:
+    def __init__(self) -> None:
+        self.conn = duckdb.connect(":memory:")
+
+
+@pytest.fixture
+def ctx(tmp_path: Path) -> ToolContext:
+    context = ToolContext(
+        repl=_REPLStub(),
+        artifact_discovery=MagicMock(),
+        project_path=tmp_path,
+    )
+    set_tool_context(context)
+    return context
+
+
+# ---------------------------------------------------------------------------
+# list_context_files
+# ---------------------------------------------------------------------------
+
+
+def test_list_context_files_missing_directory(tmp_path, ctx):
+    out = list_context_files()
+    assert "No `context/` directory" in out
+
+
+def test_list_context_files_empty(tmp_path, ctx):
+    (tmp_path / "context").mkdir()
+    out = list_context_files()
+    assert "is empty" in out
+
+
+def test_list_context_files_returns_entries_and_hints(tmp_path, ctx):
+    ctx_dir = tmp_path / "context"
+    ctx_dir.mkdir()
+    (ctx_dir / "glossary.md").write_text("# Business Glossary\n\nRevenue = gmv.\n")
+    (ctx_dir / "data_quality.yml").write_text("caveats:\n  - orders table lags 24h\n")
+    (ctx_dir / "metric_definitions").mkdir()
+    (ctx_dir / "metric_definitions" / "revenue.md").write_text(
+        "## Revenue\n\nDefined as SUM(gmv) not SUM(revenue_column).\n"
+    )
+
+    out = list_context_files()
+    assert "3 available" in out
+    assert "context/glossary.md" in out
+    # First-line hint stripped of '#' markers
+    assert "Business Glossary" in out
+    assert "context/data_quality.yml" in out
+    assert "context/metric_definitions/revenue.md" in out
+
+
+def test_list_context_files_skips_unknown_suffixes(tmp_path, ctx):
+    ctx_dir = tmp_path / "context"
+    ctx_dir.mkdir()
+    (ctx_dir / "ok.md").write_text("# ok\n")
+    (ctx_dir / "skip.pdf").write_bytes(b"%PDF")
+    (ctx_dir / "secret.env").write_text("API_KEY=...\n")
+    out = list_context_files()
+    assert "context/ok.md" in out
+    assert "skip.pdf" not in out
+    assert "secret.env" not in out
+
+
+# ---------------------------------------------------------------------------
+# write_project_file
+# ---------------------------------------------------------------------------
+
+
+def test_write_project_file_happy_path(tmp_path, ctx):
+    out = write_project_file("glossary.md", "# Glossary\n\nRevenue = gmv.\n")
+    assert "Wrote `context/glossary.md`" in out
+    assert (tmp_path / "context" / "glossary.md").exists()
+    assert (
+        "Revenue = gmv"
+        in (tmp_path / "context" / "glossary.md").read_text()
+    )
+
+
+def test_write_project_file_nested_path(tmp_path, ctx):
+    out = write_project_file(
+        "metric_definitions/revenue.md", "## Revenue\n\nSUM(gmv).\n"
+    )
+    assert "Wrote" in out
+    assert (tmp_path / "context" / "metric_definitions" / "revenue.md").exists()
+
+
+def test_write_project_file_rejects_path_traversal(tmp_path, ctx):
+    for bad in (
+        "../secret.md",
+        "subdir/../../etc/passwd.md",
+        "..\\winpath.md",
+    ):
+        out = write_project_file(bad, "x")
+        assert out.startswith("Error:")
+        assert "traversal" in out.lower() or "invalid path" in out.lower()
+
+
+def test_write_project_file_rejects_absolute_path(tmp_path, ctx):
+    out = write_project_file("/etc/passwd.md", "x")
+    assert out.startswith("Error:")
+
+
+def test_write_project_file_rejects_unsupported_extension(tmp_path, ctx):
+    out = write_project_file("payload.sh", "echo hi")
+    assert out.startswith("Error:")
+    assert "unsupported extension" in out.lower()
+
+
+def test_write_project_file_rejects_oversized_content(tmp_path, ctx, monkeypatch):
+    monkeypatch.setattr(
+        "seeknal.ask.agents.tools.write_project_file._MAX_CONTENT_BYTES", 100
+    )
+    out = write_project_file("big.md", "x" * 200)
+    assert out.startswith("Error:")
+    assert "exceeds" in out.lower()
+
+
+def test_write_project_file_rejects_empty_content(tmp_path, ctx):
+    assert write_project_file("x.md", "").startswith("Error:")
+    assert write_project_file("x.md", "   \n  \n").startswith("Error:")
+
+
+# ---------------------------------------------------------------------------
+# save_preference
+# ---------------------------------------------------------------------------
+
+
+def test_save_preference_creates_yaml(tmp_path, ctx):
+    out = save_preference("Revenue means gmv column, not revenue_column.")
+    assert "Saved to `preferences.yml`" in out
+    pf = tmp_path / "preferences.yml"
+    assert pf.exists()
+    content = pf.read_text()
+    assert "preferences:" in content
+    assert "Revenue means gmv" in content
+
+
+def test_save_preference_appends_subsequent_entries(tmp_path, ctx):
+    save_preference("First rule.")
+    save_preference("Second rule.")
+    prefs = load_preferences(tmp_path)
+    assert prefs == ["First rule.", "Second rule."]
+
+
+def test_save_preference_deduplicates(tmp_path, ctx):
+    save_preference("Same rule.")
+    out = save_preference("Same rule.")
+    assert "already present" in out
+    prefs = load_preferences(tmp_path)
+    assert prefs == ["Same rule."]
+
+
+def test_save_preference_rejects_too_short(ctx):
+    assert save_preference("ok").startswith("Error:")
+
+
+def test_save_preference_rejects_empty(ctx):
+    assert save_preference("").startswith("Error:")
+    assert save_preference("   ").startswith("Error:")
+
+
+def test_save_preference_rejects_oversized(ctx, monkeypatch):
+    monkeypatch.setattr(
+        "seeknal.ask.agents.tools.save_preference._PREF_MAX_LEN", 20
+    )
+    out = save_preference("This is a very long preference that exceeds the limit")
+    assert out.startswith("Error:")
+
+
+def test_save_preference_escapes_yaml_specials(tmp_path, ctx):
+    save_preference('Use path "C:\\logs\\app" for Windows.')
+    prefs = load_preferences(tmp_path)
+    # Round-trip unescaped
+    assert prefs == ['Use path "C:\\logs\\app" for Windows.']
+
+
+# ---------------------------------------------------------------------------
+# load_preferences (used by agent.py at session init)
+# ---------------------------------------------------------------------------
+
+
+def test_load_preferences_returns_empty_when_no_file(tmp_path):
+    assert load_preferences(tmp_path) == []
+
+
+def test_load_preferences_tolerates_malformed_file(tmp_path):
+    (tmp_path / "preferences.yml").write_text("not actually yaml: [unclosed\n")
+    # Must not raise — returns [] instead of crashing the agent
+    result = load_preferences(tmp_path)
+    assert isinstance(result, list)
+
+
+def test_load_preferences_handles_unquoted_entries(tmp_path):
+    (tmp_path / "preferences.yml").write_text(
+        "preferences:\n  - Plain unquoted rule\n  - Another rule\n"
+    )
+    assert load_preferences(tmp_path) == ["Plain unquoted rule", "Another rule"]

--- a/tests/ask/test_execute_sql.py
+++ b/tests/ask/test_execute_sql.py
@@ -1,0 +1,180 @@
+"""Tests for the execute_sql tool — context-window guards."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import duckdb
+import pytest
+
+from seeknal.ask.agents.tools._context import ToolContext, set_tool_context
+from seeknal.ask.agents.tools.execute_sql import execute_sql
+
+
+class _REPLStub:
+    """Minimal REPL shim — forwards execute_oneshot to a real in-memory DuckDB."""
+
+    def __init__(self) -> None:
+        self.conn = duckdb.connect(":memory:")
+
+    def execute_oneshot(self, sql: str, limit=None):
+        if limit is not None:
+            sql = f"SELECT * FROM ({sql}) AS _q LIMIT {int(limit)}"
+        result = self.conn.execute(sql)
+        if not result.description:
+            return [], []
+        cols = [d[0] for d in result.description]
+        rows = result.fetchall()
+        return cols, rows
+
+
+@pytest.fixture
+def ctx(tmp_path: Path) -> ToolContext:
+    repl = _REPLStub()
+    # Seed tables used across tests
+    repl.conn.execute("CREATE TABLE small AS SELECT range AS id, 'hi' AS v FROM range(3)")
+    repl.conn.execute("CREATE TABLE big AS SELECT range AS id, 'x' AS v FROM range(1500)")
+    repl.conn.execute(
+        "CREATE TABLE wide AS "
+        "SELECT range AS id, "
+        + ", ".join(f"'v{i}' AS c{i}" for i in range(60))
+        + " FROM range(2)"
+    )
+    repl.conn.execute(
+        "CREATE TABLE longcells AS "
+        "SELECT 1 AS id, repeat('a', 500) AS big_text"
+    )
+    context = ToolContext(
+        repl=repl,
+        artifact_discovery=MagicMock(),
+        project_path=tmp_path,
+    )
+    set_tool_context(context)
+    return context
+
+
+# ---------------------------------------------------------------------------
+# Happy paths — no guards triggered
+# ---------------------------------------------------------------------------
+
+
+def test_small_result_returns_clean_table(ctx):
+    out = execute_sql("SELECT * FROM small", limit=10)
+    assert "| id | v |" in out
+    assert "(3 rows)" in out
+    # No truncation notices on a clean, within-budget query.
+    assert "Result truncated" not in out
+
+
+def test_zero_result_message(ctx):
+    out = execute_sql("SELECT * FROM small WHERE id = 999")
+    assert "no results" in out.lower() or "0 rows" in out
+
+
+# ---------------------------------------------------------------------------
+# Row hard cap — 500 — with accurate total row count
+# ---------------------------------------------------------------------------
+
+
+def test_row_hard_cap_shows_total_count(ctx):
+    # big has 1500 rows; caller asks for 10000 → clamped to 500
+    out = execute_sql("SELECT * FROM big", limit=10_000)
+    # Footer reports both shown and true total
+    assert "(500 of 1,500 rows shown)" in out
+    # Explicit truncation notice present
+    assert "Result truncated" in out
+    assert "500" in out and "1,500" in out
+
+
+def test_row_hard_cap_limit_beyond_hard_cap_warning(ctx):
+    # Query fits under the cap but caller asked for too many — we still warn
+    out = execute_sql("SELECT * FROM small", limit=10_000)
+    # All 3 rows fit
+    assert "(3 rows)" in out
+    # Caller warned about the clamp anyway
+    assert "clamped to 500" in out
+
+
+def test_caller_limit_informs_without_alarm(ctx):
+    # Caller asked for a modest limit that clamps the result — footer reports
+    # "N of M rows shown" so the agent knows more exist, but no ⚠ fires because
+    # the clamp was the caller's own choice, not the hard cap.
+    out = execute_sql("SELECT * FROM small", limit=2)
+    assert "2 of 3 rows shown" in out
+    # No "Result truncated" alarm when the caller's own limit does the clamping
+    assert "Result truncated" not in out
+
+
+# ---------------------------------------------------------------------------
+# Column hard cap — 50
+# ---------------------------------------------------------------------------
+
+
+def test_column_hard_cap(ctx):
+    # wide has 61 columns (id + c0..c59)
+    out = execute_sql("SELECT * FROM wide")
+    # Column cap applied
+    assert "showing 50 of 61 columns" in out
+    assert "Result truncated" in out
+    # Header has exactly 50 columns (50 pipes of content between outer pipes)
+    header_line = next(line for line in out.splitlines() if line.startswith("|"))
+    # The header line is "| c1 | c2 | ... |"; 50 columns = 50 cell separators
+    assert header_line.count("|") == 51  # 50 cells between 51 pipes
+
+
+# ---------------------------------------------------------------------------
+# Cell cap — 200 chars per cell
+# ---------------------------------------------------------------------------
+
+
+def test_cell_length_cap(ctx):
+    out = execute_sql("SELECT * FROM longcells")
+    # The 500-char 'a's are truncated
+    assert "…" in out
+    assert "capped at 200 chars" in out
+    # The row should contain 200 chars worth of the cell value including the …
+    body_line = next(line for line in out.splitlines() if "…" in line)
+    # Approximate: ellipsis + padded text around it; just verify long field shrunk
+    assert len(body_line) < 260
+
+
+# ---------------------------------------------------------------------------
+# Byte budget — drops trailing rows to fit
+# ---------------------------------------------------------------------------
+
+
+def test_byte_budget_drops_rows(ctx, monkeypatch):
+    # Force the byte budget tiny so the guard triggers on a small result
+    monkeypatch.setattr(
+        "seeknal.ask.agents.tools.execute_sql._BYTE_BUDGET", 120
+    )
+    out = execute_sql("SELECT * FROM big", limit=500)
+    assert "output exceeded" in out
+    assert "Result truncated" in out
+
+
+# ---------------------------------------------------------------------------
+# Robustness: invalid limit, pipes in cells, errors pass through
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_limit_coerces_to_default(ctx):
+    # Passing a non-integer limit shouldn't explode — should fall back to 100
+    out = execute_sql("SELECT * FROM small", limit="oops")  # type: ignore[arg-type]
+    assert "(3 rows)" in out
+
+
+def test_pipes_in_cells_are_escaped(ctx):
+    ctx.repl.conn.execute(
+        "CREATE TABLE piped AS SELECT 1 AS id, 'a|b|c' AS raw"
+    )
+    out = execute_sql("SELECT * FROM piped")
+    # Literal pipes in the cell must be escaped so the markdown row stays aligned
+    assert "a\\|b\\|c" in out
+
+
+def test_sql_error_returns_tool_error(ctx):
+    out = execute_sql("SELECT * FROM table_that_doesnt_exist")
+    # The tool's error formatter returns a JSON blob. Check the substring.
+    assert "retryable" in out or "category" in out

--- a/tests/ask/test_preview_query.py
+++ b/tests/ask/test_preview_query.py
@@ -1,0 +1,174 @@
+"""Tests for the preview_query safety-hook tool."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import duckdb
+import pytest
+
+from seeknal.ask.agents.tools._context import ToolContext, set_tool_context
+from seeknal.ask.agents.tools.preview_query import preview_query
+
+
+class _REPLStub:
+    def __init__(self) -> None:
+        self.conn = duckdb.connect(":memory:")
+
+    def execute_oneshot(self, sql: str, limit=None):
+        if limit is not None:
+            sql = f"SELECT * FROM ({sql}) AS _q LIMIT {int(limit)}"
+        result = self.conn.execute(sql)
+        if not result.description:
+            return [], []
+        cols = [d[0] for d in result.description]
+        rows = result.fetchall()
+        return cols, rows
+
+
+@pytest.fixture
+def ctx(tmp_path: Path) -> ToolContext:
+    repl = _REPLStub()
+    repl.conn.execute("CREATE TABLE small AS SELECT range AS id FROM range(50)")
+    repl.conn.execute("CREATE TABLE medium AS SELECT range AS id FROM range(15000)")
+    repl.conn.execute("CREATE TABLE huge AS SELECT range AS id FROM range(150000)")
+    # Wide table: 60 columns
+    repl.conn.execute(
+        "CREATE TABLE wide AS SELECT range AS id, "
+        + ", ".join(f"'v' AS c{i}" for i in range(60))
+        + " FROM range(5)"
+    )
+    # Fan-out demo: customers with many orders each
+    repl.conn.execute("CREATE TABLE customers AS SELECT range AS cust_id FROM range(500)")
+    repl.conn.execute(
+        "CREATE TABLE orders AS "
+        "SELECT range AS order_id, (range % 500) AS cust_id FROM range(5000)"
+    )
+    context = ToolContext(
+        repl=repl, artifact_discovery=MagicMock(), project_path=tmp_path,
+    )
+    set_tool_context(context)
+    return context
+
+
+# ---------------------------------------------------------------------------
+# OK paths
+# ---------------------------------------------------------------------------
+
+
+def test_small_query_ok(ctx):
+    out = preview_query("SELECT * FROM small")
+    assert "OK" in out
+    assert "Estimated rows: **50**" in out
+
+
+def test_limit_1_skipped(ctx):
+    out = preview_query("SELECT * FROM huge LIMIT 1")
+    assert "OK (aggregation / LIMIT 1 — hooks skipped)" in out
+
+
+def test_pure_aggregation_skipped(ctx):
+    out = preview_query("SELECT COUNT(*) FROM huge")
+    assert "OK (aggregation / LIMIT 1 — hooks skipped)" in out
+
+
+def test_run_hooks_false_skips(ctx):
+    out = preview_query("SELECT * FROM huge", run_hooks=False)
+    assert "OK (hooks skipped by caller)" in out
+
+
+# ---------------------------------------------------------------------------
+# WARN: >= 10k rows
+# ---------------------------------------------------------------------------
+
+
+def test_warn_on_large_result(ctx):
+    out = preview_query("SELECT * FROM medium")
+    assert "WARN" in out
+    assert "15,000 rows" in out
+    # Not blocked
+    assert "BLOCK" not in out
+
+
+# ---------------------------------------------------------------------------
+# BLOCK: >= 100k rows
+# ---------------------------------------------------------------------------
+
+
+def test_block_on_huge_result(ctx):
+    out = preview_query("SELECT * FROM huge")
+    assert "BLOCK" in out
+    assert "150,000 rows" in out
+    assert "Execution blocked" in out
+    assert "Do not call `execute_sql`" in out
+
+
+# ---------------------------------------------------------------------------
+# Column count warning
+# ---------------------------------------------------------------------------
+
+
+def test_column_count_warning(ctx):
+    out = preview_query("SELECT * FROM wide")
+    assert "Columns in projection: **61**" in out
+    assert "WARN" in out
+    assert "61 columns" in out
+
+
+# ---------------------------------------------------------------------------
+# Fan-out detection
+# ---------------------------------------------------------------------------
+
+
+def test_fanout_detected_on_many_to_many_join(ctx):
+    # Cartesian-ish JOIN: customers (500) × orders (5000) with no constraint =
+    # 500 * 5000 = 2.5M rows. That trips both the row threshold and fan-out.
+    # Use a proper JOIN that multiplies — each customer has 10 orders on average,
+    # so customers JOIN orders ON cust_id produces 5000 rows from a 500-row primary.
+    sql = "SELECT c.cust_id, o.order_id FROM customers c JOIN orders o ON c.cust_id = o.cust_id"
+    out = preview_query(sql)
+    # Primary table has 500 rows, result has 5000 → 10x ratio
+    assert "multiply rows" in out
+    assert "500" in out and "5,000" in out
+
+
+def test_no_fanout_warning_without_join(ctx):
+    out = preview_query("SELECT * FROM medium")
+    assert "multiply rows" not in out
+
+
+# ---------------------------------------------------------------------------
+# Reachability error
+# ---------------------------------------------------------------------------
+
+
+def test_error_on_unreachable_table(ctx):
+    out = preview_query("SELECT * FROM does_not_exist")
+    assert "ERROR" in out
+    assert "list_tables" in out
+
+
+def test_empty_sql_rejected(ctx):
+    out = preview_query("")
+    assert "ERROR: empty SQL" in out
+
+
+# ---------------------------------------------------------------------------
+# Safety
+# ---------------------------------------------------------------------------
+
+
+def test_primary_table_identifier_guard():
+    # Direct unit test of the injection guard — only valid SQL identifiers
+    # (with optional dotted qualifiers) should pass through to the FROM-clause
+    # interpolation in the fan-out probe.
+    from seeknal.ask.agents.tools.preview_query import _is_safe_identifier
+
+    assert _is_safe_identifier("customers") is True
+    assert _is_safe_identifier("main.customers") is True
+    assert _is_safe_identifier('"customers"') is True
+    # Anything with spaces, parens, semicolons, or injection characters fails.
+    assert _is_safe_identifier("customers; DROP TABLE users") is False
+    assert _is_safe_identifier("customers WHERE 1=1") is False
+    assert _is_safe_identifier("(SELECT * FROM x)") is False

--- a/tests/ask/test_providers.py
+++ b/tests/ask/test_providers.py
@@ -1,0 +1,189 @@
+"""Tests for seeknal.ask.agents.providers — provider factory."""
+
+from __future__ import annotations
+
+import pytest
+
+from seeknal.ask.agents.providers import (
+    SUPPORTED_PROVIDERS,
+    get_model_string,
+    resolve_provider_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    """Strip provider-related env vars so each test starts from a known state."""
+    for key in (
+        "SEEKNAL_ASK_LLM_PROVIDER", "SEEKNAL_ASK_MODEL",
+        "GOOGLE_API_KEY",
+        "OPENAI_API_KEY", "OPENAI_BASE_URL", "SEEKNAL_ASK_OPENAI_BASE_URL",
+        "ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "SEEKNAL_ASK_ANTHROPIC_BASE_URL",
+        "SEEKNAL_ASK_OLLAMA_URL", "OLLAMA_BASE_URL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# SUPPORTED_PROVIDERS is stable
+# ---------------------------------------------------------------------------
+
+
+def test_supported_providers_includes_all_four():
+    assert set(SUPPORTED_PROVIDERS) == {"google", "ollama", "openai", "anthropic"}
+
+
+# ---------------------------------------------------------------------------
+# resolve_provider_config — defaults and env resolution
+# ---------------------------------------------------------------------------
+
+
+def test_google_default_model_and_api_key_from_env(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "sk-google-test")
+    cfg = resolve_provider_config(provider="google")
+    assert cfg["provider"] == "google"
+    assert cfg["model"] == "gemini-2.5-flash"
+    assert cfg["api_key"] == "sk-google-test"
+    assert cfg["base_url"] is None
+
+
+def test_ollama_default_model_and_optional_base_url(monkeypatch):
+    monkeypatch.setenv("SEEKNAL_ASK_OLLAMA_URL", "http://ollama.local:11434")
+    cfg = resolve_provider_config(provider="ollama")
+    assert cfg["provider"] == "ollama"
+    assert cfg["model"] == "llama3.1"
+    assert cfg["api_key"] is None
+    assert cfg["base_url"] == "http://ollama.local:11434"
+
+
+def test_openai_default_model_and_env_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+    cfg = resolve_provider_config(provider="openai")
+    assert cfg["provider"] == "openai"
+    assert cfg["model"] == "gpt-4o"
+    assert cfg["api_key"] == "sk-openai-test"
+    assert cfg["base_url"] is None
+
+
+def test_openai_honors_base_url_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk")
+    monkeypatch.setenv("SEEKNAL_ASK_OPENAI_BASE_URL", "https://proxy.example/v1")
+    cfg = resolve_provider_config(provider="openai")
+    assert cfg["base_url"] == "https://proxy.example/v1"
+
+
+def test_anthropic_default_model_and_env_key(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    cfg = resolve_provider_config(provider="anthropic")
+    assert cfg["provider"] == "anthropic"
+    assert cfg["model"] == "claude-sonnet-4-6"
+    assert cfg["api_key"] == "sk-ant-test"
+    assert cfg["base_url"] is None
+
+
+def test_anthropic_honors_base_url_env(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk")
+    monkeypatch.setenv("SEEKNAL_ASK_ANTHROPIC_BASE_URL", "https://api.minimax.io/anthropic")
+    cfg = resolve_provider_config(provider="anthropic")
+    assert cfg["base_url"] == "https://api.minimax.io/anthropic"
+
+
+def test_explicit_argument_beats_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "from-env")
+    cfg = resolve_provider_config(
+        provider="openai", model="gpt-5", api_key="from-arg",
+        base_url="https://custom/v1",
+    )
+    assert cfg["model"] == "gpt-5"
+    assert cfg["api_key"] == "from-arg"
+    assert cfg["base_url"] == "https://custom/v1"
+
+
+def test_provider_from_env_var(monkeypatch):
+    monkeypatch.setenv("SEEKNAL_ASK_LLM_PROVIDER", "anthropic")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk")
+    cfg = resolve_provider_config()  # no explicit provider arg
+    assert cfg["provider"] == "anthropic"
+
+
+def test_unsupported_provider_raises(monkeypatch):
+    with pytest.raises(ValueError, match="Unsupported LLM provider"):
+        resolve_provider_config(provider="bedrock")
+
+
+# ---------------------------------------------------------------------------
+# get_model_string — pydantic-ai model strings
+# ---------------------------------------------------------------------------
+
+
+def test_google_model_string(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "sk")
+    assert get_model_string(provider="google") == "google-gla:gemini-2.5-flash"
+
+
+def test_ollama_model_string():
+    assert get_model_string(provider="ollama") == "ollama:llama3.1"
+
+
+def test_ollama_model_string_bridges_base_url(monkeypatch):
+    get_model_string(provider="ollama", base_url="http://x:1/")
+    assert os.environ.get("OLLAMA_BASE_URL") == "http://x:1/"
+
+
+def test_openai_model_string_requires_api_key():
+    with pytest.raises(ValueError, match="OpenAI API key required"):
+        get_model_string(provider="openai")
+
+
+def test_openai_model_string_happy_path(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+    assert get_model_string(provider="openai") == "openai:gpt-4o"
+
+
+def test_openai_model_string_honors_custom_model(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk")
+    assert get_model_string(provider="openai", model="gpt-4o-mini") == "openai:gpt-4o-mini"
+
+
+def test_openai_bridges_base_url(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk")
+    get_model_string(
+        provider="openai",
+        base_url="https://azure-openai.example/openai/deployments/x",
+    )
+    assert os.environ.get("OPENAI_BASE_URL") == (
+        "https://azure-openai.example/openai/deployments/x"
+    )
+
+
+def test_anthropic_model_string_requires_api_key():
+    with pytest.raises(ValueError, match="Anthropic API key required"):
+        get_model_string(provider="anthropic")
+
+
+def test_anthropic_model_string_happy_path(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant")
+    assert get_model_string(provider="anthropic") == "anthropic:claude-sonnet-4-6"
+
+
+def test_anthropic_bridges_base_url(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk")
+    get_model_string(
+        provider="anthropic",
+        base_url="https://api.minimax.io/anthropic",
+    )
+    assert os.environ.get("ANTHROPIC_BASE_URL") == "https://api.minimax.io/anthropic"
+
+
+def test_unsupported_provider_on_get_model_string():
+    with pytest.raises(ValueError, match="Unsupported LLM provider"):
+        get_model_string(provider="bedrock")
+
+
+# ``os`` import needed by env-bridging tests.
+import os  # noqa: E402


### PR DESCRIPTION
## Summary

Ask agent improvements batch. Closes four of the five open enhancement issues in a single additive release. The fifth (blocked by PR #35) is intentionally out of scope.

| Issue | Status |
|---|---|
| #23 OpenAI + Anthropic providers | ✅ closed by this PR |
| #24 list_context_files | ✅ closed by this PR |
| #25 save_preference + write_project_file | ✅ closed by this PR |
| #26 execute_sql guards + truncation notices | ✅ closed by this PR |
| #27 Pre-execution query safety hooks | ✅ closed by this PR |
| #36, #37 | Still blocked on PR #35 |

## What's new

### #23 — OpenAI + Anthropic provider support

`get_model_string()` now resolves `openai` and `anthropic` providers alongside Google and Ollama. Uses pydantic-ai's native `openai:<model>` / `anthropic:<model>` prefixes (not langchain — the issue's sample code was drafted against langchain but seeknal is built on pydantic-ai). Custom base URLs are forwarded via `SEEKNAL_ASK_OPENAI_BASE_URL` / `SEEKNAL_ASK_ANTHROPIC_BASE_URL`, bridged at factory time to pydantic-ai's `OPENAI_BASE_URL` / `ANTHROPIC_BASE_URL`. Works with Azure OpenAI, Together AI, Groq, vLLM, LM Studio, enterprise Anthropic proxies, MiniMax, etc.

### #26 — execute_sql context-window guards

| Guard | Value | Behaviour |
|---|---|---|
| Row hard cap | 500 rows | Ignores caller's `limit` if larger |
| Column hard cap | 50 | Extra dropped, notice emitted |
| Per-cell length | 200 chars | Truncated with `…` |
| Byte budget | 50 KB | Trailing rows dropped to fit |

Every truncation emits a `⚠ Result truncated:` notice explaining cause + suggested remediation. When the hard cap clamps, a `COUNT(*)` round-trip populates the accurate total (`12 of 4,823 rows shown`). Caller's own `limit` pagination is reported in the footer without an alarm.

Pipe and newline characters in cell values are now escaped so table rows stay aligned.

### #27 — `preview_query` — pre-execution safety hooks

New tool runs four cheap probes before `execute_sql` touches data. Returns a markdown report with a `decision` header:

- `OK` — safe to execute
- `WARN` — large but fetchable; proceed with caution
- `BLOCK` — would exceed hard caps; refine before calling `execute_sql`
- `ERROR` — query couldn't be analyzed (unreachable table, etc.)

Thresholds: rows ≥10k WARN, ≥100k BLOCK; columns ≥50 WARN; JOIN fan-out ≥3× WARN. Pure aggregations / `LIMIT 1` auto-skip the probes. Callers can pass `run_hooks=False` for known-small queries. FROM-clause identifier guard prevents SQL injection in the fan-out probe.

### #24 + #25 — Context files + durable preferences

Three new tools implementing the domain-knowledge vision from the issues:

- **`list_context_files`** — scans `{project}/context/` for `.md / .yml / .yaml / .txt` files with first-line hints. Returns a markdown list the agent can use to pick targets for `read_project_file`.
- **`write_project_file`** — path-safe writes into `context/` only. Rejects path traversal, absolute paths, unsupported extensions, oversized content (>100 KB), and empty content. Resolves+verifies containment against `context/` as defense in depth.
- **`save_preference`** — append durable one-line rules to `{project}/preferences.yml`. Dedupes, escapes YAML specials, caps at 500 chars. `load_preferences()` in `agent.py` injects them into every new session's system prompt.

## Test plan

- [x] `pytest tests/ask/ --ignore=tests/ask/qa` → **874 passed in 58.75s** (up from 809; 65 new)
- [x] New files: `test_providers.py` (21), `test_execute_sql.py` (11), `test_preview_query.py` (12), `test_context_preferences.py` (21)
- [x] All previously-passing tests still green (zero regressions)
- [ ] Manual smoke: set `SEEKNAL_ASK_LLM_PROVIDER=openai` + `OPENAI_API_KEY`, confirm the agent picks up OpenAI
- [ ] Manual smoke: run a wide intentional query and confirm the truncation warnings render correctly in chat

## Not in this PR

- **#36, #37** — both blocked on PR #35 (OPEN, awaits maintainer review). Will close/action those once PR #35 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)