### PR TITLE
Add HTTP-only Ask worker mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,16 @@ Supports Google Gemini (default), OpenAI-compatible providers, Anthropic-compati
 
 ## Changelog
 
+### v2.9.1 (April 2026)
+
+**HTTP-only Ask worker mode** — Adds a gateway-routed worker topology where workers only need outbound HTTP(S) to Seeknal Gateway or a compatible kc-service gateway.
+
+- **HTTP worker transport**: `seeknal gateway worker --transport http` long-polls gateway work-stream endpoints, runs Ask locally near the data, and posts streaming events plus completion back over HTTP.
+- **Gateway broker mode**: `seeknal gateway start --temporal --worker-transport http` and `seeknal gateway backend --worker-transport http` keep Temporal routing inside the gateway while external workers avoid Temporal credentials/network access.
+- **Token-routed runtime config**: token records can advertise `worker_transport: http`; workers still bootstrap from `SEEKNAL_GATEWAY_URL` + `SEEKNAL_API_TOKEN`.
+- **Worker reliability fixes**: project `.env` is loaded in worker mode, gateway polling retries transient connection failures, and Temporal activities heartbeat while waiting for HTTP workers.
+- **pydantic-deep compatibility**: skips unsupported `stuck_loop_detection` passthrough on current runtime versions while preserving config compatibility in tests/mocks.
+
 ### v2.9.0 (April 2026)
 
 **Read-only Ask source harness + project SQL QA** — Adds a TUI-first workflow for users who already have analytical tables in a database and want Seeknal Ask to answer business questions without building a pipeline.
@@ -181,15 +191,6 @@ Supports Google Gemini (default), OpenAI-compatible providers, Anthropic-compati
 - **`preview_query` tool**: four pre-execution safety probes (row count, column count, JOIN fan-out, dry-run reachability) — blocks queries returning ≥100k rows; pure aggregations auto-skip
 - **Context files**: `list_context_files` and `write_project_file` tools scan/write `{project}/context/` with path-traversal guards
 - **Durable preferences**: `save_preference` appends to `preferences.yml`; preferences are injected into the system prompt on every session
-
-### v2.7.1 (April 2026)
-
-**Gateway pairing + `execute_uv_script` + pipeline runtime helpers** — Additive batch combining gateway Telegram pairing, a new agent tool for running uv-managed scripts, and lightweight per-node runtime helpers.
-
-- **Gateway pairing**: `FilePairingStore`, `TelegramLinkStore`, `PublicSessionStore` wired into lifespan; `/pair` Telegram command for admin-generated codes
-- **`execute_uv_script` tool**: run arbitrary uv-managed Python scripts from the agent with full dependency isolation
-- **Pipeline runtime**: `ctx.llm` (Ask-aligned text/JSON generation) and `ctx.state` (lightweight per-node persistent state) helpers available inside `@transform` functions
-- **Config discovery**: `find_agent_config_path()` locates `seeknal_agent.yml` under project root or `seeknal/` directory
 
 ## Install from Source
 

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -67,6 +67,7 @@ WORKDIR /app/project
 # supplied after the image name, or by environment variables supported by the CLI:
 # TEMPORAL_ADDRESS, TEMPORAL_NAMESPACE, TEMPORAL_TASK_QUEUE,
 # TEMPORAL_MAX_CONCURRENT_ACTIVITIES, CALLBACK_BASE_URL, CALLBACK_AUTH_TOKEN,
-# SEEKNAL_GATEWAY_URL, and SEEKNAL_API_TOKEN.
+# SEEKNAL_GATEWAY_URL, SEEKNAL_API_TOKEN, and SEEKNAL_WORKER_TRANSPORT=http
+# for HTTP-only gateway-routed mode.
 ENTRYPOINT ["seeknal", "gateway", "worker"]
 CMD []

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,7 +9,7 @@ context so the Dockerfiles can copy `pyproject.toml`, `README.md`, and `src/`.
 | Dockerfile | Image purpose | Default command |
 | --- | --- | --- |
 | `docker/Dockerfile.gateway` | Seeknal Ask HTTP gateway for REST, SSE, WebSocket, Telegram, and Temporal client mode | `seeknal gateway start --project /app/project --port 8000 --host 0.0.0.0 --temporal --no-worker` |
-| `docker/Dockerfile.worker` | Standalone Temporal worker that runs Ask agent turns near the data | `seeknal gateway worker` |
+| `docker/Dockerfile.worker` | Standalone Ask worker. Supports Temporal SDK mode and HTTP-only gateway-routed mode | `seeknal gateway worker` |
 | `docker/Dockerfile.prefect` | Prefect deployment runner for Seeknal pipeline projects | `seeknal prefect serve --project-path /app` |
 | `docker/report-server/Dockerfile` | Report server for published Evidence-style reports | `seeknal report-server` |
 
@@ -63,8 +63,8 @@ docker run --rm \
   seeknal-worker:local --project /app/project
 ```
 
-For token-routed multi-tenant worker deployments, let the worker fetch its queue
-and callback configuration from the gateway:
+For token-routed multi-tenant Temporal worker deployments, let the worker fetch
+its queue and callback configuration from the gateway:
 
 ```bash
 docker run --rm \
