### PR TITLE
[codex] Bump Seeknal version to 2.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "seeknal"
-version = "2.8.0"
+version = "2.8.1"
 description = "All-in-one platform for data and AI/ML engineering"
 authors = [
     {name = "Fitra Kacamarga"}

--- a/src/seeknal/__init__.py
+++ b/src/seeknal/__init__.py
@@ -29,7 +29,7 @@ Example:
 For more information, see the documentation at https://seeknal.readthedocs.io/
 """
 
-__version__ = "2.6.3"
+__version__ = "2.8.1"
 
 # Export validation functions
 from .validation import (

--- a/uv.lock
+++ b/uv.lock
@@ -4062,7 +4062,7 @@ wheels = [
 
 [[package]]
 name = "seeknal"
-version = "2.6.3"
+version = "2.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## What changed
- bumped the project version to `2.8.1` in `pyproject.toml`
- updated `seeknal.__version__` to `2.8.1`
- synchronized the editable `uv.lock` package entry to `2.8.1`

## Why it changed
The repository is preparing the next patch release and the version metadata needed to be aligned across packaging and runtime version surfaces.

## User impact
Builds, installed package metadata, and `seeknal --version` now consistently report `2.8.1`.

## Validation
- `uv run python -c "from importlib.metadata import version; import seeknal; print(version('seeknal')); print(seeknal.__version__)"`
- `.venv/bin/seeknal --version`
- `uv run python -m py_compile src/seeknal/__init__.py src/seeknal/cli/main.py`
