### PR TITLE
[codex] Add top-level --version support to seeknal CLI

### DIFF
--- a/src/seeknal/cli/main.py
+++ b/src/seeknal/cli/main.py
@@ -93,6 +93,7 @@ from datetime import datetime, timedelta
 from difflib import get_close_matches
 from enum import Enum
 from functools import wraps
+from importlib.metadata import PackageNotFoundError, version as package_version
 import os
 import sys
 from pathlib import Path
@@ -146,6 +147,13 @@ app = typer.Typer(
 
 @app.callback()
 def main_callback(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        help="Show the Seeknal version and exit",
+        callback=lambda value: _show_version(value),
+        is_eager=True,
+    ),
     no_animation: bool = typer.Option(False, "--no-animation", help="Disable all animations"),
     theme: str = typer.Option("", "--theme", help="UI theme: dark, light, dark-ansi, light-ansi, auto"),
 ):
@@ -591,10 +599,24 @@ class ValidationModeChoice(str, Enum):
 def _get_version() -> str:
     """Get package version."""
     try:
+        return package_version("seeknal")
+    except PackageNotFoundError:
+        pass
+
+    try:
         from seeknal import __version__
         return __version__
     except ImportError:
         return "1.0.0"
+
+
+def _show_version(value: bool) -> None:
+    """Print the installed Seeknal version and exit early."""
+    if not value:
+        return
+
+    typer.echo(_get_version())
+    raise typer.Exit()
 
 
 from seeknal.ui.output import echo_success as _ui_echo_success

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,6 +35,12 @@ runner = CliRunner()
 class TestVersionCommand:
     """Tests for the info command (displays version information)."""
 
+    def test_global_version_flag_displays_version(self):
+        """Global --version flag should print the CLI version."""
+        result = runner.invoke(app, ["--version"])
+        assert result.exit_code == 0
+        assert result.stdout.strip() == _get_version()
+
     def test_version_displays_seeknal_version(self):
         """Info command should display Seeknal version."""
         result = runner.invoke(app, ["info"])

--- a/tests/test_cli_e2e.py
+++ b/tests/test_cli_e2e.py
@@ -135,6 +135,12 @@ class TestDryRunWorkflow:
 class TestVersionWorkflow:
     """E2E tests for version information workflows."""
 
+    def test_global_version_flag(self):
+        """Test that the global version flag works without a subcommand."""
+        result = runner.invoke(app, ["--version"])
+        assert result.exit_code == 0
+        assert result.stdout.strip()
+
     def test_version_shows_all_components(self):
         """Test that version shows all component versions."""
         result = runner.invoke(app, ["info"])


### PR DESCRIPTION
## What changed
- added an eager top-level `seeknal --version` flag
- made version lookup prefer installed package metadata before falling back to `seeknal.__version__`
- added focused CLI and E2E coverage for the new flag

## Why it changed
The CLI exposed version details through `seeknal info`, but common shell and packaging workflows expect `seeknal --version` to work directly.

## User impact
Users can now check the installed Seeknal version with a standard CLI flag without invoking the broader dependency info command.

## Root cause
The CLI had no global `--version` option, so `seeknal --version` exited with an argument parsing error.

## Validation
- `uv run seeknal --version`
- `uv run seeknal --help`
- `uv run python -m py_compile src/seeknal/cli/main.py`
- pytest version-focused tests were attempted but skipped in this environment because `findspark` is missing