@@ -74,6 +74,25 @@ docker run --rm \
   -e SEEKNAL_API_TOKEN="$SEEKNAL_API_TOKEN" \
   seeknal-worker:local --project /app/project
 ```
+
+For HTTP-only worker deployments, the worker has no Temporal address, queue, or
+credentials. It long-polls the gateway/kc-service for work and posts streaming
+events/completion back over HTTP:
+
+```bash
+docker run --rm \
+  -v /path/to/seeknal-project:/app/project \
+  --env-file /path/to/seeknal-project/.env \
+  -e SEEKNAL_WORKER_TRANSPORT=http \
+  -e SEEKNAL_GATEWAY_URL=https://gateway.example.com \
+  -e SEEKNAL_API_TOKEN="$SEEKNAL_API_TOKEN" \
+  seeknal-worker:local --project /app/project
+```
+
+The gateway side must run a Temporal worker activity in HTTP broker mode, for
+example `seeknal gateway start --temporal --worker-transport http` or `seeknal
+gateway backend --worker-transport http`. In this topology the gateway owns
+Temporal routing and the external worker only needs outbound HTTPS.
 
 ## Compose
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "seeknal"
-version = "2.9.0"
+version = "2.9.1"
 description = "All-in-one platform for data and AI/ML engineering"
 authors = [
     {name = "Fitra Kacamarga"}

--- a/src/seeknal/__init__.py
+++ b/src/seeknal/__init__.py
@@ -29,7 +29,7 @@ Example:
 For more information, see the documentation at https://seeknal.readthedocs.io/
 """
 
-__version__ = "2.9.0"
+__version__ = "2.9.1"
 
 # Export validation functions
 from .validation import (

--- a/src/seeknal/ask/agents/agent.py
+++ b/src/seeknal/ask/agents/agent.py
@@ -524,9 +524,21 @@ a plain-language follow-up in the final response; do not call `ask_user`.
         parameter.kind == inspect.Parameter.VAR_KEYWORD
         for parameter in _sig.parameters.values()
     )
+    # pydantic-deep 0.3.x exposes ``**agent_kwargs`` but still rejects some
+    # unknown experimental config keys in the underlying Agent constructor. Keep
+    # tests/mocks flexible, but avoid known runtime-incompatible kwargs for the
+    # real pydantic_deep implementation.
+    _real_pydantic_deep = getattr(create_deep_agent, "__module__", "").startswith(
+        "pydantic_deep"
+    )
+    _known_unsupported_kwargs = (
+        {"stuck_loop_detection"} if _real_pydantic_deep else set()
+    )
 
     def _supported_kwarg(name: str, value):
-        if _accepts_kwargs or name in _sig.parameters:
+        if name in _sig.parameters or (
+            _accepts_kwargs and name not in _known_unsupported_kwargs
+        ):
             return {name: value}
         return {}
 

--- a/src/seeknal/ask/gateway/auth.py
+++ b/src/seeknal/ask/gateway/auth.py
@@ -39,6 +39,7 @@ class TokenPrincipal:
     project_path: str | None = None
     temporal_address: str | None = None
     temporal_namespace: str | None = None
+    worker_transport: str | None = None
     role: str | None = None
 
     @property
@@ -58,6 +59,7 @@ class WorkerRuntimeConfig:
     temporal_address: str | None = None
     temporal_namespace: str | None = None
     project_path: str | None = None
+    worker_transport: str | None = None
 
     def public_dict(self) -> dict[str, str | None]:
         return {
@@ -68,6 +70,7 @@ class WorkerRuntimeConfig:
             "temporal_address": self.temporal_address,
             "temporal_namespace": self.temporal_namespace,
             "project_path": self.project_path,
+            "worker_transport": self.worker_transport,
         }
 
 
@@ -116,6 +119,7 @@ class TokenRegistry:
         default_temporal_address: str | None = None,
         default_temporal_namespace: str | None = None,
         default_project_path: str | None = None,
+        default_worker_transport: str | None = None,
     ) -> WorkerRuntimeConfig:
         principal = self.resolve(token)
         return WorkerRuntimeConfig(
@@ -126,6 +130,7 @@ class TokenRegistry:
             temporal_address=principal.temporal_address or default_temporal_address,
             temporal_namespace=principal.temporal_namespace or default_temporal_namespace,
             project_path=principal.project_path or default_project_path,
+            worker_transport=principal.worker_transport or default_worker_transport,
         )
 
 
@@ -248,6 +253,9 @@ def _parse_token_records(raw: Any) -> list[TokenPrincipal]:
                 project_path=_optional_str(record.get("project_path")),
                 temporal_address=_optional_str(record.get("temporal_address")),
                 temporal_namespace=_optional_str(record.get("temporal_namespace")),
+                worker_transport=_optional_str(
+                    record.get("worker_transport") or record.get("transport")
+                ),
                 role=_optional_str(record.get("role")),
             )
         )

--- a/src/seeknal/ask/gateway/http_worker.py
+++ b/src/seeknal/ask/gateway/http_worker.py
@@ -1,0 +1,186 @@
+"""HTTP-only worker broker for gateway-routed Seeknal workers.
+
+This module is intentionally dependency-light. It provides an in-process async
+broker used when the gateway hosts the Temporal workflow/activity, but the agent
+execution is delegated to an on-prem worker that only talks HTTP(S) to the
+gateway/kc-service.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+import time
+from typing import Any
+from uuid import uuid4
+
+from seeknal.ask.gateway.tenant import DEFAULT_TENANT
+
+
+@dataclass(frozen=True)
+class HttpWorkerItem:
+    """A single unit of agent work delivered to an HTTP-only worker."""
+
+    work_id: str
+    tenant_id: str
+    session_id: str
+    question: str
+    project_path: str
+    provider: str | None = None
+    model: str | None = None
+    created_at: float = field(default_factory=time.time)
+
+    def public_dict(self) -> dict[str, Any]:
+        return {
+            "work_id": self.work_id,
+            "tenant_id": self.tenant_id,
+            "session_id": self.session_id,
+            "question": self.question,
+            "project_path": self.project_path,
+            "provider": self.provider,
+            "model": self.model,
+            "created_at": self.created_at,
+        }
+
+
+@dataclass(frozen=True)
+class HttpWorkerResult:
+    """Final result posted by an HTTP-only worker."""
+
+    answer: str = ""
+    event_count: int = 0
+    error: str | None = None
+
+
+class HttpWorkerBroker:
+    """In-memory queue for HTTP-only workers.
+
+    This broker is scoped to a single gateway process. It is a deliberately thin
+    first implementation: production multi-replica deployments can put the same
+    endpoint contract in front of Redis or another durable broker without
+    changing worker behavior.
+    """
+
+    def __init__(self) -> None:
+        self._condition = asyncio.Condition()
+        self._pending: list[HttpWorkerItem] = []
+        self._inflight: dict[str, HttpWorkerItem] = {}
+        self._futures: dict[str, asyncio.Future[HttpWorkerResult]] = {}
+
+    async def reset(self) -> None:
+        """Clear broker state. Intended for tests and controlled shutdown."""
+        async with self._condition:
+            for future in self._futures.values():
+                if not future.done():
+                    future.cancel()
+            self._pending.clear()
+            self._inflight.clear()
+            self._futures.clear()
+            self._condition.notify_all()
+
+    async def enqueue_and_wait(
+        self,
+        *,
+        session_id: str,
+        question: str,
+        project_path: str,
+        tenant_id: str = DEFAULT_TENANT,
+        provider: str | None = None,
+        model: str | None = None,
+        timeout: float | None = None,
+    ) -> HttpWorkerResult:
+        """Enqueue work and wait for a matching completion POST."""
+        loop = asyncio.get_running_loop()
+        item = HttpWorkerItem(
+            work_id=uuid4().hex,
+            tenant_id=tenant_id,
+            session_id=session_id,
+            question=question,
+            project_path=project_path,
+            provider=provider,
+            model=model,
+        )
+        future: asyncio.Future[HttpWorkerResult] = loop.create_future()
+        async with self._condition:
+            self._pending.append(item)
+            self._futures[item.work_id] = future
+            self._condition.notify_all()
+
+        try:
+            if timeout is None:
+                return await future
+            return await asyncio.wait_for(future, timeout=timeout)
+        except BaseException:
+            await self.discard(item.work_id)
+            raise
+
+    async def claim_next(
+        self,
+        *,
+        tenant_id: str,
+        timeout: float = 30.0,
+    ) -> HttpWorkerItem | None:
+        """Return the next pending item for a tenant, or ``None`` on timeout."""
+        deadline = time.monotonic() + max(timeout, 0.0)
+        async with self._condition:
+            while True:
+                for index, item in enumerate(self._pending):
+                    if item.tenant_id == tenant_id:
+                        claimed = self._pending.pop(index)
+                        self._inflight[claimed.work_id] = claimed
+                        return claimed
+
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return None
+                try:
+                    await asyncio.wait_for(self._condition.wait(), timeout=remaining)
+                except asyncio.TimeoutError:
+                    return None
+
+    async def complete(
+        self,
+        *,
+        work_id: str,
+        tenant_id: str,
+        result: HttpWorkerResult,
+    ) -> bool:
+        """Complete an in-flight item if it belongs to the tenant."""
+        async with self._condition:
+            item = self._inflight.get(work_id)
+            if item is None or item.tenant_id != tenant_id:
+                return False
+            self._inflight.pop(work_id, None)
+            future = self._futures.pop(work_id, None)
+            if future is not None and not future.done():
+                future.set_result(result)
+            self._condition.notify_all()
+            return True
+
+    async def fail(self, *, work_id: str, tenant_id: str, error: str) -> bool:
+        return await self.complete(
+            work_id=work_id,
+            tenant_id=tenant_id,
+            result=HttpWorkerResult(error=error),
+        )
+
+    async def discard(self, work_id: str) -> None:
+        """Remove work after cancellation/timeout."""
+        async with self._condition:
+            self._pending = [item for item in self._pending if item.work_id != work_id]
+            self._inflight.pop(work_id, None)
+            future = self._futures.pop(work_id, None)
+            if future is not None and not future.done():
+                future.cancel()
+            self._condition.notify_all()
+
+    async def owns(self, *, work_id: str, tenant_id: str) -> HttpWorkerItem | None:
+        """Return item if a tenant owns it, otherwise ``None``."""
+        async with self._condition:
+            item = self._inflight.get(work_id)
+            if item is not None and item.tenant_id == tenant_id:
+                return item
+            return None
+
+
+http_worker_broker = HttpWorkerBroker()

--- a/src/seeknal/ask/gateway/server.py
+++ b/src/seeknal/ask/gateway/server.py
@@ -21,7 +21,7 @@ from typing import Any, Callable
 
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import FileResponse, JSONResponse, StreamingResponse
+from starlette.responses import FileResponse, JSONResponse, Response, StreamingResponse
 from starlette.routing import Mount, Route, WebSocketRoute
 from starlette.staticfiles import StaticFiles
 from starlette.websockets import WebSocket, WebSocketDisconnect
@@ -1308,6 +1308,82 @@ async def publish_event_callback(request: Request) -> JSONResponse:
     return JSONResponse({"status": "published"})
 
 
+
+
+async def http_worker_work_stream(request: Request) -> Response:
+    """Long-poll one work item for an HTTP-only worker.
+
+    Token mode derives the tenant from the worker API token. Compatibility mode
+    falls back to the existing tenant header/query resolver for local tests.
+    """
+    auth, err = _safe_auth_context(request)
+    if err:
+        return err
+
+    try:
+        timeout = float(request.query_params.get("timeout", "30"))
+    except ValueError:
+        timeout = 30.0
+    timeout = max(0.0, min(timeout, 60.0))
+
+    from seeknal.ask.gateway.http_worker import http_worker_broker
+
+    item = await http_worker_broker.claim_next(
+        tenant_id=auth.tenant_id,
+        timeout=timeout,
+    )
+    if item is None:
+        return Response(status_code=204)
+    return JSONResponse(item.public_dict())
+
+
+async def http_worker_work_event(request: Request) -> JSONResponse:
+    """Receive a streaming event from an HTTP-only worker and publish it to SSE."""
+    auth, err = _safe_auth_context(request)
+    if err:
+        return err
+
+    work_id = request.path_params["work_id"]
+    from seeknal.ask.gateway.http_worker import http_worker_broker
+
+    item = await http_worker_broker.owns(work_id=work_id, tenant_id=auth.tenant_id)
+    if item is None:
+        return JSONResponse({"error": "unknown work_id"}, status_code=404)
+
+    body = await request.json()
+    event_json = json.dumps(body)
+    await request.app.state.broadcaster.publish(
+        item.session_id,
+        event_json,
+        tenant_id=item.tenant_id,
+    )
+    return JSONResponse({"status": "published"})
+
+
+async def http_worker_work_complete(request: Request) -> JSONResponse:
+    """Receive final completion from an HTTP-only worker."""
+    auth, err = _safe_auth_context(request)
+    if err:
+        return err
+
+    work_id = request.path_params["work_id"]
+    body = await request.json()
+    from seeknal.ask.gateway.http_worker import HttpWorkerResult, http_worker_broker
+
+    ok = await http_worker_broker.complete(
+        work_id=work_id,
+        tenant_id=auth.tenant_id,
+        result=HttpWorkerResult(
+            answer=str(body.get("answer") or ""),
+            event_count=int(body.get("event_count") or 0),
+            error=body.get("error"),
+        ),
+    )
+    if not ok:
+        return JSONResponse({"error": "unknown work_id"}, status_code=404)
+    return JSONResponse({"status": "completed"})
+
+
 async def worker_config(request: Request) -> JSONResponse:
     """Return token-derived runtime config for a standalone worker.
 
@@ -1333,6 +1409,9 @@ async def worker_config(request: Request) -> JSONResponse:
                 default_project_path=getattr(
                     request.app.state, "worker_project_path", None
                 ),
+                default_worker_transport=getattr(
+                    request.app.state, "worker_transport", None
+                ),
             )
         except TokenAuthError as exc:
             return JSONResponse({"error": str(exc)}, status_code=401)
@@ -1349,6 +1428,7 @@ async def worker_config(request: Request) -> JSONResponse:
         temporal_address=getattr(request.app.state, "temporal_address", None),
         temporal_namespace=getattr(request.app.state, "temporal_namespace", None),
         project_path=getattr(request.app.state, "worker_project_path", None),
+        worker_transport=getattr(request.app.state, "worker_transport", None),
     )
     return JSONResponse(cfg.public_dict())
 
@@ -1365,6 +1445,7 @@ def create_gateway_app(
     token_config: str | Path | None = None,
     temporal_address: str | None = None,
     temporal_namespace: str | None = None,
+    worker_transport: str | None = None,
 ) -> Starlette:
     """Create the Starlette ASGI application.
 
@@ -1388,6 +1469,8 @@ def create_gateway_app(
         temporal_address: Temporal address advertised to token-authenticated
             workers through ``/internal/worker/config``.
         temporal_namespace: Temporal namespace advertised to workers.
+        worker_transport: Worker execution transport advertised to token-routed
+            workers (for example ``temporal`` or ``http``).
     """
     # Backend-only mode: no project_path means no in-process agent execution.
     # Only Temporal dispatch, SSE fan-out, and session listing work.
@@ -1408,6 +1491,9 @@ def create_gateway_app(
             methods=["POST"],
         ),
         Route("/internal/worker/config", worker_config, methods=["GET"]),
+        Route("/internal/worker/work-stream", http_worker_work_stream, methods=["GET"]),
+        Route("/internal/worker/work/{work_id}/event", http_worker_work_event, methods=["POST"]),
+        Route("/internal/worker/work/{work_id}/complete", http_worker_work_complete, methods=["POST"]),
     ]
 
     # In-process agent execution routes are only available when a project
@@ -1508,6 +1594,7 @@ def create_gateway_app(
     app.state.token_registry = token_registry or load_token_registry(token_config)
     app.state.temporal_address = temporal_address
     app.state.temporal_namespace = temporal_namespace
+    app.state.worker_transport = worker_transport
     if temporal_client is not None:
         app.state.temporal_client = temporal_client
     return app

--- a/src/seeknal/ask/gateway/temporal.py
+++ b/src/seeknal/ask/gateway/temporal.py
@@ -103,6 +103,45 @@ if TEMPORAL_AVAILABLE:
 
         from seeknal.ask.gateway.server import _run_agent_streaming
 
+        # HTTP-only worker mode: the gateway/Temporal activity brokers work
+        # to an external worker over HTTP. The external worker does not connect
+        # to Temporal; it long-polls the gateway, runs the agent locally, and
+        # posts completion back. Keep the default as local execution for
+        # backward compatibility.
+        import os as _os
+        worker_transport = _os.environ.get("SEEKNAL_WORKER_TRANSPORT", "temporal").strip().lower()
+        if worker_transport in {"http", "gateway", "poll"}:
+            from seeknal.ask.gateway.http_worker import http_worker_broker
+
+            async def _http_heartbeat_loop():
+                while True:
+                    await asyncio.sleep(10)
+                    activity.heartbeat("waiting for HTTP worker")
+
+            heartbeat_task = asyncio.create_task(_http_heartbeat_loop())
+            try:
+                timeout = float(_os.environ.get("SEEKNAL_HTTP_WORK_TIMEOUT_SECONDS", "300"))
+                result = await http_worker_broker.enqueue_and_wait(
+                    session_id=input.session_id,
+                    question=input.question,
+                    project_path=input.project_path,
+                    tenant_id=input.tenant_id,
+                    provider=input.provider,
+                    model=input.model,
+                    timeout=timeout,
+                )
+                return AgentWorkflowOutput(
+                    answer=result.answer,
+                    event_count=result.event_count,
+                    error=result.error,
+                )
+            finally:
+                heartbeat_task.cancel()
+                try:
+                    await heartbeat_task
+                except asyncio.CancelledError:
+                    pass
+
         # Set up HTTP client for callback if URL provided (on-prem worker mode)
         http_session = None
         callback_headers: dict[str, str] = {}
@@ -133,7 +172,6 @@ if TEMPORAL_AVAILABLE:
         # Worker override: SEEKNAL_PROJECT_PATH env var takes precedence over
         # input.project_path. This lets a standalone worker use its own local
         # project path instead of the gateway's (for split topologies).
-        import os as _os
         effective_project_path = _os.environ.get("SEEKNAL_PROJECT_PATH") or input.project_path
 
         try:

--- a/src/seeknal/cli/gateway.py
+++ b/src/seeknal/cli/gateway.py
@@ -63,6 +63,10 @@ def gateway_start(
         None, "--token-config", envvar="SEEKNAL_TOKEN_CONFIG",
         help="JSON/YAML API token registry for tenant-scoped worker routing"
     ),
+    worker_transport: str = typer.Option(
+        "temporal", "--worker-transport", envvar="SEEKNAL_WORKER_TRANSPORT",
+        help="Temporal activity execution transport: temporal/local or http for HTTP-only workers"
+    ),
 ):
     """Start the seeknal ask gateway server."""
     project_path = project or find_project_path()
@@ -152,6 +156,8 @@ def gateway_start(
                 if not no_worker:
                     import asyncio
 
+                    if worker_transport:
+                        os.environ["SEEKNAL_WORKER_TRANSPORT"] = worker_transport
                     worker = create_temporal_worker(
                         client,
                         task_queue=temporal_task_queue,
@@ -159,7 +165,7 @@ def gateway_start(
                     )
                     worker_task = asyncio.create_task(worker.run())
                     typer.echo(typer.style(
-                        f"Temporal worker enabled (queue={temporal_task_queue}, max_activities={max_activities})",
+                        f"Temporal worker enabled (queue={temporal_task_queue}, max_activities={max_activities}, transport={worker_transport})",
                         fg=typer.colors.GREEN,
                     ))
                 else:
@@ -208,6 +214,7 @@ def gateway_start(
         token_config=token_config,
         temporal_address=temporal_address,
         temporal_namespace=temporal_namespace,
+        worker_transport=worker_transport,
     )
     if worker_project_path:
         app.state.worker_project_path = worker_project_path
@@ -262,6 +269,14 @@ def gateway_backend(
         None, "--token-config", envvar="SEEKNAL_TOKEN_CONFIG",
         help="JSON/YAML API token registry for tenant-scoped worker routing"
     ),
+    max_activities: int = typer.Option(
+        15, "--max-activities", envvar="TEMPORAL_MAX_CONCURRENT_ACTIVITIES",
+        help="Maximum concurrent Temporal activities for gateway-hosted broker workers"
+    ),
+    worker_transport: str = typer.Option(
+        "temporal", "--worker-transport", envvar="SEEKNAL_WORKER_TRANSPORT",
+        help="Set to http to make the gateway-hosted Temporal activity broker work to HTTP-only workers"
+    ),
 ):
     """Start the seeknal ask gateway in backend-only mode.
 
@@ -303,7 +318,7 @@ def gateway_backend(
 
     @asynccontextmanager
     async def lifespan(app):
-        from seeknal.ask.gateway.temporal import connect_temporal_client
+        from seeknal.ask.gateway.temporal import connect_temporal_client, create_temporal_worker
 
         client = await connect_temporal_client(
             address=temporal_address,
@@ -317,6 +332,24 @@ def gateway_backend(
                 f"Temporal client connected (queue={temporal_task_queue})",
                 fg=typer.colors.GREEN,
             ))
+            worker = None
+            worker_task = None
+            if worker_transport.strip().lower() in {"http", "gateway", "poll"}:
+                import asyncio
+
+                os.environ["SEEKNAL_WORKER_TRANSPORT"] = "http"
+                worker = create_temporal_worker(
+                    client,
+                    task_queue=temporal_task_queue,
+                    max_concurrent_activities=max_activities,
+                )
+                worker_task = asyncio.create_task(worker.run())
+                app.state.http_broker_worker = worker
+                app.state.http_broker_worker_task = worker_task
+                typer.echo(typer.style(
+                    f"HTTP worker broker enabled (queue={temporal_task_queue}, max_activities={max_activities})",
+                    fg=typer.colors.GREEN,
+                ))
         else:
             typer.echo(typer.style(
                 f"Failed to connect to Temporal at {temporal_address}",
@@ -324,7 +357,14 @@ def gateway_backend(
             ))
             raise typer.Exit(1)
 
-        yield
+        try:
+            yield
+        finally:
+            worker_task = getattr(app.state, "http_broker_worker_task", None)
+            worker = getattr(app.state, "http_broker_worker", None)
+            if worker_task is not None and worker is not None:
+                await worker.shutdown()
+                await worker_task
 
     effective_callback_url = callback_url or f"http://{host}:{port}"
 
@@ -338,6 +378,7 @@ def gateway_backend(
         token_config=token_config,
         temporal_address=temporal_address,
         temporal_namespace=temporal_namespace,
+        worker_transport=worker_transport,
     )
     if worker_project_path:
         app.state.worker_project_path = worker_project_path
@@ -359,6 +400,95 @@ def gateway_backend(
     typer.echo(typer.style("  (no /ask, no /ws — backend mode)", fg=typer.colors.YELLOW))
 
     uvicorn.run(app, host=host, port=port, log_level="info")
+
+
+async def _run_http_only_worker(
+    *,
+    project_path: Path,
+    gateway_url: str,
+    api_token: str,
+    poll_timeout: float = 30.0,
+) -> None:
+    """Run a worker that talks only HTTP(S) to the gateway/kc-service."""
+    import httpx
+
+    from seeknal.ask.gateway.server import _run_agent_streaming
+    from seeknal.ask.gateway.tenant import DEFAULT_TENANT
+
+    base_url = gateway_url.rstrip("/")
+    headers = {"Authorization": f"Bearer {api_token}"}
+
+    typer.echo("Seeknal HTTP worker started")
+    typer.echo(f"  Project: {project_path}")
+    typer.echo(f"  Gateway: {base_url}")
+    typer.echo("  Transport: http-only")
+
+    async with httpx.AsyncClient(timeout=None) as client:
+        while True:
+            try:
+                response = await client.get(
+                    f"{base_url}/internal/worker/work-stream",
+                    headers=headers,
+                    params={"timeout": poll_timeout},
+                    timeout=poll_timeout + 10,
+                )
+            except httpx.RequestError as exc:
+                typer.echo(typer.style(
+                    f"Gateway poll failed: {exc}; retrying",
+                    fg=typer.colors.YELLOW,
+                ))
+                await asyncio.sleep(5)
+                continue
+            if response.status_code == 204:
+                continue
+            response.raise_for_status()
+            work = response.json()
+            work_id = work["work_id"]
+            session_id = work["session_id"]
+            tenant_id = work.get("tenant_id") or DEFAULT_TENANT
+            question = work["question"]
+            answer = ""
+            error = None
+            event_count = 0
+
+            async def post_event(event: dict) -> None:
+                await client.post(
+                    f"{base_url}/internal/worker/work/{work_id}/event",
+                    headers=headers,
+                    json=event,
+                    timeout=15.0,
+                )
+
+            try:
+                async for event in _run_agent_streaming(
+                    project_path,
+                    session_id,
+                    question,
+                    provider=work.get("provider"),
+                    model=work.get("model"),
+                    tenant_id=tenant_id,
+                ):
+                    event_count += 1
+                    if event.get("type") == "answer":
+                        answer = str(event.get("data") or "")
+                    elif event.get("type") == "error":
+                        error = str(event.get("data") or "")
+                    await post_event(event)
+            except Exception as exc:  # noqa: BLE001 - surface worker failures to gateway
+                error = str(exc)
+                await post_event({"type": "error", "data": error})
+                await post_event({"type": "done"})
+            finally:
+                await client.post(
+                    f"{base_url}/internal/worker/work/{work_id}/complete",
+                    headers=headers,
+                    json={
+                        "answer": answer,
+                        "event_count": event_count,
+                        "error": error,
+                    },
+                    timeout=15.0,
+                )
 
 
 @gateway_app.command("worker")
@@ -390,32 +520,40 @@ def gateway_worker(
         None, "--api-token", envvar="SEEKNAL_API_TOKEN",
         help="Worker API token used to fetch tenant queue/callback config from the gateway"
     ),
+    transport: str = typer.Option(
+        "auto", "--transport", envvar="SEEKNAL_WORKER_TRANSPORT",
+        help="Worker transport: auto, temporal, or http. http uses no Temporal SDK connection."
+    ),
 ):
-    """Start a standalone Temporal worker (no HTTP server).
+    """Start a standalone worker.
 
-    Connects to Temporal, polls the task queue, and executes agent
-    activities locally. Use this for on-prem worker deployments where
-    the gateway runs elsewhere.
-
-    Streaming events are POSTed to the gateway's callback URL.
+    In temporal mode, connects to Temporal and polls a task queue. In HTTP
+    mode, talks only to the gateway/kc-service using SEEKNAL_GATEWAY_URL and
+    SEEKNAL_API_TOKEN; the gateway owns Temporal routing.
     """
     import asyncio
 
     project_path = project or find_project_path()
+    from seeknal.cli.ask import _load_project_env
+    _load_project_env(project_path)
+    transport = (transport or "auto").strip().lower()
 
-    try:
-        from seeknal.ask.gateway.temporal import (
-            _require_temporal,
-            connect_temporal_client,
-            create_temporal_worker,
-        )
-        _require_temporal()
-    except ImportError:
-        typer.echo(typer.style(
-            "Temporal requires: pip install seeknal[temporal]",
-            fg=typer.colors.RED,
-        ))
-        raise typer.Exit(1)
+    if transport in {"http", "gateway", "poll"}:
+        if not gateway_url or not api_token:
+            typer.echo(typer.style(
+                "HTTP worker mode requires --gateway-url and --api-token",
+                fg=typer.colors.RED,
+            ))
+            raise typer.Exit(1)
+        try:
+            asyncio.run(_run_http_only_worker(
+                project_path=project_path,
+                gateway_url=gateway_url,
+                api_token=api_token,
+            ))
+        except KeyboardInterrupt:
+            typer.echo("\nHTTP worker stopped.")
+        return
 
     from seeknal.ask.gateway.tenant import task_queue_for_tenant
 
@@ -446,6 +584,14 @@ def gateway_worker(
             )
             response.raise_for_status()
             runtime_config = response.json()
+            config_transport = str(runtime_config.get("worker_transport") or "").strip().lower()
+            if transport == "auto" and config_transport in {"http", "gateway", "poll"}:
+                asyncio.run(_run_http_only_worker(
+                    project_path=project_path,
+                    gateway_url=gateway_url,
+                    api_token=api_token,
+                ))
+                return
         except Exception as exc:
             typer.echo(typer.style(
                 f"Failed to fetch worker config from gateway: {exc}",
@@ -461,6 +607,20 @@ def gateway_worker(
         if project is None and runtime_config.get("project_path"):
             project_path = Path(runtime_config["project_path"])
         tenant = runtime_config.get("tenant_id") or tenant
+
+    try:
+        from seeknal.ask.gateway.temporal import (
+            _require_temporal,
+            connect_temporal_client,
+            create_temporal_worker,
+        )
+        _require_temporal()
+    except ImportError:
+        typer.echo(typer.style(
+            "Temporal requires: pip install seeknal[temporal]",
+            fg=typer.colors.RED,
+        ))
+        raise typer.Exit(1)
 
     async def _run_worker():
         client = await connect_temporal_client(

--- a/tests/ask/test_gateway_token_auth.py
+++ b/tests/ask/test_gateway_token_auth.py
@@ -32,13 +32,20 @@ def registry(tmp_path):
 def test_load_token_registry_from_mapping_env(monkeypatch):
     monkeypatch.setenv(
         "SEEKNAL_API_TOKENS",
-        json.dumps({"sk-1": {"tenant_id": "tenant1", "task_queue": "queue1"}}),
+        json.dumps({
+            "sk-1": {
+                "tenant_id": "tenant1",
+                "task_queue": "queue1",
+                "worker_transport": "http",
+            }
+        }),
     )
 
     principal = load_token_registry().resolve("sk-1")
 
     assert principal.tenant_id == "tenant1"
     assert principal.task_queue == "queue1"
+    assert principal.worker_transport == "http"
 
 
 def test_worker_config_derives_queue_and_callback_from_token(tmp_path, registry):
@@ -49,6 +56,7 @@ def test_worker_config_derives_queue_and_callback_from_token(tmp_path, registry)
         callback_base_url="https://fallback.example.com",
         temporal_address="localhost:7233",
         temporal_namespace="default",
+        worker_transport="http",
     )
 
     with TestClient(app) as client:
@@ -65,6 +73,7 @@ def test_worker_config_derives_queue_and_callback_from_token(tmp_path, registry)
     assert body["callback_url"] == "https://gateway.example.com"
     assert body["temporal_address"] == "temporal.example.com:7233"
     assert body["temporal_namespace"] == "seeknal-prod"
+    assert body["worker_transport"] == "http"
 
 
 def test_token_mode_requires_auth_for_tenant_scoped_routes(tmp_path, registry):
@@ -143,3 +152,86 @@ def test_temporal_start_derives_queue_from_token_and_rejects_overrides(tmp_path,
     assert workflow_input.tenant_id == "acme"
     assert workflow_input.callback_auth_token == "cb-acme-worker"
     assert workflow_input.project_path == str(tmp_path / "worker-project")
+
+
+@pytest.mark.asyncio
+async def test_http_worker_stream_is_token_scoped_and_completes(tmp_path, registry):
+    """HTTP-only workers receive tenant work via gateway without Temporal access."""
+    import asyncio
+    import httpx
+
+    from seeknal.ask.gateway.http_worker import http_worker_broker
+
+    await http_worker_broker.reset()
+    app = create_gateway_app(
+        project_path=None,
+        sessions_dir=tmp_path,
+        token_registry=registry,
+        worker_transport="http",
+    )
+    from seeknal.ask.gateway.sse import SSEBroadcaster
+    app.state.broadcaster = SSEBroadcaster()
+
+    async def enqueue():
+        return await http_worker_broker.enqueue_and_wait(
+            session_id="sess-http",
+            question="hello",
+            project_path=str(tmp_path / "worker-project"),
+            tenant_id="acme",
+            timeout=5,
+        )
+
+    wait_task = asyncio.create_task(enqueue())
+    await asyncio.sleep(0)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get(
+            "/internal/worker/work-stream",
+            params={"timeout": 1},
+            headers={"Authorization": "Bearer sk-acme-worker"},
+        )
+        assert response.status_code == 200
+        work = response.json()
+        assert work["tenant_id"] == "acme"
+        assert work["session_id"] == "sess-http"
+        assert work["question"] == "hello"
+
+        sse_queue = app.state.broadcaster.subscribe("sess-http", tenant_id="acme")
+        event_response = await client.post(
+            f"/internal/worker/work/{work['work_id']}/event",
+            headers={"Authorization": "Bearer sk-acme-worker"},
+            json={"type": "token", "data": "hi"},
+        )
+        assert event_response.status_code == 200
+        assert json.loads(sse_queue.get_nowait())["data"] == "hi"
+
+        complete_response = await client.post(
+            f"/internal/worker/work/{work['work_id']}/complete",
+            headers={"Authorization": "Bearer sk-acme-worker"},
+            json={"answer": "done", "event_count": 3},
+        )
+        assert complete_response.status_code == 200
+
+    result = await wait_task
+    assert result.answer == "done"
+    assert result.event_count == 3
+    assert result.error is None
+    await http_worker_broker.reset()
+
+
+@pytest.mark.asyncio
+async def test_http_worker_stream_rejects_missing_token_in_token_mode(tmp_path, registry):
+    import httpx
+
+    app = create_gateway_app(
+        project_path=None,
+        sessions_dir=tmp_path,
+        token_registry=registry,
+        worker_transport="http",
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get("/internal/worker/work-stream", params={"timeout": 0})
+
+    assert response.status_code == 401

--- a/tests/ask/test_temporal_integration.py
+++ b/tests/ask/test_temporal_integration.py
@@ -297,3 +297,43 @@ class TestTemporalWorkerFactory:
         assert kwargs["task_queue"] == "test-queue"
         assert AgentWorkflow in kwargs["workflows"]
         assert run_agent_activity in kwargs["activities"]
+
+
+@pytest.mark.skipif(not TEMPORAL_AVAILABLE, reason="temporalio not installed")
+@pytest.mark.asyncio
+async def test_temporal_activity_can_broker_to_http_worker(monkeypatch, tmp_path):
+    """HTTP worker transport makes the Temporal activity enqueue instead of run locally."""
+    import asyncio
+
+    from seeknal.ask.gateway.http_worker import HttpWorkerResult, http_worker_broker
+    from seeknal.ask.gateway.temporal import run_agent_activity
+
+    await http_worker_broker.reset()
+    monkeypatch.setenv("SEEKNAL_WORKER_TRANSPORT", "http")
+    monkeypatch.setenv("SEEKNAL_HTTP_WORK_TIMEOUT_SECONDS", "5")
+
+    activity_task = asyncio.create_task(run_agent_activity(AgentWorkflowInput(
+        session_id="sess-activity-http",
+        question="hello",
+        project_path=str(tmp_path),
+        tenant_id="tenant-http",
+    )))
+    await asyncio.sleep(0)
+
+    item = await http_worker_broker.claim_next(tenant_id="tenant-http", timeout=1)
+    assert item is not None
+    assert item.session_id == "sess-activity-http"
+    assert item.question == "hello"
+
+    completed = await http_worker_broker.complete(
+        work_id=item.work_id,
+        tenant_id="tenant-http",
+        result=HttpWorkerResult(answer="done", event_count=2),
+    )
+    assert completed is True
+
+    output = await activity_task
+    assert output.answer == "done"
+    assert output.event_count == 2
+    assert output.error is None
+    await http_worker_broker.reset()


### PR DESCRIPTION
## Summary

- bump Seeknal patch version to `2.9.1`
- add HTTP-only Ask worker mode where workers only talk to gateway/kc-service with `SEEKNAL_GATEWAY_URL` + `SEEKNAL_API_TOKEN`
- add gateway broker endpoints for long-poll work, streaming worker events, and final completion
- keep existing Temporal worker mode compatible while enabling `--worker-transport http` gateway-side broker mode
- fix runtime issues found in BPOM RPO tmux E2E: project `.env` loading in worker mode, transient gateway poll retries, HTTP-broker Temporal heartbeats, and unsupported `stuck_loop_detection` passthrough

## Verification

```bash
PYTHONPATH=src pytest -q \
  tests/ask/test_gateway_token_auth.py \
  tests/ask/test_temporal_integration.py \
  tests/ask/test_gateway_parity.py \
  tests/ask/test_gateway_concurrency.py \
  tests/ask/test_cli.py \
  tests/ask/test_toolset.py::test_create_agent_applies_agent_harness_config
# 48 passed in 14.89s
```

Manual tmux E2E against `/Users/fitrakacamarga/project/mta/seeknal-bpom-rpo-dummy`:

- gateway: `seeknal gateway start --temporal --worker-transport http --port 18080`
- worker: `seeknal gateway worker --transport http --gateway-url http://127.0.0.1:18080 --api-token dev-e2e-token`
- request: `Jumlah Izin Edar Pangan Olahan Risiko Menengah Rendah?`
- observed SSE `tool_start`, `tool_end`, `answer`, `done`; answer returned `30 produk`
