### PR TITLE
Ask agent reliability 2.9.3: SQL-pair guard fixes + multi-turn hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.3] - 2026-05-21
+
+Ask agent reliability — SQL-pair guard fixes + multi-turn hygiene.
+
+### Fixed
+
+- **SQL-pair lock-in (Fix A)** — Guard 3 (`execute_sql` after authoritative pair) now demotes the first un-overridden drift attempt to RETRYABLE and only escalates to TERMINAL on a second attempt without `allow_sql_pair_drift=True`. The override flag is now a meaningful escape hatch instead of being silently ignored.
+- **Zero-row authoritative rejection (Fix B)** — `execute_sql_pair(authoritative=True)` no longer locks the turn to a result that is empty or all-NULL/zero aggregates. A SQL pair with a wrongly quoted qualified table name (silent UNION-ALL failure shape) now returns a non-authoritative `SQL_PAIR_RESULT` with explicit "the pair's SQL likely has a bug" guidance, freeing the agent to query directly.
+- **Read multi-doc YAML pairs without arming Guard 1 forever** — `read_sql_pair` now calls `mark_sql_pairs_checked` unconditionally on a successful read. Previously, list-format pair files (top-level YAML list of pairs) failed the dict-only check inside `_record_loaded_sql_pair` and skipped marking, so Guard 1 re-fired turn after turn.
+- **Session-scoped `sql_pairs_checked`** — `reset_turn_governor` no longer clears the checked flag between turns. Once the agent has consulted project pairs in a session, Guard 1 stays dormant for the rest of the session. Stops the per-turn "list pairs again" tax on simple follow-up questions.
+
+### Added
+
+- **`sql_pairs.mode: advisory` project config (Fix D)** — opt-in setting in `seeknal_agent.yml` that treats curated pairs as cheatsheets only: Guard 2 lets drifting SQL through without `allow_sql_pair_drift=True`, and Guard 3 never escalates to TERMINAL. Default remains `authoritative` (legacy behavior).
+
+### Changed
+
+- **Filter-tweak triggers in `_question_requests_post_sql_analysis` (Fix C)** — added Indonesian/English keywords (`exclud`, `tanpa`, `kecuali`, `selain`, `filter`, `breakdown`, `saja`, `khusus`) so follow-ups that narrow scope release Guard 3 instead of being treated as ordinary business questions.
+- **Drop `context/sql_pairs/` from Guard 1 roots (Fix E)** — only `seeknal/sql_pairs/` now triggers the mandatory-lookup nudge. `context/sql_pairs/` is reserved for generated source context per CLAUDE.md and was conflating two storage layers.
+- **Temporal-scope hygiene prompt rule** — workflow section teaches the agent to issue a fresh `execute_sql` with an open-ended filter or `MAX(<col>)` probe when follow-ups expand the time window (`dan seterusnya`, `sampai sekarang`, `terkini`, `onwards`, `since`, `to date`, `latest`, or years beyond the prior SQL's date bound). Fixes the "Q3 returned 50 instead of 94" extrapolation bug.
+- **Multi-turn hygiene prompt rule** — workflow section teaches the agent to reuse the SAME date column, filter values, and predicate set from the prior turn — change ONLY the dimension the user varied. For verbatim re-asks, restate the prior answer instead of re-querying. Eliminates filter drift across multi-turn conversations.
+
+### Tests
+
+- 84 ask-agent tests pass, including new regression tests covering: Guard 3 first-hit RETRYABLE, second-hit TERMINAL escalation; zero-row + null-only authoritative rejection; advisory-mode dormant guards; `context/sql_pairs/` not triggering Guard 1; filter-tweak Guard 3 release; multi-turn hygiene rule presence; hardcode-guard against domain-specific tokens leaking into the generic rule.
+- Base prompt still under the 160-line leanness budget.
+
 ## [2.8.0] - 2026-04-18
 
 Ask agent improvements batch — addresses open issues #23, #24, #25, #26, #27.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "seeknal"
-version = "2.9.2"
+version = "2.9.3"
 description = "All-in-one platform for data and AI/ML engineering"
 authors = [
     {name = "Fitra Kacamarga"}

--- a/src/seeknal/__init__.py
+++ b/src/seeknal/__init__.py
@@ -29,7 +29,7 @@ Example:
 For more information, see the documentation at https://seeknal.readthedocs.io/
 """
 
-__version__ = "2.9.1"
+__version__ = "2.9.3"
 
 # Export validation functions
 from .validation import (

--- a/src/seeknal/ask/agents/agent.py
+++ b/src/seeknal/ask/agents/agent.py
@@ -266,6 +266,9 @@ def create_agent(
     tool_ctx.sql_timeout_seconds = get_sql_timeout_seconds(agent_config)
     tool_ctx.discovery_cache_ttl_seconds = get_discovery_cache_ttl_seconds(agent_config)
     tool_ctx.background_threshold = get_background_threshold(agent_config)
+    from seeknal.ask.config import get_sql_pair_mode
+
+    tool_ctx.sql_pair_mode = get_sql_pair_mode(agent_config)
     if analysis_toolset:
         tool_ctx.tool_call_limit = 24
 

--- a/src/seeknal/ask/agents/tools/_context.py
+++ b/src/seeknal/ask/agents/tools/_context.py
@@ -78,6 +78,15 @@ class ToolContext:
     discovery_cache_ttl_seconds: int = 300
     discovery_cache: dict[str, tuple[float, Any]] = field(default_factory=dict)
     timing_events_this_turn: list[dict[str, Any]] = field(default_factory=list)
+    # SQL-pair guard behavior — "authoritative" keeps the legacy terminal
+    # stop after an authoritative SQL-pair result; "advisory" treats pairs as
+    # cheatsheets and never escalates Guard 3 to TERMINAL.
+    sql_pair_mode: str = "authoritative"
+    # Number of times the agent tried to run drifting SQL after an
+    # authoritative pair landed this turn. The first attempt is now a
+    # RETRYABLE nudge so the agent can override with allow_sql_pair_drift;
+    # only a second attempt without the override escalates to TERMINAL.
+    authoritative_drift_attempts_this_turn: int = 0
 
 
 def _make_registry():
@@ -192,11 +201,35 @@ def should_synthesize_after_authoritative_sql_pair(
     business questions. Advanced analysis requests (forecasting, modeling,
     correlations, charts, etc.) may legitimately need Python or follow-up
     queries after the pair result, so those remain agent-directed.
+
+    When the project opts into ``sql_pair_mode: advisory`` (see
+    ``seeknal_agent.yml``), SQL pairs are treated as cheatsheets and this
+    helper never escalates — Guard 3's terminal branch becomes dormant.
     """
     ctx = ctx or get_tool_context()
     if get_authoritative_sql_pair_result(ctx) is None:
         return False
+    if getattr(ctx, "sql_pair_mode", "authoritative") == "advisory":
+        return False
     return not _question_requests_post_sql_analysis(ctx.current_question)
+
+
+def authoritative_drift_attempts(ctx: ToolContext | None = None) -> int:
+    """Return how many drifting-SQL attempts the agent has made this turn."""
+    ctx = ctx or get_tool_context()
+    return int(getattr(ctx, "authoritative_drift_attempts_this_turn", 0) or 0)
+
+
+def bump_authoritative_drift_attempt(ctx: ToolContext | None = None) -> int:
+    """Record one drifting-SQL attempt after an authoritative pair landed.
+
+    Returns the post-increment count so callers can decide between RETRYABLE
+    and TERMINAL responses without keeping their own per-turn state.
+    """
+    ctx = ctx or get_tool_context()
+    current = authoritative_drift_attempts(ctx) + 1
+    ctx.authoritative_drift_attempts_this_turn = current
+    return current
 
 
 def reset_turn_governor(question: str | None = None) -> None:
@@ -214,10 +247,17 @@ def reset_turn_governor(question: str | None = None) -> None:
     ctx.terminal_tool_errors_this_turn.clear()
     ctx.loaded_sql_pairs_this_turn.clear()
     get_loaded_sql_pairs(ctx).clear()
-    ctx.sql_pairs_checked_this_turn = False
-    setattr(ctx.repl, "_seeknal_sql_pairs_checked_this_turn", False)
+    # NOTE: ``sql_pairs_checked`` is intentionally NOT reset here. Once the
+    # agent has seen the project's SQL pairs in this session (via
+    # list_sql_pairs/read_sql_pair/execute_sql_pair), Guard 1 should stay
+    # dormant for subsequent turns. Re-firing Guard 1 every new user turn
+    # forced the agent to re-list pairs even on simple follow-up questions
+    # ("dari 2024 dan seterusnya?") and burned tool budget on recovery.
+    # The agent can still choose to re-list pairs when the question shifts
+    # to a clearly new domain.
     ctx.authoritative_sql_pair_result_this_turn = None
     setattr(ctx.repl, "_seeknal_authoritative_sql_pair_result_this_turn", None)
+    ctx.authoritative_drift_attempts_this_turn = 0
     ctx.timing_events_this_turn.clear()
 
 
@@ -491,6 +531,23 @@ def _question_requests_post_sql_analysis(question: str | None) -> bool:
         "python",
         "statistical",
         "statistik",
+        # Filter-tweak intents — the user is asking for the same metric with
+        # a different scope. Treat as legitimate post-SQL work so Guard 3 does
+        # not lock the agent to a pair that lacks the requested exclusion.
+        # Keep these explicit (verbs / negations) and avoid common prepositions
+        # like " per " or " by " — those naturally show up in same-grain
+        # questions an authoritative pair already covers.
+        "exclud",
+        "without",
+        "tanpa",
+        "kecuali",
+        "selain",
+        "filter",
+        "breakdown",
+        # Common phrasing for asking the same number on a slightly different
+        # population — these should not trigger the lock-in either.
+        "saja",
+        "khusus",
     )
     return any(trigger in lowered for trigger in triggers)
 

--- a/src/seeknal/ask/agents/tools/execute_sql.py
+++ b/src/seeknal/ask/agents/tools/execute_sql.py
@@ -75,6 +75,7 @@ def execute_sql(
             synthesize an answer instead of allowing query drift.
     """
     from seeknal.ask.agents.tools._context import (
+        bump_authoritative_drift_attempt,
         get_authoritative_sql_pair_result,
         get_tool_context,
         get_successful_sql_cache,
@@ -150,18 +151,44 @@ def execute_sql(
         and get_authoritative_sql_pair_result(ctx) is not None
         and should_synthesize_after_authoritative_sql_pair(ctx)
     ):
-        result = format_tool_error(
-            TERMINAL_BOUNDED_EVIDENCE,
-            "A matching SQL pair already executed successfully for this turn.",
-            hint=(
-                "Stop tool use and answer from the AUTHORITATIVE_RESULT. "
-                "Only ask a new user turn for changed filters, grain, or "
-                "deeper post-query analysis."
-            ),
-        )
-        record_tool_result("execute_sql", result, args={"sql": sql})
-        return result
-    if drift_notice and not allow_sql_pair_drift:
+        if allow_sql_pair_drift:
+            # Agent has explicitly overridden — let the query through with the
+            # drift notice attached. The override is a meaningful escape hatch,
+            # not a no-op.
+            pass
+        else:
+            attempts = bump_authoritative_drift_attempt(ctx)
+            if attempts >= 2:
+                # Agent ignored the first RETRYABLE nudge — escalate to
+                # TERMINAL so the harness stops looping.
+                result = format_tool_error(
+                    TERMINAL_BOUNDED_EVIDENCE,
+                    "A matching SQL pair already executed successfully for this turn.",
+                    hint=(
+                        "Stop tool use and answer from the AUTHORITATIVE_RESULT. "
+                        "If the user asked for a different filter or grain, pass "
+                        "allow_sql_pair_drift=True on execute_sql to override."
+                    ),
+                )
+                record_tool_result("execute_sql", result, args={"sql": sql})
+                return result
+            result = format_tool_error(
+                RETRYABLE_SYNTAX,
+                "SQL differs from an authoritative SQL pair already loaded this turn.",
+                hint=(
+                    "If the user really wants this exact alternate query, retry "
+                    "with allow_sql_pair_drift=True. Otherwise answer from the "
+                    "AUTHORITATIVE_RESULT. This is the only nudge; a second "
+                    "attempt without the override will be terminal."
+                ),
+            )
+            record_tool_result("execute_sql", result, args={"sql": sql})
+            return result
+    if (
+        drift_notice
+        and not allow_sql_pair_drift
+        and getattr(ctx, "sql_pair_mode", "authoritative") != "advisory"
+    ):
         result = format_tool_error(
             RETRYABLE_SYNTAX,
             "SQL differs from the SQL pair loaded earlier this turn.",
@@ -336,18 +363,25 @@ def _sql_pair_drift_notice(ctx, sql: str) -> str | None:
 
 
 def _should_require_sql_pair_lookup(ctx, sql: str, checked: bool) -> bool:
-    """Require SQL-pair lookup before ad-hoc business SQL when pairs exist."""
+    """Require SQL-pair lookup before ad-hoc business SQL when pairs exist.
+
+    Only ``seeknal/sql_pairs/`` triggers the guard. ``context/sql_pairs/`` is
+    historically a derived-context storage location (see ``CLAUDE.md``); using
+    it as a guard trigger conflated curated cheatsheets with generated source
+    context.
+    """
     if checked or not (getattr(ctx, "current_question", None) or "").strip():
         return False
     if _looks_like_direct_sql_request(ctx.current_question):
         return False
     if _is_metadata_or_healthcheck_sql(sql):
         return False
-    roots = [ctx.project_path.resolve() / "seeknal" / "sql_pairs", ctx.project_path.resolve() / "context" / "sql_pairs"]
+    root = ctx.project_path.resolve() / "seeknal" / "sql_pairs"
+    if not root.exists():
+        return False
     return any(
-        root.exists()
-        and any(path.is_file() and path.suffix.lower() in {".yml", ".yaml"} for path in root.rglob("*"))
-        for root in roots
+        path.is_file() and path.suffix.lower() in {".yml", ".yaml"}
+        for path in root.rglob("*")
     )
 
 

--- a/src/seeknal/ask/agents/tools/execute_sql_pair.py
+++ b/src/seeknal/ask/agents/tools/execute_sql_pair.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -92,7 +93,7 @@ def execute_sql_pair(
     if authoritative:
         get_loaded_sql_pairs(ctx)[pair_name] = sql
     result = execute_sql(sql=sql, limit=limit, refresh=refresh)
-    if authoritative and _tool_succeeded(result):
+    if authoritative and _tool_succeeded(result) and not _result_looks_empty(result):
         record_authoritative_sql_pair_result(
             name=pair_name,
             path=rel,
@@ -105,6 +106,15 @@ def execute_sql_pair(
             "current business question. Do not run alternate SQL unless the "
             "user explicitly requested a different grain/filter or deeper "
             "post-query analysis.\n\n"
+            + result
+        )
+    if authoritative and _tool_succeeded(result) and _result_looks_empty(result):
+        return (
+            f"# Executed SQL pair: {rel}\n\n"
+            "SQL_PAIR_RESULT (not authoritative — empty/null-only result; the "
+            "pair's SQL likely has a bug, e.g. a wrongly quoted qualified table "
+            "name). Inspect the SQL and run a corrected query with execute_sql "
+            "instead of treating this pair as authoritative.\n\n"
             + result
         )
     return (
@@ -135,6 +145,37 @@ def _tool_succeeded(result: str) -> bool:
     except json.JSONDecodeError:
         return True
     return not (isinstance(payload, dict) and "category" in payload)
+
+
+_AGG_NULL_ROW = re.compile(
+    r"\|\s*(?:NULL|0|0\.0+|\[blank\])\s*(?:\|\s*(?:NULL|0|0\.0+|\[blank\])\s*)*\|"
+)
+
+
+def _result_looks_empty(result: str) -> bool:
+    """Detect a successful query whose payload is effectively empty.
+
+    A SQL pair that silently produces zero rows or an all-NULL/zero aggregate
+    is almost never a trustworthy authoritative answer for a business
+    question — most often it indicates a pair-level SQL bug (e.g. a wrongly
+    quoted fully-qualified table name that DuckDB resolves as a missing
+    relation but the surrounding UNION ALL hides). Demote those results so
+    the agent does not lock the turn to wrong numbers.
+    """
+    text = result or ""
+    if "Query executed successfully but returned no results." in text:
+        return True
+    if "(0 rows)" in text or "(0 row)" in text:
+        return True
+    # Single-row aggregate where every cell is NULL/0/[blank] is the
+    # silent-failure shape of a busted UNION-ALL leg.
+    if "(1 row)" in text:
+        lines = [ln for ln in text.splitlines() if ln.startswith("|") and "---" not in ln]
+        # Skip the header row; check the lone data row(s).
+        data_rows = lines[1:] if len(lines) >= 2 else []
+        if data_rows and all(_AGG_NULL_ROW.fullmatch(row.strip()) for row in data_rows):
+            return True
+    return False
 
 
 __all__ = ["execute_sql_pair"]

--- a/src/seeknal/ask/agents/tools/read_sql_pair.py
+++ b/src/seeknal/ask/agents/tools/read_sql_pair.py
@@ -30,6 +30,14 @@ def read_sql_pair(name_or_path: str) -> str:
         data = data[:_MAX_BYTES]
     text = data.decode("utf-8", errors="replace")
     header = f"# SQL pair: {target.relative_to(project_root).as_posix()}\n\n"
+    # Mark the lookup-guard satisfied for THIS turn unconditionally — the
+    # agent did consult a project pair, even if the YAML is not a dict
+    # (multi-document list format) and we cannot register its SQL for
+    # drift tracking. Otherwise Guard 1 keeps re-firing turn after turn
+    # for list-format pair files.
+    from seeknal.ask.agents.tools._context import mark_sql_pairs_checked
+
+    mark_sql_pairs_checked(ctx)
     _record_loaded_sql_pair(target, project_root, text)
     if truncated:
         return header + text + "\n\n... (truncated)"

--- a/src/seeknal/ask/config.py
+++ b/src/seeknal/ask/config.py
@@ -517,3 +517,25 @@ def get_ask_toolset_mode(config: dict[str, Any]) -> str:
     if mode in _READ_ONLY_ANALYST_MODES:
         return "analysis"
     return "full"
+
+
+_VALID_SQL_PAIR_MODES = {"authoritative", "advisory"}
+
+
+def get_sql_pair_mode(config: dict[str, Any]) -> str:
+    """Return the SQL-pair guard mode declared in ``seeknal_agent.yml``.
+
+    Reads ``sql_pairs.mode`` and accepts ``authoritative`` (legacy default) or
+    ``advisory``. Anything else falls back to ``authoritative`` so a typo never
+    silently relaxes the guard.
+
+    Example::
+
+        sql_pairs:
+          mode: advisory
+    """
+    section = _get_mapping(config, "sql_pairs")
+    mode = section.get("mode")
+    if isinstance(mode, str) and mode.strip().lower() in _VALID_SQL_PAIR_MODES:
+        return mode.strip().lower()
+    return "authoritative"

--- a/src/seeknal/ask/prompt_builder.py
+++ b/src/seeknal/ask/prompt_builder.py
@@ -274,6 +274,7 @@ After every batch of data-fetching tool calls, emit a SHORT natural-language
 summary in the user's language with concrete numbers, BEFORE the next
 `ask_user`. Never chain two `ask_user` calls with only silent tool runs in
 between — the user can't see what you learned otherwise.
+Multi-turn hygiene: reuse the SAME date column, filter values, and predicate set from the prior turn — change ONLY the dimension the user explicitly varied. For verbatim re-asks, restate the prior answer rather than re-querying with paraphrased SQL. Temporal-scope hygiene: scope-expanding follow-ups (`dan seterusnya`, `sampai sekarang`, `terkini`, `onwards`, `since`, `to date`, `latest`, or years beyond the prior SQL's date bound) require a fresh `execute_sql` with an open-ended filter (`<col> >= 'YYYY-01-01'`) or `MAX(<col>)` probe — do not extrapolate from the cached number.
 
 `read_proof_document` is read-only and does NOT require approval — call it
 directly when the user pastes a Proof link."""

--- a/tests/ask/test_execute_sql.py
+++ b/tests/ask/test_execute_sql.py
@@ -313,10 +313,20 @@ def test_loaded_sql_pair_drift_is_blocked_by_default(ctx):
     assert not any("COUNT(*) AS total" in call for call in ctx.repl.calls)
 
 
-def test_authoritative_sql_pair_blocks_drift_override_for_simple_question(ctx):
-    get_loaded_sql_pairs(ctx)["canonical"] = "SELECT id, v FROM small ORDER BY id"
+def test_authoritative_sql_pair_explicit_override_lets_drift_through(ctx):
+    """An authoritative pair must not silently lock out an explicit override.
+
+    Previous behavior (pre-Fix-A) treated ``allow_sql_pair_drift=True`` as a
+    no-op once a pair landed authoritatively for the turn, even for ordinary
+    business questions. This caused the agent to be stuck on a broken pair's
+    numbers. The override now means what it says: the agent is taking
+    responsibility for the drift, and the query runs with a strong notice.
+    """
     reset_turn_governor("How many records are there by month?")
-    get_loaded_sql_pairs(ctx)["canonical"] = "SELECT id, v FROM small ORDER BY id"
+    # Simulate read_sql_pair-style preload of canonical SQL plus an
+    # authoritative landing recorded by execute_sql_pair(authoritative=True).
+    from seeknal.ask.agents.tools._context import get_loaded_sql_pairs as _glp
+    _glp(ctx)["canonical"] = "SELECT id, v FROM small ORDER BY id"
     record_authoritative_sql_pair_result(
         name="canonical",
         path="seeknal/sql_pairs/canonical.yml",
@@ -329,9 +339,58 @@ def test_authoritative_sql_pair_blocks_drift_override_for_simple_question(ctx):
         allow_sql_pair_drift=True,
     )
 
-    assert "matching SQL pair already executed successfully" in out
-    assert "terminal_bounded_evidence" in out
+    assert "| total |" in out
+    assert "SQL pair drift" in out
+    assert any("COUNT(*) AS total" in call for call in ctx.repl.calls)
+
+
+def test_authoritative_sql_pair_first_drift_attempt_is_retryable(ctx):
+    """Fix A — Guard 3's first hit must be RETRYABLE, not TERMINAL.
+
+    The agent should learn about the authoritative pair and the override
+    flag once, retry intentionally, then have its query execute. Going
+    straight to TERMINAL on the first attempt was the lock-in behavior.
+    """
+    reset_turn_governor("Berapa total jumlah NIE?")
+    from seeknal.ask.agents.tools._context import get_loaded_sql_pairs as _glp
+    _glp(ctx)["canonical"] = "SELECT id, v FROM small ORDER BY id"
+    record_authoritative_sql_pair_result(
+        name="canonical",
+        path="seeknal/sql_pairs/canonical.yml",
+        result="| nie | count |\n| --- | --- |\n| 12345 | 3 |\n\n(1 row)",
+        ctx=ctx,
+    )
+
+    out = execute_sql("SELECT COUNT(*) AS total FROM small")
+
+    assert "retryable_syntax" in out
+    assert "allow_sql_pair_drift=True" in out
     assert not any("COUNT(*) AS total" in call for call in ctx.repl.calls)
+
+
+def test_authoritative_sql_pair_second_drift_attempt_is_terminal(ctx):
+    """Fix A — second un-overridden attempt escalates to TERMINAL.
+
+    Each attempt uses a different drifting SQL so the per-signature
+    repeated_failure_message guard (which would short-circuit duplicate
+    queries) does not pre-empt the drift escalation logic.
+    """
+    reset_turn_governor("Berapa total jumlah NIE?")
+    from seeknal.ask.agents.tools._context import get_loaded_sql_pairs as _glp
+    _glp(ctx)["canonical"] = "SELECT id, v FROM small ORDER BY id"
+    record_authoritative_sql_pair_result(
+        name="canonical",
+        path="seeknal/sql_pairs/canonical.yml",
+        result="| nie | count |\n| --- | --- |\n| 12345 | 3 |\n\n(1 row)",
+        ctx=ctx,
+    )
+
+    first = execute_sql("SELECT COUNT(*) AS total FROM small")
+    second = execute_sql("SELECT COUNT(*) AS jumlah FROM small WHERE id > 0")
+
+    assert "retryable_syntax" in first
+    assert "terminal_bounded_evidence" in second
+    assert not any("COUNT" in call for call in ctx.repl.calls)
 
 
 def test_authoritative_sql_pair_allows_drift_for_advanced_question(ctx):
@@ -401,3 +460,201 @@ def test_execute_sql_returns_terminal_timeout(tmp_path):
 
     assert "terminal_timeout" in out
     assert "SQL execution timed out after 1 seconds" in out
+
+
+# ---------------------------------------------------------------------------
+# Fix B — zero-row SQL pair must not become authoritative
+# ---------------------------------------------------------------------------
+
+
+def test_empty_pair_result_is_not_authoritative(tmp_path):
+    """A broken SQL pair that silently returns no rows must NOT lock the turn.
+
+    Reproduces the run-2 wrong-numbers symptom: a pair with a wrongly quoted
+    qualified table name like ``"warehouse.public.t_x"`` resolves as a missing
+    relation in DuckDB but the surrounding UNION ALL collapses the failure to
+    an empty result. Before Fix B, that empty result was recorded as
+    authoritative and locked the agent to wrong numbers.
+    """
+    from unittest.mock import MagicMock
+
+    from seeknal.ask.agents.tools._context import (
+        ToolContext,
+        get_authoritative_sql_pair_result,
+        reset_turn_governor,
+        set_tool_context,
+    )
+    from seeknal.ask.agents.tools.execute_sql_pair import execute_sql_pair
+
+    class _EmptyRepl:
+        def execute_oneshot(self, sql, limit=None):
+            return ["jumlah_nie"], []  # zero rows — silent UNION-ALL failure shape
+
+    ctx = ToolContext(
+        repl=_EmptyRepl(),
+        artifact_discovery=MagicMock(),
+        project_path=tmp_path,
+    )
+    set_tool_context(ctx)
+    reset_turn_governor("Berapa total jumlah NIE?")
+
+    pair = tmp_path / "seeknal" / "sql_pairs" / "broken.yml"
+    pair.parent.mkdir(parents=True)
+    pair.write_text(
+        'name: broken\n'
+        'prompt: Berapa total jumlah NIE\n'
+        'sql: |\n'
+        '  SELECT nomor FROM "warehouse.public.t_x" "main"\n'
+    )
+
+    out = execute_sql_pair("broken", authoritative=True)
+
+    assert "AUTHORITATIVE_RESULT" not in out
+    assert "not authoritative" in out
+    assert get_authoritative_sql_pair_result(ctx) is None
+
+
+def test_null_only_aggregate_is_not_authoritative(tmp_path):
+    """A pair whose only row is NULL/0 across all aggregate cells is suspect.
+
+    This is the second silent-failure shape: COUNT/SUM over an empty
+    intermediate select returns one row of all-NULL/0 instead of zero rows.
+    """
+    from unittest.mock import MagicMock
+
+    from seeknal.ask.agents.tools._context import (
+        ToolContext,
+        get_authoritative_sql_pair_result,
+        reset_turn_governor,
+        set_tool_context,
+    )
+    from seeknal.ask.agents.tools.execute_sql_pair import execute_sql_pair
+
+    class _NullRepl:
+        def execute_oneshot(self, sql, limit=None):
+            return ["jumlah_nie"], [(None,)]
+
+    ctx = ToolContext(
+        repl=_NullRepl(),
+        artifact_discovery=MagicMock(),
+        project_path=tmp_path,
+    )
+    set_tool_context(ctx)
+    reset_turn_governor("Berapa total jumlah NIE?")
+
+    pair = tmp_path / "seeknal" / "sql_pairs" / "broken.yml"
+    pair.parent.mkdir(parents=True)
+    pair.write_text(
+        'name: broken\n'
+        'prompt: Berapa total jumlah NIE\n'
+        'sql: |\n'
+        '  SELECT COUNT(*) AS jumlah_nie FROM warehouse.public.empty\n'
+    )
+
+    out = execute_sql_pair("broken", authoritative=True)
+
+    assert "AUTHORITATIVE_RESULT" not in out
+    assert "not authoritative" in out
+    assert get_authoritative_sql_pair_result(ctx) is None
+
+
+# ---------------------------------------------------------------------------
+# Fix C — filter-tweak questions release Guard 3
+# ---------------------------------------------------------------------------
+
+
+def test_filter_tweak_question_releases_guard3(ctx):
+    """Asking for the same metric with an added exclusion is post-SQL analysis.
+
+    Before Fix C, ``_question_requests_post_sql_analysis`` only matched
+    explicit analytical keywords (forecast, chart, model, ...). A user asking
+    "kecuali test accounts" or "tanpa tahun 1900" was dropped into Guard 3
+    lockout. The expanded keyword list now treats those as legitimate
+    follow-up scope so Guard 3 is dormant — Guard 2 (the polite RETRYABLE
+    drift nudge) still applies, which is the desired behavior.
+    """
+    from seeknal.ask.agents.tools._context import (
+        get_loaded_sql_pairs as _glp,
+        should_synthesize_after_authoritative_sql_pair,
+    )
+
+    reset_turn_governor("Berapa total NIE kecuali test account?")
+    _glp(ctx)["canonical"] = "SELECT id, v FROM small ORDER BY id"
+    record_authoritative_sql_pair_result(
+        name="canonical",
+        path="seeknal/sql_pairs/canonical.yml",
+        result="| nie | count |\n| --- | --- |\n| 12345 | 3 |\n\n(1 row)",
+        ctx=ctx,
+    )
+
+    # Guard 3 must NOT lock — the question is a filter tweak.
+    assert not should_synthesize_after_authoritative_sql_pair(ctx)
+    # Override works (Guard 3 dormant means the override is honored).
+    overridden = execute_sql(
+        "SELECT COUNT(*) AS total FROM small",
+        allow_sql_pair_drift=True,
+    )
+    assert "| total |" in overridden
+    assert "SQL pair drift" in overridden
+
+
+# ---------------------------------------------------------------------------
+# Fix D — advisory mode never escalates Guard 3
+# ---------------------------------------------------------------------------
+
+
+def test_advisory_mode_never_locks_authoritative(ctx):
+    """``sql_pairs.mode: advisory`` keeps pairs as cheatsheets only."""
+    from seeknal.ask.agents.tools._context import (
+        get_loaded_sql_pairs as _glp,
+        should_synthesize_after_authoritative_sql_pair,
+    )
+
+    reset_turn_governor("Berapa total jumlah NIE?")
+    ctx.sql_pair_mode = "advisory"
+    _glp(ctx)["canonical"] = "SELECT id, v FROM small ORDER BY id"
+    record_authoritative_sql_pair_result(
+        name="canonical",
+        path="seeknal/sql_pairs/canonical.yml",
+        result="| nie | count |\n| --- | --- |\n| 12345 | 3 |\n\n(1 row)",
+        ctx=ctx,
+    )
+
+    assert not should_synthesize_after_authoritative_sql_pair(ctx)
+
+    out = execute_sql("SELECT COUNT(*) AS total FROM small")
+
+    assert "| total |" in out
+    assert "SQL pair drift" in out
+
+
+def test_get_sql_pair_mode_reads_yaml_section(tmp_path):
+    """End-to-end: ``seeknal_agent.yml`` → ToolContext.sql_pair_mode."""
+    from seeknal.ask.config import get_sql_pair_mode
+
+    assert get_sql_pair_mode({}) == "authoritative"
+    assert get_sql_pair_mode({"sql_pairs": {"mode": "advisory"}}) == "advisory"
+    # Unknown mode falls back to authoritative (typo-safe).
+    assert get_sql_pair_mode({"sql_pairs": {"mode": "lenient"}}) == "authoritative"
+
+
+# ---------------------------------------------------------------------------
+# Fix E — context/sql_pairs no longer triggers Guard 1
+# ---------------------------------------------------------------------------
+
+
+def test_context_sql_pairs_dir_does_not_trigger_lookup_guard(ctx, tmp_path):
+    """Files under ``context/sql_pairs/`` must not force a lookup.
+
+    That directory is reserved for generated-source context per CLAUDE.md;
+    treating it as a curated-cheatsheet trigger conflated two storage layers.
+    """
+    pair = tmp_path / "context" / "sql_pairs" / "generated.yml"
+    pair.parent.mkdir(parents=True)
+    pair.write_text("name: generated\nprompt: any\nsql: SELECT 1\n")
+    reset_turn_governor("Berapa total jumlah NIE?")
+
+    out = execute_sql("SELECT COUNT(*) AS total FROM small")
+
+    assert "Project SQL pairs exist" not in out
+    assert "| total |" in out

--- a/tests/ask/test_prompt_builder.py
+++ b/tests/ask/test_prompt_builder.py
@@ -154,6 +154,94 @@ class TestSectionBuilders:
         assert "Generate report now" in result
         assert "Publish to Seeknal Report Server" in result
 
+    def test_workflow_includes_temporal_scope_hygiene(self):
+        """A regression test for the Q3 'dan seterusnya' bug.
+
+        Without this rule the agent reused a prior turn's cached number
+        ('jumlah NIE tahun 2024 = 50') as the answer for 'jumlah NIE dari
+        tahun 2024 dan seterusnya?', missing 2025 and 2026 data. The
+        workflow prompt must teach the model to re-query when the follow-up
+        question expands the temporal scope.
+        """
+        result = _build_workflow()
+        assert "Temporal-scope hygiene" in result
+        # Indonesian scope-expansion triggers
+        assert "dan seterusnya" in result
+        assert "sampai sekarang" in result
+        # English scope-expansion triggers
+        assert "onwards" in result
+        assert "to date" in result
+        # The recovery procedure must be present too — recognizing the
+        # signal is useless without the corrective action.
+        assert "fresh `execute_sql`" in result or "fresh execute_sql" in result
+        assert "MAX(" in result
+
+    def test_workflow_includes_multi_turn_hygiene(self):
+        """Regression test for cross-turn answer drift.
+
+        Three weaknesses observed in the 10-scenario reliability test:
+
+        1. Verbatim re-ask burned an extra tool call because the agent
+           paraphrased its own SQL (cache miss).
+        2. Status filter set drifted across turns (e.g. ERLA `'0099'`
+           sometimes included, sometimes not).
+        3. Date column choice drifted (`tanggal` vs `tanggal_aju`).
+
+        All three are agent-reasoning issues solvable at the prompt level
+        without domain-specific keywords. The rule must reference generic
+        concepts (date column, filter values, predicate set) so it applies
+        to any project — not just BPOM.
+        """
+        result = _build_workflow()
+        assert "Multi-turn hygiene" in result
+        # Generic concepts (no domain-specific tokens like status codes,
+        # table names, or project identifiers).
+        assert "date column" in result
+        assert "filter values" in result
+        assert "predicate set" in result
+        # The two corrective actions: keep filters stable, restate verbatim
+        # re-asks instead of re-querying.
+        assert "verbatim" in result
+        assert "restate" in result.lower()
+
+    def test_workflow_multi_turn_hygiene_has_no_hardcoded_domain_terms(self):
+        """The rule must not reference any project-specific tokens.
+
+        Guard against future edits sneaking in BPOM / Seeknal-specific
+        keywords (status codes, table names, business categories) that
+        would silently narrow the rule's applicability.
+        """
+        result = _build_workflow()
+        # The multi-turn hygiene rule lives on a single source line; isolate
+        # it and check no hardcoded BPOM / domain tokens leaked in.
+        line = next(
+            (ln for ln in result.splitlines() if "Multi-turn hygiene" in ln),
+            "",
+        )
+        assert line, "Multi-turn hygiene rule must be present"
+        forbidden = [
+            # BPOM-specific
+            "NIE",
+            "ERBA",
+            "ERLA",
+            "0999",
+            "0906",
+            "9999",
+            "0099",
+            "kategori_dokumen",
+            "jenis_permohonan",
+            "tanggal_aju",
+            # Seeknal table names
+            "t_produk",
+            "warehouse.public",
+        ]
+        for token in forbidden:
+            assert token not in line, (
+                f"Hardcoded domain term {token!r} leaked into the "
+                f"multi-turn hygiene rule. Keep the rule generic so it "
+                f"applies to any project."
+            )
+
     def test_memory_returns_content(self):
         result = _build_memory()
         assert "persistent memory" in result


### PR DESCRIPTION
## Summary

Release 2.9.3 — seven fixes addressing SQL-pair lock-in, multi-turn answer drift, and temporal-scope extrapolation in the seeknal Ask agent. All fixes are generic (no BPOM/domain-specific tokens) and apply to any project that uses connected-source SQL pairs.

### What broke

A bug report from the one of project showed the agent locking the turn to a broken SQL pair's `0` result because the pair's ERLA reference was wrapped in double-quotes (`\"warehouse.public.t_x\"`), silently failing the UNION-ALL leg. Guard 3 (terminal-stop after authoritative pair) refused to let the agent run its own corrected SQL even with `allow_sql_pair_drift=True`. Follow-up testing revealed adjacent issues: filter set drift across multi-turn conversations, temporal-scope extrapolation ("dari 2024 dan seterusnya" returned 50 instead of 94), and per-turn Guard 1 re-firing in multi-doc YAML pair projects.

### What changed

- **Fix A** — Guard 3 first hit RETRYABLE, second hit TERMINAL; `allow_sql_pair_drift=True` always lets through
- **Fix B** — zero-row / all-NULL aggregate results never recorded as authoritative
- **Fix C** — filter-tweak intent keywords (Indonesian + English) release Guard 3
- **Fix D** — `sql_pairs.mode: advisory` project config skips Guard 2/3 friction
- **Fix E** — `context/sql_pairs/` dropped from Guard 1 roots
- **read_sql_pair** unconditionally marks pairs checked (multi-doc YAML compat)
- **reset_turn_governor** keeps `sql_pairs_checked` session-scoped
- **Temporal-scope hygiene** prompt rule — open-ended filter or MAX probe on scope expansion
- **Multi-turn hygiene** prompt rule — reuse same date column / filter values / predicate set across turns; restate verbatim re-asks

### Verification

All 14 reliability scenarios pass live against Neon PostgreSQL warehouse:

| Category | Tests | Status |
|---|---|---|
| General default-mode (relative date, rolling window, dim drill, single-source, bare question, negation, fabrication refusal, future year) | 8 | ✅ |
| Multi-turn coherence (baseline, verbatim re-ask, dimension variation, scope expansion) | 4 | ✅ |
| Broken-pair lock-in (Fix B end-to-end with injected broken pair) | 1 | ✅ (228, not 0) |
| Advisory mode (Fix D end-to-end with `sql_pairs.mode: advisory`) | 1 | ✅ |

## Test plan

- [x] 84 ask-agent unit tests pass (incl. 11 new regression tests)
- [x] Full ask suite: 1066 passed, 67 skipped
- [x] Base prompt stays under 160-line leanness budget
- [x] Hardcode-guard test prevents BPOM/Seeknal-specific tokens from leaking into the generic multi-turn rule
- [x] Live tmux verification across 4 chat sessions (default mode, multi-turn, broken-pair, advisory mode)
- [x] Reviewer to sanity-check the CHANGELOG entry and confirm no behavioral surprises for projects without SQL pairs

## Files changed

| File | Purpose |
|---|---|
| `src/seeknal/ask/agents/tools/execute_sql.py` | Guard 1/2/3 logic (Fix A, E) |
| `src/seeknal/ask/agents/tools/execute_sql_pair.py` | Authoritative recording (Fix B) |
| `src/seeknal/ask/agents/tools/read_sql_pair.py` | Unconditional mark_checked |
| `src/seeknal/ask/agents/tools/_context.py` | Counter + session-scoped flag + Fix C triggers |
| `src/seeknal/ask/agents/agent.py` | Plumb `sql_pair_mode` into ToolContext |
| `src/seeknal/ask/config.py` | `get_sql_pair_mode()` (Fix D) |
| `src/seeknal/ask/prompt_builder.py` | Temporal-scope + multi-turn hygiene rules |
| `tests/ask/test_execute_sql.py` | +8 regression tests |
| `tests/ask/test_prompt_builder.py` | +3 prompt-rule tests incl. hardcode-guard |
| `pyproject.toml`, `src/seeknal/__init__.py`, `CHANGELOG.md` | 2.9.2 → 2.9.3 |
