### PR TITLE
[codex] Fix Ask entity catalog handling for consolidated feature stores

### DIFF
--- a/src/seeknal/ask/agents/tools/get_entity_schema.py
+++ b/src/seeknal/ask/agents/tools/get_entity_schema.py
@@ -29,7 +29,7 @@ def get_entity_schema(entity_name: str) -> str:
 
     feature_groups = catalog.get("feature_groups", {})
     for fg_name, fg_info in feature_groups.items():
-        features = fg_info.get("features", {})
+        features = ctx.artifact_discovery.get_feature_types(fg_info)
         lines.append(f"### Feature Group: `{fg_name}`")
         for fname, ftype in features.items():
             lines.append(f"  - `{fg_name}.{fname}` ({ftype})")

--- a/src/seeknal/ask/modules/artifact_discovery/service.py
+++ b/src/seeknal/ask/modules/artifact_discovery/service.py
@@ -7,7 +7,7 @@ the agent's system prompt.
 
 import json
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import yaml
 
@@ -161,6 +161,32 @@ class ArtifactDiscovery:
                 return entity
         return None
 
+    @staticmethod
+    def get_feature_types(fg_info: dict[str, Any]) -> dict[str, str]:
+        """Normalize feature metadata from an entity catalog entry.
+
+        Older test fixtures stored ``features`` as a ``{name: type}`` map.
+        Real consolidated catalogs store ``features`` as a list of names and
+        keep types in ``schema``. Support both shapes so prompt construction
+        and agent tools don't crash on real projects.
+        """
+        features = fg_info.get("features", {})
+        schema = fg_info.get("schema", {}) or {}
+
+        if isinstance(features, dict):
+            return {
+                str(name): str(ftype)
+                for name, ftype in features.items()
+            }
+
+        if isinstance(features, list):
+            return {
+                str(name): str(schema.get(name, "unknown"))
+                for name in features
+            }
+
+        return {}
+
     def _format_entities(self, entities: list[dict]) -> str:
         lines = ["## Available Entities\n"]
         for entity in entities:
@@ -174,7 +200,7 @@ class ArtifactDiscovery:
             if feature_groups:
                 lines.append("- **Feature groups**:")
                 for fg_name, fg_info in feature_groups.items():
-                    features = fg_info.get("features", {})
+                    features = self.get_feature_types(fg_info)
                     feature_list = [
                         f"`{fname}` ({ftype})"
                         for fname, ftype in features.items()

--- a/tests/ask/test_artifact_discovery.py
+++ b/tests/ask/test_artifact_discovery.py
@@ -101,6 +101,35 @@ class TestArtifactDiscovery:
         assert "demographics" in context
         assert "clean_orders" in context
 
+    def test_get_context_for_prompt_supports_list_backed_features(self, tmp_path):
+        target = tmp_path / "target"
+        fs = target / "feature_store" / "customer"
+        fs.mkdir(parents=True)
+        catalog = {
+            "entity_name": "customer",
+            "join_keys": ["customer_id"],
+            "feature_groups": {
+                "customer_features": {
+                    "name": "customer_features",
+                    "features": ["total_orders", "total_revenue"],
+                    "schema": {
+                        "customer_id": "VARCHAR",
+                        "total_orders": "BIGINT",
+                        "total_revenue": "DOUBLE",
+                    },
+                }
+            },
+        }
+        (fs / "_entity_catalog.json").write_text(json.dumps(catalog))
+
+        discovery = ArtifactDiscovery(tmp_path)
+
+        context = discovery.get_context_for_prompt()
+
+        assert "customer_features" in context
+        assert "`total_orders` (BIGINT)" in context
+        assert "`total_revenue` (DOUBLE)" in context
+
     def test_no_artifacts(self, tmp_path):
         discovery = ArtifactDiscovery(tmp_path)
         context = discovery.get_context_for_prompt()
@@ -114,6 +143,30 @@ class TestArtifactDiscovery:
         discovery = ArtifactDiscovery(tmp_path)
         entities = discovery._discover_entities()
         assert len(entities) == 0
+
+    def test_get_feature_types_supports_both_catalog_shapes(self):
+        dict_backed = {
+            "features": {
+                "age": "INTEGER",
+                "city": "VARCHAR",
+            }
+        }
+        list_backed = {
+            "features": ["total_orders", "total_revenue"],
+            "schema": {
+                "total_orders": "BIGINT",
+                "total_revenue": "DOUBLE",
+            },
+        }
+
+        assert ArtifactDiscovery.get_feature_types(dict_backed) == {
+            "age": "INTEGER",
+            "city": "VARCHAR",
+        }
+        assert ArtifactDiscovery.get_feature_types(list_backed) == {
+            "total_orders": "BIGINT",
+            "total_revenue": "DOUBLE",
+        }
 
 
 @pytest.fixture

--- a/tests/ask/test_get_entity_schema.py
+++ b/tests/ask/test_get_entity_schema.py
@@ -1,0 +1,42 @@
+"""Tests for the get_entity_schema ask tool."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from seeknal.ask.agents.tools._context import ToolContext, set_tool_context
+from seeknal.ask.agents.tools.get_entity_schema import get_entity_schema
+from seeknal.ask.modules.artifact_discovery.service import ArtifactDiscovery
+
+
+def test_get_entity_schema_supports_list_backed_catalog_features(tmp_path: Path):
+    discovery = ArtifactDiscovery(tmp_path)
+    catalog = {
+        "entity_name": "customer",
+        "join_keys": ["customer_id"],
+        "feature_groups": {
+            "customer_features": {
+                "name": "customer_features",
+                "features": ["total_orders", "total_revenue"],
+                "schema": {
+                    "customer_id": "VARCHAR",
+                    "total_orders": "BIGINT",
+                    "total_revenue": "DOUBLE",
+                },
+            }
+        },
+    }
+
+    discovery._entities_cache = [catalog]
+    set_tool_context(
+        ToolContext(
+            repl=MagicMock(),
+            artifact_discovery=discovery,
+            project_path=tmp_path,
+        )
+    )
+
+    result = get_entity_schema("customer")
+
+    assert "## Entity: `customer`" in result
+    assert "`customer_features.total_orders` (BIGINT)" in result
+    assert "`customer_features.total_revenue` (DOUBLE)" in result


### PR DESCRIPTION
## What changed
- normalized Ask entity-catalog feature metadata so both legacy dict-backed and real list-backed consolidated catalogs work
- reused the normalization in both prompt context generation and the `get_entity_schema` tool
- added regression tests for the consolidated catalog shape and schema tool path

## Why it changed
Interactive Ask sessions were crashing before answering questions when project catalogs came from the real consolidation pipeline.

## User impact
Users can ask questions against consolidated projects without hitting the `'list' object has no attribute 'items'` crash during context loading.

## Root cause
Ask assumed `feature_groups[*].features` was always a `{name: type}` map, but consolidated catalogs store feature names in `features` and types in `schema`.

## Validation
- `uv run pytest tests/ask/test_artifact_discovery.py tests/ask/test_get_entity_schema.py`
- interactive `seeknal ask chat` smoke test against `/Users/fitrakacamarga/project/self/bmad-new/seeknal-getting-started`
- verified prompts like `gimana bisnis saya` no longer hit the catalog-shape crash
