### PR TITLE
Wire heartbeat daemon + smart-inbox loop + fix DAG-run core bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,64 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.6] - 2026-05-24
+
+Heartbeat smart-inbox loop — three seeknal-core bugs that blocked
+`seeknal heartbeat tick` from completing the full
+Scan → Ingest → DAG → Exposure loop for any project with transforms,
+plus a UX cleanup to the verbatim re-ask gate.
+
+### Fixed
+
+- **`Manifest` adjacency cache invalidation** (`seeknal.dag.manifest`) —
+  partial per-node `pop` left stale entries for transitively-affected
+  nodes, but the lazy rebuild in `get_upstream_nodes` /
+  `get_downstream_nodes` only fires when the cache dict is *entirely*
+  empty. Popped keys then fell through to `.get(node_id, set())` and
+  silently reported zero neighbors, so Kahn's algorithm in
+  `DAGRunner._get_topological_order` misreported acyclic DAGs as cyclic
+  (`"DAG contains cycles"`). Now clears both caches in one shot on every
+  mutation. Regression test in `tests/dag/test_manifest.py`.
+- **`heartbeat/runner.py::_run_dag` AttributeError** — referenced
+  `summary.fingerprints`, which is not on `ExecutionSummary`. Now reads
+  from `runner._current_fingerprints` (where `DAGRunner` actually stores
+  the per-node fingerprints it computed this run) and maps each to its
+  `.combined` hash, so `DagResult.fingerprints: dict[str, str]` populates
+  correctly.
+- **Cached transform-input view registration**
+  (`workflow/executors/transform_executor.py`) — `_load_views_from_inputs`
+  was creating views as quoted-literal `"source.x"`, while the existence
+  check in the same method and every transform SQL reference
+  `source.x` schema-qualified. DuckDB parses unquoted `source.x` as
+  `schema.table`, so incremental DAG re-runs hit
+  `Catalog Error: Table with name x does not exist`. Now emits
+  `CREATE SCHEMA IF NOT EXISTS "kind"` + `CREATE OR REPLACE VIEW
+  "kind"."name"`, matching the rest of the executor.
+
+### Changed
+
+- **Verbatim re-ask gate is a silent passthrough**
+  (`ask/agents/tools/_context.py`) —
+  `build_verbatim_restate_response(prior_answer)` now returns
+  `prior_answer` unchanged. The old bilingual banner ("Pertanyaan ini
+  sama dengan giliran sebelumnya / This question is the same as the
+  prior turn") is gone. `seed_prior_turn_from_history` is triple-ask
+  safe by construction — a restate is byte-identical to the canonical
+  answer, so re-seeding can never compound. Gate tests
+  (`tests/ask/test_verbatim_restate_gate.py`) updated for the no-banner
+  behaviour.
+- **Heartbeat success-notification log**
+  (`heartbeat/tick_notifier.py`) — emits
+  `[heartbeat] tick notification delivered to chat <id>` when the
+  Telegram POST returns `ok=true`. Used as an assertion target by the
+  heartbeat QA scenarios.
+
+### Docs
+
+- `docs/cli/heartbeat.md` is now part of the published CLI reference,
+  listed in `docs/cli/index.md` under a new **Smart Inbox / Daemon**
+  category alongside the existing Servers & APIs section.
+
 ## [2.9.5] - 2026-05-21
 
 Ask agent reliability — PostgreSQL EXTRACT pushdown, psycopg2 oracle path,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.7] - 2026-06-01
+
+Ask agent harness robustness + table-name discoverability — fixes that make
+`seeknal ask chat` reliable for multi-turn consultant use and let the agent query
+the friendly node names it is shown.
+
+### Fixed
+
+- **Ask chat crash on context compaction (F1)** — the `auto_summarization` history
+  processors could leave the message history ending in a `ModelResponse`, tripping
+  pydantic-ai's "Processed history must end with a `ModelRequest`" invariant and
+  crashing ~27% of chat / ask-test turns. A final `ensure_trailing_model_request`
+  history processor now guarantees the invariant; `stream_ask` and the gateway
+  `_generate` degrade gracefully on `UserError` / `UnexpectedModelBehavior` instead
+  of crashing; the Ask `FunctionToolset` now allows `max_retries=3` so one SQL
+  self-correction retry no longer kills the turn. `auto_summarization` now defaults
+  OFF in `seeknal init` and the config default, and is crash-safe to re-enable.
+- **Fabricated answers in `ask test` mode (F3)** — `testing.run_agent_answer` did not
+  seed the per-turn governor, so `current_question` stayed `None` and the grounding /
+  anti-fabrication guards silently disabled. It now calls `reset_report_approval` +
+  `reset_turn_governor`, mirroring the live chat/gateway paths.
+- **Stale `__version__`** — `seeknal.__version__` was 2.9.5 while `pyproject.toml`
+  was 2.9.6; both now track the release version.
+
+### Added
+
+- **Clean table-name aliases (F2)** — nodes registered as `transform_X` / `source_X` /
+  `model_X` are now also queryable under their bare node name (`X`) via a final
+  catalog-aware registration pass in the REPL, so the name the Ask agent is shown in
+  the manifest / `list_tables` is the name it can query. Aliases never shadow a real
+  relation (legacy cache view, consolidated `entity_`, `ingest_`, or attached table);
+  base-name collisions resolve deterministically (`source_` before `transform_`).
+
 ## [2.9.6] - 2026-05-24
 
 Heartbeat smart-inbox loop — three seeknal-core bugs that blocked

--- a/docs/cli/heartbeat.md
+++ b/docs/cli/heartbeat.md
@@ -1,0 +1,136 @@
+# seeknal heartbeat
+
+Polling daemon + smart inbox layer. `HEARTBEAT.md` at the project root drives
+the loop: scan inbox folders → ingest new files → invoke `DAGRunner` → invoke
+`ExposureExecutor` → append a run record to `target/heartbeat/runs.jsonl`.
+
+The daemon is deterministic. Best-effort failure handling means it survives
+malformed CSVs, DAG crashes, and exposure failures without exiting.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `seeknal heartbeat start` | Run the daemon (loops until SIGTERM/SIGINT). |
+| `seeknal heartbeat tick` | Run a single tick and exit (useful for cron / k8s CronJob). |
+| `seeknal heartbeat status [--limit N]` | Print the last N rows from `runs.jsonl`. |
+| `seeknal heartbeat review <run_id>` | Interactive quarantine review (CLI parity with the Telegram flow). |
+
+All commands accept `--profile <path>` to override the `profiles.yml` location.
+
+## HEARTBEAT.md schema
+
+`HEARTBEAT.md` is the project-level config. The body is either pure YAML, or
+exactly one fenced ```` ```yaml ... ``` ```` block (other content is treated as
+documentation comments).
+
+```yaml
+# Heartbeat (seeknal)
+# Polling daemon config — read by `seeknal heartbeat start|tick`.
+# Set interval: 0s to disable the daemon (tick still works).
+
+interval: 60s              # Loop interval. 30s, 2m, 1h, 0s.
+enabled: true              # Master switch. false → `start` exits cleanly.
+inbox_folders:             # Folders scanned each tick.
+  - inbox
+ingested_target: parquet   # parquet | iceberg. Defaults to profile then "parquet".
+quarantine_dir: target/heartbeat/quarantine
+# project_name: my_project # Optional override; defaults to seeknal_project.yml.
+```
+
+## Inbox layout
+
+```
+<project>/
+  HEARTBEAT.md
+  inbox/              <- drop CSV/TSV/JSON/JSONL/Parquet here
+  target/
+    heartbeat/
+      runs.jsonl                       <- one JSON line per tick
+      runs/<run_id>.json               <- pretty sidecar per tick
+      inbox_state.json                 <- per-file checksum/status
+      quarantine/                      <- bad files
+        needs_review/<run_id>/...      <- low-confidence classifier proposals
+      .lock                            <- cross-process flock
+    ingested/<table>/
+      data.parquet
+      _meta.json
+```
+
+## Idempotence
+
+The daemon stores per-file SHA-256 checksums in `inbox_state.json`. A re-drop
+of an unchanged file is a no-op — no DAG re-run, no exposure call, line in
+`runs.jsonl` has `ingested: []` and `reason: interval`.
+
+## Single-flight
+
+Two overlapping ticks (within the same process or across processes) are
+detected via an asyncio lock + `fcntl.flock` on `target/heartbeat/.lock`.
+The losing tick is recorded as `{status: "skipped", reason: "tick-in-flight"}`.
+
+## Best-effort failure handling
+
+| Failure | Behavior |
+|---------|----------|
+| Malformed CSV | File moved to `target/heartbeat/quarantine/`, status `quarantined`. |
+| DAGRunner exception | `dag.nodes_failed`/`errors[]` populated. Daemon continues. |
+| ExposureExecutor failure | `exposure[].status = failed`. Daemon continues. |
+| Classifier LLM outage (v0.5) | Fallback to deterministic `ingested.<stem>` with a warning. |
+
+## Run record schema (AC4)
+
+```json
+{
+  "run_id": "abc123",
+  "started_at": "2026-05-15T10:00:00.000000Z",
+  "finished_at": "2026-05-15T10:00:01.000000Z",
+  "duration_ms": 1234,
+  "status": "ok",            // ok | partial | failed | skipped
+  "reason": null,            // populated when status=skipped
+  "ingested": [
+    {"file": "...", "table": "sales", "rows": 100, "status": "ok", ...}
+  ],
+  "dag": {
+    "nodes_attempted": 5,
+    "nodes_skipped": 1,
+    "nodes_failed": 0,
+    "fingerprints": {"node_id": "hash"},
+    "per_node": [{"node_id": "..", "status": "..", "duration": 0.0, "row_count": 0}]
+  },
+  "exposure": [{"node": "exp1", "target": "...", "status": "ok"}],
+  "errors": [],
+  "classifier": [           // v0.5 only
+    {"file": "...", "source_used": "catalog", "target_table": "bronze.sales",
+     "confidence": 0.92, "decision": "routed"}
+  ]
+}
+```
+
+## Graceful shutdown
+
+`SIGTERM` during a tick does not abort the in-flight tick — the current tick
+completes (state writes are atomic via `os.replace` + flock + atomic append),
+then the loop exits at the next iteration. For long-pipeline projects, set
+Docker `--stop-timeout` ≥ longest expected tick duration (default 10s; bump
+to 600s for slow pipelines).
+
+## Telegram → inbox bridge (Step 7)
+
+When `telegram.inbox_drop.enabled: true` is set in `seeknal_agent.yml`, the
+existing Telegram document handler also copies the downloaded file into the
+inbox folder. Heartbeat code never imports telegram — the boundary is the
+file system.
+
+```yaml
+# seeknal_agent.yml
+telegram:
+  inbox_drop:
+    enabled: true
+    folder: inbox             # optional; default reads HEARTBEAT.md inbox_folders[0]
+```
+
+## See also
+
+- `docs/cli/init.md` — `seeknal init` scaffolds `HEARTBEAT.md`.
+- `docs/reference/configuration.md` — `source_defaults.ingested.target` profile fallback.

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -22,6 +22,7 @@ The Seeknal CLI (`seeknal`) provides commands for managing data pipelines, featu
 | `ask` | AI-powered data analysis, chat, and reports |
 | `source` | Manage read-only sources for REPL and Ask |
 | `gateway` | HTTP gateway server (WebSocket, SSE, REST, Telegram) |
+| `heartbeat` | Polling daemon + smart inbox (scan → ingest → DAG → exposure → notify) |
 | `report-server` | Host published Evidence.dev reports |
 | `list` | List resources in the current project |
 | `show` | Show details of a specific resource |
@@ -83,6 +84,13 @@ The Seeknal CLI (`seeknal`) provides commands for managing data pipelines, featu
 - `gateway backend` - Cloud-only gateway (no local project)
 - `gateway worker` - Standalone Temporal worker
 - `report-server start` - Host published Evidence.dev reports
+
+### Smart Inbox / Daemon
+
+- `heartbeat start` - Run the polling daemon (loops until SIGTERM/SIGINT)
+- `heartbeat tick` - Run a single tick and exit (cron / k8s CronJob friendly)
+- `heartbeat status` - Show recent runs from `target/heartbeat/runs.jsonl`
+- `heartbeat review` - Interactive quarantine review (CLI parity with the Telegram flow)
 
 ### Visualization & Quality
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "seeknal"
-version = "2.9.5"
+version = "2.9.6"
 description = "All-in-one platform for data and AI/ML engineering"
 authors = [
     {name = "Fitra Kacamarga"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "seeknal"
-version = "2.9.6"
+version = "2.9.7"
 description = "All-in-one platform for data and AI/ML engineering"
 authors = [
     {name = "Fitra Kacamarga"}

--- a/src/seeknal/__init__.py
+++ b/src/seeknal/__init__.py
@@ -29,7 +29,7 @@ Example:
 For more information, see the documentation at https://seeknal.readthedocs.io/
 """
 
-__version__ = "2.9.5"
+__version__ = "2.9.7"
 
 # Export validation functions
 from .validation import (

--- a/src/seeknal/ask/agents/agent.py
+++ b/src/seeknal/ask/agents/agent.py
@@ -208,7 +208,11 @@ def create_agent(
     from seeknal.ask.agents.subagents import get_subagent_configs
     from seeknal.ask.agents.tools.ask_user import interactive_ask_user
     from seeknal.ask.agents.tools.toolset import create_ask_toolset
-    from seeknal.ask.processors import MicrocompactProcessor, SqlResultCompactor
+    from seeknal.ask.processors import (
+        MicrocompactProcessor,
+        SqlResultCompactor,
+        ensure_trailing_model_request,
+    )
     from seeknal.ask.security import configure_safe_connection
     from seeknal.cli.repl import REPL
     from seeknal.ask.config import (
@@ -499,6 +503,13 @@ a plain-language follow-up in the final response; do not call `ask_user`.
             )
         )
 
+    # Safety net — registered LAST so it runs after every other processor and the
+    # context-manager summarizer: guarantee the processed history ends with a
+    # ModelRequest so compaction/summarization can never trip pydantic-ai's
+    # "Processed history must end with a `ModelRequest`" invariant and crash the
+    # turn. No-op on well-formed history.
+    history_processors.append(ensure_trailing_model_request)
+
     plan_enabled = _resolve_auto_bool(
         plan_config["enabled"],
         default=(environment == "interactive" and not analysis_toolset),
@@ -674,10 +685,15 @@ def compact_history_for_analysis_mode(message_history: list) -> None:
     except RuntimeError:
         return
 
-    from seeknal.ask.processors import MicrocompactProcessor, SqlResultCompactor
+    from seeknal.ask.processors import (
+        MicrocompactProcessor,
+        SqlResultCompactor,
+        ensure_trailing_model_request,
+    )
 
     compacted = MicrocompactProcessor(keep_recent_turns=1)(message_history)
     compacted = SqlResultCompactor(min_chars=250)(compacted)
+    compacted = ensure_trailing_model_request(compacted)
     message_history.clear()
     message_history.extend(compacted)
 

--- a/src/seeknal/ask/agents/tools/_context.py
+++ b/src/seeknal/ask/agents/tools/_context.py
@@ -300,40 +300,17 @@ def lookup_prior_turn_answer(
     return stored_answer
 
 
-# Bilingual restate prefix wrapped around a prior-turn answer when the
-# verbatim re-ask gate fires. Indonesian + English — the BPOM/KAFI tests
-# exercise Indonesian/Malay phrasing and English tests also exist.
-_VERBATIM_RESTATE_PREFIX = (
-    "Pertanyaan ini sama dengan giliran sebelumnya — jawaban tetap sama:\n"
-    "/ This question is the same as the prior turn — the answer is the same:"
-)
-_VERBATIM_RESTATE_SUFFIX = (
-    "Jika Anda ingin data baru, ubah filter atau dimensi.\n"
-    "/ If you wanted fresh data, change the filter or dimension."
-)
-
-
 def build_verbatim_restate_response(prior_answer: str) -> str:
-    """Wrap a prior-turn answer with the bilingual restate notice."""
-    return (
-        f"{_VERBATIM_RESTATE_PREFIX}\n\n"
-        f"{prior_answer}\n\n"
-        f"{_VERBATIM_RESTATE_SUFFIX}"
-    )
+    """Return the prior-turn answer for a verbatim re-ask, unchanged.
 
-
-def _unwrap_restate(answer: str) -> str:
-    """Strip the bilingual restate wrapper, returning the canonical answer.
-
-    A no-op for answers that are not themselves a restate. Keeps triple-asks
-    from compounding the wrapper (restate of a restate of ...).
+    A verbatim re-ask returns the previous answer exactly — no banner,
+    no meta-commentary, no "this is the same question" notice. The gate
+    behaves as a silent cache: identical question in, identical answer
+    out. The function is kept as the single named seam the gateway and
+    streaming entry points call, so the restate policy lives in one
+    place and is trivial to evolve.
     """
-    if not answer.startswith(_VERBATIM_RESTATE_PREFIX):
-        return answer
-    core = answer[len(_VERBATIM_RESTATE_PREFIX):]
-    if core.rstrip().endswith(_VERBATIM_RESTATE_SUFFIX):
-        core = core.rstrip()[: -len(_VERBATIM_RESTATE_SUFFIX)]
-    return core.strip()
+    return prior_answer
 
 
 def seed_prior_turn_from_history(message_history: Any) -> None:
@@ -351,10 +328,11 @@ def seed_prior_turn_from_history(message_history: Any) -> None:
     backwards for the most recent (user question, assistant answer) pair
     and stores it via ``record_prior_turn_answer``.
 
-    Triple-ask safe: if the most recent answer is itself a wrapped
-    restate, the wrapper is stripped so the canonical answer is stored
-    (never a restate-of-a-restate). Best-effort and non-fatal — any
-    failure leaves the gate dormant rather than crashing the turn.
+    Triple-ask safe by construction: a verbatim restate returns the
+    prior answer unchanged (see ``build_verbatim_restate_response``), so
+    the stored answer is always canonical — re-seeding from it can never
+    compound. Best-effort and non-fatal — any failure leaves the gate
+    dormant rather than crashing the turn.
     """
     if not message_history:
         return
@@ -397,10 +375,9 @@ def seed_prior_turn_from_history(message_history: Any) -> None:
     if prior_answer is None or prior_question is None:
         return
 
-    canonical = _unwrap_restate(prior_answer)
-    if not canonical.strip():
+    if not prior_answer.strip():
         return
-    record_prior_turn_answer(question=prior_question, answer=canonical)
+    record_prior_turn_answer(question=prior_question, answer=prior_answer)
 
 
 def reset_turn_governor(question: str | None = None) -> None:

--- a/src/seeknal/ask/agents/tools/_context.py
+++ b/src/seeknal/ask/agents/tools/_context.py
@@ -322,6 +322,87 @@ def build_verbatim_restate_response(prior_answer: str) -> str:
     )
 
 
+def _unwrap_restate(answer: str) -> str:
+    """Strip the bilingual restate wrapper, returning the canonical answer.
+
+    A no-op for answers that are not themselves a restate. Keeps triple-asks
+    from compounding the wrapper (restate of a restate of ...).
+    """
+    if not answer.startswith(_VERBATIM_RESTATE_PREFIX):
+        return answer
+    core = answer[len(_VERBATIM_RESTATE_PREFIX):]
+    if core.rstrip().endswith(_VERBATIM_RESTATE_SUFFIX):
+        core = core.rstrip()[: -len(_VERBATIM_RESTATE_SUFFIX)]
+    return core.strip()
+
+
+def seed_prior_turn_from_history(message_history: Any) -> None:
+    """Re-seed the durable prior-turn pair from a persisted message_history.
+
+    The gateway rebuilds the agent's REPL on every turn (``create_agent``),
+    so the in-memory prior-turn pair written by ``record_prior_turn_answer``
+    does not survive between turns — and the verbatim re-ask gate, which
+    reads that pair off ``ctx.repl``, never fires on gateway/Telegram
+    sessions. ``message_history`` IS persisted per session (via the
+    session store), so it is the authoritative cross-turn source.
+
+    Call this after ``create_agent`` (so the ToolContext + fresh REPL
+    exist) and before the verbatim gate. Walks ``message_history``
+    backwards for the most recent (user question, assistant answer) pair
+    and stores it via ``record_prior_turn_answer``.
+
+    Triple-ask safe: if the most recent answer is itself a wrapped
+    restate, the wrapper is stripped so the canonical answer is stored
+    (never a restate-of-a-restate). Best-effort and non-fatal — any
+    failure leaves the gate dormant rather than crashing the turn.
+    """
+    if not message_history:
+        return
+    try:
+        from pydantic_ai.messages import (
+            ModelRequest,
+            ModelResponse,
+            TextPart,
+            UserPromptPart,
+        )
+    except Exception:  # noqa: BLE001 - pydantic_ai optional at import time
+        return
+
+    prior_answer: str | None = None
+    prior_question: str | None = None
+    for msg in reversed(message_history):
+        if prior_answer is None and isinstance(msg, ModelResponse):
+            for part in msg.parts:
+                if (
+                    isinstance(part, TextPart)
+                    and isinstance(part.content, str)
+                    and part.content.strip()
+                ):
+                    prior_answer = part.content
+                    break
+        elif (
+            prior_answer is not None
+            and prior_question is None
+            and isinstance(msg, ModelRequest)
+        ):
+            for part in msg.parts:
+                if isinstance(part, UserPromptPart) and isinstance(
+                    part.content, str
+                ) and part.content.strip():
+                    prior_question = part.content
+                    break
+        if prior_answer is not None and prior_question is not None:
+            break
+
+    if prior_answer is None or prior_question is None:
+        return
+
+    canonical = _unwrap_restate(prior_answer)
+    if not canonical.strip():
+        return
+    record_prior_turn_answer(question=prior_question, answer=canonical)
+
+
 def reset_turn_governor(question: str | None = None) -> None:
     """Reset per-user-turn harness state.
 

--- a/src/seeknal/ask/agents/tools/toolset.py
+++ b/src/seeknal/ask/agents/tools/toolset.py
@@ -191,4 +191,9 @@ def create_ask_toolset(
     return FunctionToolset(
         tools=tools,
         id=toolset_id,
+        # pydantic-ai's FunctionToolset defaults to max_retries=1. The SQL
+        # security / self-correction hooks raise ModelRetry on a bad query, so a
+        # single retry exhaustion would raise UnexpectedModelBehavior and kill the
+        # whole turn. Give the model room to self-correct before failing.
+        max_retries=3,
     )

--- a/src/seeknal/ask/config.py
+++ b/src/seeknal/ask/config.py
@@ -334,7 +334,12 @@ def get_auto_summarization_config(config: dict[str, Any]) -> dict[str, Any]:
     sql_compactor = _get_mapping(section, "sql_result_compactor")
 
     return {
-        "enabled": _coerce_bool(section.get("enabled"), True),
+        # Default OFF: the context-management history processors can leave the
+        # message history ending in a ModelResponse, which trips pydantic-ai's
+        # "Processed history must end with a `ModelRequest`" invariant. It is
+        # opt-in until/unless explicitly enabled (the trailing-ModelRequest guard
+        # in agents/agent.py makes it crash-safe when a project does enable it).
+        "enabled": _coerce_bool(section.get("enabled"), False),
         "context_manager": _coerce_auto_bool(section.get("context_manager"), "auto"),
         "context_manager_max_tokens": _coerce_int(
             section.get("context_manager_max_tokens"), None

--- a/src/seeknal/ask/gateway/channels/telegram.py
+++ b/src/seeknal/ask/gateway/channels/telegram.py
@@ -10,6 +10,7 @@ Configure: TELEGRAM_BOT_TOKEN environment variable
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
@@ -348,6 +349,103 @@ class TelegramChannel:
             except Exception:
                 await update.message.reply_text(f"❌ Error: {e}")
 
+    # ------------------------------------------------------------------
+    # Manifest-aware photo intake
+    # ------------------------------------------------------------------
+    # When the project ships ``data/telegram_uploads/ingestion_manifest.json``
+    # with a route whose ``file_pattern`` matches the user's caption, the
+    # destination table is already decided. Drive the agent straight to
+    # ``extract_from_image`` -> ``write_ingested_table`` -> ``execute_sql``
+    # verify, skipping the ``propose_record_table`` round-trip. Without a
+    # manifest hit, fall back to the legacy generic prompt.
+
+    def _load_ingestion_manifest(self) -> dict[str, Any] | None:
+        """Read the project's ``data/telegram_uploads/ingestion_manifest.json``.
+
+        Returns the parsed dict, or ``None`` when missing, unreadable, or
+        lacking a non-empty ``routes`` list.
+        """
+        manifest_path = (
+            self._project_path
+            / "data"
+            / "telegram_uploads"
+            / "ingestion_manifest.json"
+        )
+        if not manifest_path.exists():
+            return None
+        try:
+            data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            logger.warning(
+                "[telegram] failed to read ingestion_manifest.json: %s", exc
+            )
+            return None
+        if not isinstance(data, dict):
+            return None
+        routes = data.get("routes")
+        if not isinstance(routes, list) or not routes:
+            return None
+        return data
+
+    def _match_manifest_route(
+        self, hint_text: str, manifest: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        """Return the unique manifest route whose ``file_pattern`` matches.
+
+        Photos from Telegram do not carry meaningful filenames, so we match
+        the ``file_pattern`` token (``*order*`` -> ``order``) against the
+        lowercased caption text. When zero or multiple routes match we
+        return ``None`` and the legacy generic flow handles disambiguation.
+        """
+        if not hint_text:
+            return None
+        hint = hint_text.lower()
+        matched: list[dict[str, Any]] = []
+        for route in manifest.get("routes", []):
+            if not isinstance(route, dict):
+                continue
+            pattern = route.get("file_pattern", "")
+            if not isinstance(pattern, str):
+                continue
+            token = pattern.replace("*", "").strip().lower()
+            if not token:
+                continue
+            if token in hint:
+                matched.append(route)
+        if len(matched) == 1:
+            return matched[0]
+        return None
+
+    def _load_photo_intake_config(self) -> dict[str, Any]:
+        """Read ``telegram.photo_intake`` from ``seeknal_agent.yml``.
+
+        Defaults to ``require_confirmation=True`` (the safer setting) when
+        the file is missing, unreadable, or omits the key.
+        """
+        cfg_path = self._project_path / "seeknal_agent.yml"
+        if not cfg_path.exists():
+            cfg_path = self._project_path / "seeknal_agent.yaml"
+        if not cfg_path.exists():
+            return {"require_confirmation": True}
+        try:
+            import yaml
+
+            data = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+        except (OSError, ValueError) as exc:
+            logger.warning(
+                "[telegram] failed to read seeknal_agent.yml: %s", exc
+            )
+            return {"require_confirmation": True}
+        if not isinstance(data, dict):
+            return {"require_confirmation": True}
+        telegram_cfg = data.get("telegram") or {}
+        intake = telegram_cfg.get("photo_intake") or {}
+        return {
+            "require_confirmation": bool(
+                intake.get("require_confirmation", True)
+            )
+        }
+
     async def _handle_photo(self, update: Any, context: Any) -> None:
         """Handle photo uploads — stage and route into record-entry skill."""
         from telegram.constants import ChatAction
@@ -403,22 +501,91 @@ class TelegramChannel:
             return
 
         caption = (update.message.caption or "").strip()
-        user_prompt = (
-            "The user sent a photo via Telegram — most likely a fund-transfer "
-            "proof (BCA/Mandiri/BNI/BRI/GoPay/OVO/DANA/QRIS), a shop receipt, "
-            "or an order photo. Load the 'record-entry' skill and walk through "
-            f"the full workflow on this image:\n\n"
-            f"Absolute image path: {staged_path}\n"
+
+        manifest = self._load_ingestion_manifest()
+        matched_route = (
+            self._match_manifest_route(caption, manifest) if manifest else None
         )
-        if caption:
-            user_prompt += f"User caption / hint: {caption}\n"
-        user_prompt += (
-            "\nStart with `extract_from_image(image_path=<path>, hint=<caption "
-            "if any>)`, then `list_tables` + `propose_record_table`, then "
-            "`ask_user` until every required field is resolved, then "
-            "`write_ingested_table`. Strict clarification — do not record "
-            "until the draft is fully confirmed."
-        )
+
+        if matched_route:
+            target_table = str(matched_route.get("target_table", "")).strip()
+            required_cols = matched_route.get("required_columns") or []
+            if not isinstance(required_cols, list):
+                required_cols = []
+            require_confirmation = self._load_photo_intake_config()[
+                "require_confirmation"
+            ]
+            ingest_table = f"ingest_{target_table}"
+            cols_line = (
+                ", ".join(str(c) for c in required_cols)
+                if required_cols
+                else "(see manifest)"
+            )
+            logger.info(
+                "[telegram] manifest route matched: target=%s, confirm=%s",
+                target_table,
+                require_confirmation,
+            )
+
+            user_prompt = (
+                "The user sent a photo via Telegram and the project's "
+                "ingestion manifest routes this upload to a known canonical "
+                "table. The destination is already decided — do NOT call "
+                "`propose_record_table`.\n\n"
+                f"Absolute image path: {staged_path}\n"
+            )
+            if caption:
+                user_prompt += f"User caption / hint: {caption}\n"
+            user_prompt += (
+                f"\nCanonical destination: source.{target_table}\n"
+                f"Ingest staging table: {ingest_table}\n"
+                f"Required columns: {cols_line}\n\n"
+                "Workflow:\n"
+                "1. Call `extract_from_image(image_path=<path>, "
+                "hint=<caption if any>)`.\n"
+                "2. Coerce the extracted fields onto the required columns "
+                "listed above.\n"
+            )
+            if require_confirmation:
+                user_prompt += (
+                    "3. Show the draft row to the user in plain Indonesian "
+                    "and ask: Ya / Edit / Salah / Batal.\n"
+                    "4. After the user confirms, call "
+                    f"`write_ingested_table(table_name='{ingest_table}', "
+                    "mode='append', user_confirmed=True)`.\n"
+                )
+            else:
+                user_prompt += (
+                    "3. Auto-save is enabled — call "
+                    f"`write_ingested_table(table_name='{ingest_table}', "
+                    "mode='append', user_confirmed=True)` directly.\n"
+                )
+            user_prompt += (
+                "5. Verify by calling `execute_sql("
+                f"\"SELECT COUNT(*) FROM {ingest_table}\")` and quote the "
+                "row count in your reply. Never claim 'tersimpan' or "
+                "'saved' without this verification step.\n"
+                "Reply in plain Indonesian owner language."
+            )
+        else:
+            user_prompt = (
+                "The user sent a photo via Telegram — most likely a "
+                "fund-transfer proof "
+                "(BCA/Mandiri/BNI/BRI/GoPay/OVO/DANA/QRIS), a shop receipt, "
+                "or an order photo. Load the 'record-entry' skill and walk "
+                "through the full workflow on this image:\n\n"
+                f"Absolute image path: {staged_path}\n"
+            )
+            if caption:
+                user_prompt += f"User caption / hint: {caption}\n"
+            user_prompt += (
+                "\nStart with `extract_from_image(image_path=<path>, "
+                "hint=<caption if any>)`, then `list_tables` + "
+                "`propose_record_table`, then `ask_user` until every "
+                "required field is resolved, then `write_ingested_table`. "
+                "Strict clarification — do not record until the draft is "
+                "fully confirmed."
+            )
 
         try:
             await status_msg.edit_text("🧐 Reading the image...")

--- a/src/seeknal/ask/gateway/channels/telegram.py
+++ b/src/seeknal/ask/gateway/channels/telegram.py
@@ -32,7 +32,20 @@ _MAX_MESSAGE_LENGTH = 4096
 
 # Document upload constraints (match the gateway /upload endpoint)
 _UPLOAD_MAX_BYTES = 200 * 1024 * 1024  # 200 MB
-_UPLOAD_ALLOWED_SUFFIXES = {".xlsx", ".csv", ".tsv", ".json"}
+# Tabular files → the data-ingest skill (read_tabular → write_ingested_table).
+_TABULAR_SUFFIXES = {".xlsx", ".csv", ".tsv", ".json"}
+# Image / document files → the record-entry (vision/extraction) skill.
+_VISION_DOC_SUFFIXES = {
+    ".png", ".jpg", ".jpeg", ".webp", ".heic", ".heif", ".pdf", ".txt",
+}
+# Archives → unpacked, then each entry routed by its own suffix.
+_ARCHIVE_SUFFIXES = {".zip"}
+# Union of every accepted document suffix; anything else is rejected.
+_UPLOAD_ALLOWED_SUFFIXES = (
+    _TABULAR_SUFFIXES | _VISION_DOC_SUFFIXES | _ARCHIVE_SUFFIXES
+)
+# Archive-extraction guards: cap entry count to bound a zip-bomb / fan-out.
+_ARCHIVE_MAX_ENTRIES = 50
 
 # Image upload constraints (routed into record-entry skill)
 _IMAGE_MAX_BYTES = 20 * 1024 * 1024  # 20 MB
@@ -761,8 +774,70 @@ class TelegramChannel:
                 return first.strip()
         return None
 
+    def _extract_archive(
+        self, archive_path: Path, staging_dir: Path
+    ) -> tuple[Path | None, list[str], str | None]:
+        """Safely extract a ZIP into a staging subdirectory.
+
+        Returns ``(extract_dir, member_relpaths, error)``. On any guard
+        violation returns ``(None, [], error_message)``. Guards:
+
+        - entry-count cap (``_ARCHIVE_MAX_ENTRIES``) — bounds fan-out
+        - total-uncompressed-size cap (``_UPLOAD_MAX_BYTES``) — zip bomb
+        - zip-slip containment — every member must resolve inside the
+          extract dir; a ``../`` entry aborts the whole extraction
+        """
+        import shutil
+        import zipfile
+
+        extract_dir = staging_dir / f"{archive_path.stem}_unzip"
+        try:
+            with zipfile.ZipFile(archive_path) as zf:
+                infos = [i for i in zf.infolist() if not i.is_dir()]
+                if len(infos) > _ARCHIVE_MAX_ENTRIES:
+                    return None, [], (
+                        f"ZIP has {len(infos)} files; the limit is "
+                        f"{_ARCHIVE_MAX_ENTRIES}."
+                    )
+                total = sum(i.file_size for i in infos)
+                if total > _UPLOAD_MAX_BYTES:
+                    return None, [], (
+                        f"ZIP expands to {total / 1024 / 1024:.1f} MB; "
+                        f"the limit is 200 MB."
+                    )
+                extract_dir.mkdir(parents=True, exist_ok=True)
+                resolved_root = extract_dir.resolve()
+                members: list[str] = []
+                for info in infos:
+                    target = (extract_dir / info.filename).resolve()
+                    # zip-slip guard: the member must stay under extract_dir.
+                    try:
+                        target.relative_to(resolved_root)
+                    except ValueError:
+                        return None, [], (
+                            f"ZIP entry escapes the extract directory: "
+                            f"{info.filename}"
+                        )
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    with zf.open(info) as src, open(target, "wb") as dst:
+                        shutil.copyfileobj(src, dst)
+                    members.append(info.filename)
+        except zipfile.BadZipFile:
+            return None, [], "That file is not a valid ZIP archive."
+        except OSError as exc:
+            return None, [], f"ZIP extraction failed: {exc}"
+        if not members:
+            return None, [], "The ZIP archive is empty."
+        return extract_dir, members, None
+
     async def _handle_document(self, update: Any, context: Any) -> None:
-        """Handle document uploads — stage file and trigger data-ingest skill."""
+        """Handle document uploads.
+
+        Routes by suffix: tabular files (.csv/.xlsx/.tsv/.json) into the
+        data-ingest skill; images / PDF / text into the record-entry
+        (vision) skill; ZIP archives are unpacked and each entry routed
+        by its own suffix.
+        """
         from telegram.constants import ChatAction
 
         doc = update.message.document
@@ -778,9 +853,15 @@ class TelegramChannel:
             chat_id, original_name, doc.file_size,
         )
 
-        if suffix not in _UPLOAD_ALLOWED_SUFFIXES:
+        if suffix in _TABULAR_SUFFIXES:
+            doc_category = "tabular"
+        elif suffix in _VISION_DOC_SUFFIXES:
+            doc_category = "vision"
+        elif suffix in _ARCHIVE_SUFFIXES:
+            doc_category = "archive"
+        else:
             await update.message.reply_text(
-                f"Sorry, I can't ingest '{suffix}' files. "
+                f"Sorry, I can't process '{suffix}' files. "
                 f"Supported: {', '.join(sorted(_UPLOAD_ALLOWED_SUFFIXES))}."
             )
             return
@@ -822,17 +903,51 @@ class TelegramChannel:
             return
 
         caption = (update.message.caption or "").strip()
-        user_prompt = (
-            f"The user uploaded a tabular file via Telegram. "
-            f"Absolute file path: {staged_path}. "
-            f"Please load the 'data-ingest' skill and walk through the ingestion "
-            f"workflow: use read_tabular to preview the file, propose a table "
-            f"name and business key via ask_user, write it via "
-            f"write_ingested_table, and save a reusable skill via "
-            f"save_ingestion_skill. "
-        )
+
+        if doc_category == "tabular":
+            user_prompt = (
+                f"The user uploaded a tabular file via Telegram. "
+                f"Absolute file path: {staged_path}. "
+                f"Please load the 'data-ingest' skill and walk through the "
+                f"ingestion workflow: use read_tabular to preview the file, "
+                f"propose a table name and business key via ask_user, write "
+                f"it via write_ingested_table, and save a reusable skill via "
+                f"save_ingestion_skill. "
+            )
+        elif doc_category == "vision":
+            user_prompt = (
+                f"The user uploaded a document file ({suffix}) via Telegram — "
+                f"an image, PDF, or text file. Absolute file path: "
+                f"{staged_path}. Load the 'record-entry' skill and extract "
+                f"its content: for an image use extract_from_image; for a PDF "
+                f"or text file read the content directly with the appropriate "
+                f"tool. Then propose_record_table, ask_user until every "
+                f"required field is confirmed, and write_ingested_table. "
+                f"Strict clarification — do not record until the draft is "
+                f"fully confirmed. "
+            )
+        else:  # archive
+            extract_dir, members, archive_err = self._extract_archive(
+                staged_path, staging_dir
+            )
+            if archive_err is not None or extract_dir is None:
+                try:
+                    await status_msg.edit_text(f"❌ {archive_err}")
+                except Exception:
+                    await update.message.reply_text(f"❌ {archive_err}")
+                return
+            file_list = "\n".join(f"  - {m}" for m in members)
+            user_prompt = (
+                f"The user uploaded a ZIP archive via Telegram; it was "
+                f"extracted to {extract_dir} and contains {len(members)} "
+                f"file(s):\n{file_list}\n\n"
+                f"Process each file by its type: tabular files "
+                f"(.csv/.xlsx/.tsv/.json) via the 'data-ingest' skill; "
+                f"images, PDFs, and text files via the 'record-entry' skill. "
+                f"Give a concise per-file summary of what was ingested. "
+            )
         if caption:
-            user_prompt += f"User note: {caption}"
+            user_prompt += f"\nUser note: {caption}"
 
         try:
             await status_msg.edit_text(f"🔍 Inspecting {original_name}...")

--- a/src/seeknal/ask/gateway/channels/telegram.py
+++ b/src/seeknal/ask/gateway/channels/telegram.py
@@ -456,6 +456,134 @@ class TelegramChannel:
             except Exception:
                 await update.message.reply_text(f"❌ Error: {exc}")
 
+    # ------------------------------------------------------------------
+    # Step 7 — Telegram → heartbeat-inbox bridge
+    # ------------------------------------------------------------------
+    # The Telegram channel stages every uploaded file under
+    # ``target/ask_ingest/_staging/`` and runs the interactive ``data-ingest``
+    # skill (existing behavior, untouched). Optionally, projects that also
+    # run ``seeknal heartbeat`` can mirror the staged file into the
+    # heartbeat's inbox folder so the deterministic tick picks it up on
+    # its next scan. The bridge is a *copy*, not a move, so the interactive
+    # path keeps working in parallel.
+    #
+    # The lint contract in ``tests/heartbeat/test_telegram_bridge.py::
+    # test_no_telegram_imports_in_heartbeat`` forbids the reverse direction
+    # — heartbeat must never import from this module. We honour the same
+    # boundary from this side by reading ``HEARTBEAT.md`` inline rather
+    # than importing ``seeknal.heartbeat.config``.
+
+    def _inbox_drop_settings(self) -> dict[str, Any]:
+        """Return the Telegram → heartbeat-inbox bridge settings.
+
+        Returns a dict with two keys:
+
+        - ``enabled`` (bool): when False, :meth:`_copy_to_inbox` is a no-op
+          and the existing staging-only behavior is preserved.
+        - ``folder`` (str | None): when set, overrides HEARTBEAT.md's first
+          ``inbox_folders`` entry. ``None`` defers to that lookup and finally
+          to the ``inbox`` default.
+
+        Default is disabled so existing deployments keep their current
+        behavior. Projects opt in by subclassing or future config wiring.
+        """
+        return {"enabled": False, "folder": None}
+
+    def _copy_to_inbox(self, staged_path: Path) -> Path | None:
+        """Copy a staged Telegram upload into the heartbeat's inbox folder.
+
+        Returns the destination path on success, or ``None`` when the
+        bridge is disabled OR the resolved inbox path would escape the
+        project root (containment guard).
+
+        Folder resolution order:
+
+        1. ``_inbox_drop_settings()["folder"]`` (explicit override)
+        2. HEARTBEAT.md's first ``inbox_folders`` entry
+        3. ``inbox`` (project-root default)
+
+        On filename collision, appends a UTC timestamp to the stem so the
+        original uploaded name is preserved as the prefix. The staged file
+        itself is left in place.
+        """
+        settings = self._inbox_drop_settings()
+        if not settings.get("enabled"):
+            return None
+
+        folder_name = settings.get("folder")
+        if folder_name is None:
+            folder_name = (
+                self._read_inbox_folder_from_heartbeat_md() or "inbox"
+            )
+
+        # Containment guard: resolved inbox must stay under project root.
+        try:
+            project_root = self._project_path.resolve()
+            inbox_dir = (project_root / folder_name).resolve()
+            inbox_dir.relative_to(project_root)
+        except (ValueError, OSError):
+            logger.warning(
+                "[telegram] inbox drop refused — resolved path escapes "
+                "project root: %s",
+                folder_name,
+            )
+            return None
+
+        try:
+            inbox_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            logger.warning(
+                "[telegram] inbox drop refused — mkdir failed: %s", exc
+            )
+            return None
+
+        dest = inbox_dir / staged_path.name
+        if dest.exists():
+            from datetime import datetime, timezone
+
+            ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+            dest = inbox_dir / f"{staged_path.stem}.{ts}{staged_path.suffix}"
+
+        import shutil
+
+        try:
+            shutil.copy2(staged_path, dest)
+        except OSError as exc:
+            logger.warning("[telegram] inbox drop copy failed: %s", exc)
+            return None
+        return dest
+
+    def _read_inbox_folder_from_heartbeat_md(self) -> str | None:
+        """Best-effort: return HEARTBEAT.md's first ``inbox_folders`` entry.
+
+        Done inline so this module stays independent of the heartbeat
+        package surface; the lint contract on the heartbeat side prevents
+        the reverse import.
+        """
+        md = self._project_path / "HEARTBEAT.md"
+        if not md.exists():
+            return None
+        try:
+            text = md.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            return None
+        match = re.search(r"```yaml\s*(.*?)```", text, re.DOTALL)
+        body = match.group(1) if match else text
+        try:
+            import yaml
+
+            data = yaml.safe_load(body)
+        except Exception:
+            return None
+        if not isinstance(data, dict):
+            return None
+        folders = data.get("inbox_folders")
+        if isinstance(folders, list) and folders:
+            first = folders[0]
+            if isinstance(first, str) and first.strip():
+                return first.strip()
+        return None
+
     async def _handle_document(self, update: Any, context: Any) -> None:
         """Handle document uploads — stage file and trigger data-ingest skill."""
         from telegram.constants import ChatAction

--- a/src/seeknal/ask/gateway/channels/telegram.py
+++ b/src/seeknal/ask/gateway/channels/telegram.py
@@ -390,12 +390,17 @@ class TelegramChannel:
     def _match_manifest_route(
         self, hint_text: str, manifest: dict[str, Any]
     ) -> dict[str, Any] | None:
-        """Return the unique manifest route whose ``file_pattern`` matches.
+        """Return the manifest route whose ``file_pattern`` matches the hint.
 
         Photos from Telegram do not carry meaningful filenames, so we match
         the ``file_pattern`` token (``*order*`` -> ``order``) against the
-        lowercased caption text. When zero or multiple routes match we
-        return ``None`` and the legacy generic flow handles disambiguation.
+        lowercased caption text. Multiple routes may match — e.g. an
+        English token and its Indonesian alias both pointing at the same
+        ``target_table``. Such matches are collapsed: as long as every
+        match resolves to a single ``target_table`` the first one is
+        returned. Only a genuine ambiguity (matches spanning two or more
+        distinct target tables) returns ``None`` and defers to the legacy
+        generic flow.
         """
         if not hint_text:
             return None
@@ -412,7 +417,12 @@ class TelegramChannel:
                 continue
             if token in hint:
                 matched.append(route)
-        if len(matched) == 1:
+        if not matched:
+            return None
+        target_tables = {
+            str(route.get("target_table", "")).strip() for route in matched
+        }
+        if len(target_tables) == 1:
             return matched[0]
         return None
 

--- a/src/seeknal/ask/gateway/server.py
+++ b/src/seeknal/ask/gateway/server.py
@@ -694,6 +694,42 @@ async def _run_agent_inner(
         record_prior_turn_answer(question=question, answer=answer)
         yield {"type": "answer", "data": answer}
 
+    except Exception as exc:
+        # Recoverable harness errors must not 500 the gateway turn:
+        #  - UserError "Processed history must end with a `ModelRequest`"
+        #    (context compaction/summarization left a ModelResponse tail), and
+        #  - UnexpectedModelBehavior "exceeded max retries" (a tool gave up).
+        # Repair the history tail and answer from gathered evidence; re-raise
+        # anything else unchanged.
+        from pydantic_ai.exceptions import (
+            UnexpectedModelBehavior,
+            UserError,
+        )
+
+        _exc_msg = str(exc).lower()
+        if not (
+            isinstance(exc, (UserError, UnexpectedModelBehavior))
+            and (
+                "processed history must end with" in _exc_msg
+                or "exceeded max retries" in _exc_msg
+                or "max retries count" in _exc_msg
+                or "exceeded maximum retries" in _exc_msg
+            )
+        ):
+            raise
+        from seeknal.ask.agents.tools._context import synthesize_evidence_fallback
+
+        # Answer deterministically from evidence already gathered — no further
+        # model call, so the broken history is never re-fed. Nothing reads
+        # message_history after this branch (the finally block saves only when a
+        # run `result` exists), so repairing it here would be dead code.
+        answer = synthesize_evidence_fallback(
+            "a recoverable harness error interrupted the run; "
+            "answering from the evidence gathered so far"
+        )
+        record_prior_turn_answer(question=question, answer=answer)
+        yield {"type": "answer", "data": answer}
+
     finally:
         # Always save conversation — even when the consumer closes the generator
         # early (e.g. Telegram breaking on answer event). Without this, session

--- a/src/seeknal/ask/gateway/server.py
+++ b/src/seeknal/ask/gateway/server.py
@@ -423,10 +423,18 @@ async def _run_agent_inner(
         record_prior_turn_answer,
         reset_report_approval,
         reset_turn_governor,
+        seed_prior_turn_from_history,
     )
 
     reset_report_approval()
     reset_turn_governor(question)
+
+    # The gateway rebuilds the REPL on every turn (create_agent above), so
+    # the in-memory prior-turn pair from record_prior_turn_answer never
+    # survives between turns. Re-seed it from the persisted message_history
+    # so the verbatim re-ask gate below actually fires on gateway/Telegram
+    # sessions (without this it is permanently dormant here).
+    seed_prior_turn_from_history(message_history)
 
     # Verbatim re-ask short-circuit: same question as the prior turn returns
     # the prior answer with a bilingual restate notice BEFORE any LLM/tool

--- a/src/seeknal/ask/processors.py
+++ b/src/seeknal/ask/processors.py
@@ -55,6 +55,32 @@ def _get_turn_index(messages: list[ModelMessage], msg_idx: int) -> int:
     return max(current_turn, 0)
 
 
+def ensure_trailing_model_request(
+    messages: list[ModelMessage],
+) -> list[ModelMessage]:
+    """Guarantee the processed history ends with a ``ModelRequest``.
+
+    pydantic-ai's ``_prepare_request`` raises
+    ``UserError('Processed history must end with a `ModelRequest`.')`` when the
+    message list handed to the next model request ends in a ``ModelResponse``.
+    Upstream context management (the LLM summarizer / eviction, or any history
+    processor) can leave such a tail. Registered as the LAST history processor,
+    this trims any trailing non-``ModelRequest`` messages so the invariant holds
+    instead of crashing the whole turn. It is a no-op on well-formed history and
+    never returns an empty list.
+    """
+    if not messages or isinstance(messages[-1], ModelRequest):
+        return messages
+    trimmed = list(messages)
+    while trimmed and not isinstance(trimmed[-1], ModelRequest):
+        trimmed.pop()
+    # If history was reduced to all non-ModelRequest messages, trimming alone
+    # cannot satisfy the invariant; return the original (non-empty) list and let
+    # the streaming/gateway recovery handler degrade gracefully rather than send
+    # an empty history.
+    return trimmed or messages
+
+
 @dataclass
 class MicrocompactProcessor:
     """Tier 1: Replace old tool results with a short placeholder.

--- a/src/seeknal/ask/streaming.py
+++ b/src/seeknal/ask/streaming.py
@@ -1064,6 +1064,45 @@ async def stream_ask(
                 )
                 record_prior_turn_answer(question=question, answer=fallback)
                 return fallback
+
+            # Recoverable harness errors must NOT crash the chat turn. Two cases:
+            #  - UserError "Processed history must end with a `ModelRequest`"
+            #    (context compaction/summarization left a ModelResponse tail), and
+            #  - UnexpectedModelBehavior "exceeded max retries" (a tool gave up).
+            # Repair the history tail and answer from gathered evidence instead.
+            from pydantic_ai.exceptions import (
+                UnexpectedModelBehavior,
+                UserError,
+            )
+
+            _exc_msg = str(exc).lower()
+            if isinstance(exc, (UserError, UnexpectedModelBehavior)) and (
+                "processed history must end with" in _exc_msg
+                or "exceeded max retries" in _exc_msg
+                or "max retries count" in _exc_msg
+                or "exceeded maximum retries" in _exc_msg
+            ):
+                from seeknal.ask.processors import ensure_trailing_model_request
+
+                repaired = ensure_trailing_model_request(message_history)
+                message_history.clear()
+                message_history.extend(repaired)
+                try:
+                    fallback = await _stream_evidence_synthesis(
+                        agent,
+                        deps,
+                        message_history,
+                        "a recoverable harness error interrupted the run; "
+                        "answering from the evidence gathered so far",
+                        console,
+                    )
+                except Exception:
+                    from seeknal.ask.agents.agent import _NO_RESPONSE
+
+                    _show_answer(console, _NO_RESPONSE)
+                    fallback = _NO_RESPONSE
+                record_prior_turn_answer(question=question, answer=fallback)
+                return fallback
             raise
         # Update message history in place
         message_history.clear()

--- a/src/seeknal/ask/testing.py
+++ b/src/seeknal/ask/testing.py
@@ -338,7 +338,12 @@ def run_agent_answer(
     """Run the real Ask agent once in a headless environment."""
     from seeknal.ask.agents.agent import ask as agent_ask
     from seeknal.ask.agents.agent import create_agent
-    from seeknal.ask.agents.tools._context import get_tool_context, set_tool_context
+    from seeknal.ask.agents.tools._context import (
+        get_tool_context,
+        reset_report_approval,
+        reset_turn_governor,
+        set_tool_context,
+    )
 
     try:
         previous_context = get_tool_context()
@@ -352,6 +357,13 @@ def run_agent_answer(
             model=model,
             environment="gateway",
         )
+        # Seed the per-turn governor exactly as the live chat/gateway paths do
+        # (stream_ask in streaming.py, _generate in gateway/server.py). create_agent has already
+        # installed the ToolContext. Without this, ctx.current_question stays None
+        # and the grounding / anti-fabrication guards silently disable, letting the
+        # agent fabricate answers in test mode that it would never produce live.
+        reset_report_approval()
+        reset_turn_governor(prompt)
         return agent_ask(agent, deps, message_history, prompt)
     finally:
         if previous_context is not None:

--- a/src/seeknal/cli/main.py
+++ b/src/seeknal/cli/main.py
@@ -283,6 +283,22 @@ app.add_typer(intervals_app, name="intervals")
 
 
 # =============================================================================
+# Heartbeat daemon (HEARTBEAT.md polling + smart inbox + DAG/exposure)
+# =============================================================================
+from seeknal.cli.heartbeat import app as heartbeat_app  # noqa: E402
+
+app.add_typer(heartbeat_app, name="heartbeat")
+
+
+# =============================================================================
+# Admin (Ask access policy + admin approval queue)
+# =============================================================================
+from seeknal.cli.admin import app as admin_app  # noqa: E402
+
+app.add_typer(admin_app, name="admin")
+
+
+# =============================================================================
 # Atlas Integration (Optional)
 # =============================================================================
 # The Atlas command group is loaded dynamically if atlas-data-platform is installed.
@@ -1409,6 +1425,7 @@ def init(
             "context/sql_pairs",
             "context/tests",
             "target/intermediate",
+            "inbox",
         ]
 
         for dir_name in directories:
@@ -1486,6 +1503,35 @@ __pycache__/
 """
         (project_path / ".gitignore").write_text(gitignore_content)
         typer.echo(f"  Created: .gitignore")
+
+        # Scaffold HEARTBEAT.md (heartbeat daemon config). The format is one
+        # YAML block per the daemon's parser. The daemon is enabled by default
+        # so `seeknal heartbeat tick` works out of the box; set
+        # `enabled: false` to silence `seeknal heartbeat start`.
+        heartbeat_md_content = """\
+# HEARTBEAT.md — seeknal heartbeat daemon config
+#
+# Polling daemon that scans inbox folders, classifies new files, ingests
+# them into a target table, runs the DAG, and triggers exposures.
+#
+# Run one tick:        seeknal heartbeat tick
+# Run as a daemon:     seeknal heartbeat start
+# Recent runs:         seeknal heartbeat status
+
+```yaml
+interval: 60s            # 0s disables `start`; `tick` still works.
+inbox_folders:
+  - inbox
+ingested_target: null    # null → use profiles.yml source_defaults['ingested']['target']
+enabled: true
+quarantine_dir: target/heartbeat/quarantine
+classifier:
+  enabled: false         # Phase A.5 smart classifier — opt-in.
+  confidence_threshold: 0.8
+```
+"""
+        (project_path / "HEARTBEAT.md").write_text(heartbeat_md_content)
+        typer.echo(f"  Created: HEARTBEAT.md")
 
         # Generate default ask skills (SKILL.md files, Claude Code-style)
         _scaffold_ask_skills(project_path)

--- a/src/seeknal/cli/main.py
+++ b/src/seeknal/cli/main.py
@@ -943,7 +943,11 @@ discovery_cache_ttl_seconds: 300
 # limits, hook behavior, planning, or delegation need project-specific policy.
 agent_harness:
   auto_summarization:
-    enabled: true
+    # Off by default: history compaction can break the pydantic-ai
+    # "history must end with a ModelRequest" invariant and crash chat turns.
+    # Safe to enable for long/low-cost sessions (a trailing-request guard
+    # protects it), but opt in deliberately.
+    enabled: false
     context_manager: auto
     context_manager_max_tokens:
     eviction_token_limit: 20000

--- a/src/seeknal/cli/repl.py
+++ b/src/seeknal/cli/repl.py
@@ -202,6 +202,13 @@ class REPL:
         except Exception as e:
             warnings.warn(f"REPL: Failed to register ask-ingested tables: {e}")
 
+        # Phase 4 (final): clean prefix-stripped aliases for queryable nodes. Runs
+        # last so it sees every real relation and never shadows one.
+        try:
+            self._register_clean_aliases()
+        except Exception as e:
+            warnings.warn(f"REPL: Failed to register clean-name aliases: {e}")
+
     def _register_parquets(self) -> None:
         """Phase 1: Register intermediate parquets as DuckDB views.
 
@@ -248,6 +255,11 @@ class REPL:
         becomes view ``transform_orders_cleaned``). The kind prefix is kept so that
         nodes of different types with the same name don't collide.
 
+        Clean prefix-stripped aliases (so the friendly node name the Ask agent is
+        shown is directly queryable) are NOT created here — they are added by
+        _register_clean_aliases() as a final, catalog-aware pass so an alias can
+        never shadow a real relation registered by another phase.
+
         Args:
             directory: Directory to scan for .parquet files.
             registered_names: Already-registered view names (skipped, updated in place).
@@ -290,6 +302,42 @@ class REPL:
                 self._registered_parquets += 1
             except Exception:
                 pass
+
+    def _register_clean_aliases(self) -> None:
+        """Final pass: expose clean, prefix-stripped aliases for project nodes.
+
+        Intermediate parquets register as ``{kind}_{name}`` views (e.g.
+        ``transform_channel_profitability``), but the Ask manifest / list_tables
+        surface the bare node name (``channel_profitability``). Register a bare
+        alias for each prefixed node — but ONLY when that bare name is not already
+        a real relation in the catalog, so an alias never shadows a source/cache
+        view, a consolidated ``entity_`` view, an ``ingest_`` view, or any other
+        registered relation. Runs after every other registration phase so the full
+        catalog is visible. Collisions between two prefixed nodes sharing a base
+        name resolve deterministically (sorted: ``source_`` < ``transform_``).
+        """
+        kind_prefixes = ("transform_", "source_", "model_")
+        try:
+            rows = self.conn.execute(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = 'main'"
+            ).fetchall()
+        except Exception:
+            return
+        existing = {row[0] for row in rows}
+        for view_name in sorted(existing):
+            for prefix in kind_prefixes:
+                if view_name.startswith(prefix):
+                    alias = view_name[len(prefix):]
+                    if alias and alias not in existing:
+                        try:
+                            self.conn.execute(
+                                f'CREATE VIEW "{alias}" AS SELECT * FROM "{view_name}"'
+                            )
+                            existing.add(alias)
+                        except Exception:
+                            pass  # best-effort; the prefixed name still works
+                    break
 
     def _register_consolidated_entities(self) -> None:
         """Phase 1b: Register consolidated entity parquets as DuckDB views.

--- a/src/seeknal/dag/manifest.py
+++ b/src/seeknal/dag/manifest.py
@@ -163,23 +163,24 @@ class Manifest:
         return self.nodes.get(node_id)
 
     def _invalidate_node_cache(self, node_id: str) -> None:
-        """Invalidate cache for nodes affected by a change to node_id.
+        """Invalidate the adjacency caches after a graph mutation.
 
-        Clears caches for the node and all its upstream and downstream neighbors,
-        providing more efficient cache management than clearing all caches.
+        Both caches are rebuilt lazily and atomically — :meth:`_build_adjacency_lists`
+        recomputes every node in one pass. Partial per-node invalidation is
+        unsafe here: popping only the mutated node's key leaves stale entries
+        for transitively-affected nodes, and the lazy rebuild in
+        ``get_upstream_nodes`` / ``get_downstream_nodes`` only fires when the
+        cache dict is *completely* empty. A popped key would then fall through
+        to the ``.get(node_id, set())`` default and silently report no
+        neighbors. Clearing both caches entirely guarantees the next query
+        does a full, correct rebuild.
 
         Args:
-            node_id: The ID of the node that changed.
+            node_id: The ID of the node that changed (unused; kept for a
+                stable call signature).
         """
-        # Collect all affected nodes: the node itself and all its neighbors
-        affected_nodes = {node_id}
-        affected_nodes.update(self.get_upstream_nodes(node_id))
-        affected_nodes.update(self.get_downstream_nodes(node_id))
-
-        # Clear caches only for affected nodes
-        for node in affected_nodes:
-            self._upstream_cache.pop(node, None)
-            self._downstream_cache.pop(node, None)
+        self._upstream_cache = {}
+        self._downstream_cache = {}
 
     def _build_adjacency_lists(self) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
         """Build upstream and downstream adjacency lists."""

--- a/src/seeknal/heartbeat/runner.py
+++ b/src/seeknal/heartbeat/runner.py
@@ -1,0 +1,456 @@
+"""HeartbeatRunner — the polling loop.
+
+Phases per tick:
+    A   Scan    — discover new/changed files in inbox folders.
+    A.5 Classify (opt-in v0.5) — route each file to a target table.
+    B   Ingest  — write each file via :class:`IngestWriter`; quarantine bad ones.
+    C   DAG     — invoke ``DAGRunner.run()`` if anything new ingested.
+    D   Exposure — call ``ExposureExecutor.run()`` for each exposure node.
+    E   Record  — append a ``HeartbeatRun`` to ``runs.jsonl`` + sidecar.
+
+The loop never exits on data errors; each phase is wrapped in best-effort
+try/except. Overlapping ticks (same process or another process) are detected
+via ``asyncio.Lock`` + ``fcntl.flock`` and recorded as ``status=skipped``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import fcntl
+import logging
+import os
+import signal
+import time
+import traceback
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Optional
+
+from seeknal.heartbeat.config import HeartbeatConfig
+from seeknal.heartbeat.inbox_state import InboxState
+from seeknal.heartbeat.ingest import IngestWriter, quarantine_file
+from seeknal.heartbeat.recorder import (
+    DagResult,
+    ExposureResult,
+    HeartbeatRun,
+    IngestResult,
+    RunRecorder,
+    make_run,
+    _utcnow_iso,
+)
+
+logger = logging.getLogger("seeknal.heartbeat.runner")
+
+
+def _try_load_dotenv() -> None:
+    """Best-effort .env loader for non-CLI heartbeat startup. No-op if missing."""
+    try:
+        from dotenv import load_dotenv  # type: ignore
+
+        load_dotenv(usecwd=True)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+class HeartbeatRunner:
+    """Drives heartbeat ticks. Owns lifecycle but delegates work."""
+
+    def __init__(
+        self,
+        config: HeartbeatConfig,
+        project_root: Path,
+        *,
+        profile_loader: Optional[Any] = None,
+    ):
+        _try_load_dotenv()
+        self._config = config
+        self._project_root = Path(project_root).expanduser().resolve()
+        self._profile_loader = profile_loader
+
+        target_dir = self._project_root / "target" / "heartbeat"
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        self._inbox_state = InboxState.load(target_dir / "inbox_state.json")
+        self._recorder = RunRecorder(target_dir)
+        self._lock_path = target_dir / ".lock"
+        self._asyncio_lock = asyncio.Lock()
+        self._shutdown_event = asyncio.Event()
+
+        iceberg_uri = None
+        iceberg_warehouse = None
+        if config.ingested_target == "iceberg" and profile_loader is not None:
+            try:
+                defaults = profile_loader.load_source_defaults("iceberg") or {}
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Failed to load iceberg source_defaults: %s", exc
+                )
+                defaults = {}
+            iceberg_uri = defaults.get("catalog_uri")
+            iceberg_warehouse = defaults.get("warehouse")
+
+        try:
+            self._ingest_writer = IngestWriter(
+                self._project_root,
+                target=config.ingested_target or "parquet",
+                iceberg_catalog_uri=iceberg_uri,
+                iceberg_warehouse=iceberg_warehouse,
+            )
+        except ValueError as exc:
+            logger.warning(
+                "Iceberg target unavailable (%s); falling back to parquet.", exc
+            )
+            self._ingest_writer = IngestWriter(self._project_root, target="parquet")
+
+    @property
+    def config(self) -> HeartbeatConfig:
+        return self._config
+
+    @property
+    def project_root(self) -> Path:
+        return self._project_root
+
+    @property
+    def recorder(self) -> RunRecorder:
+        return self._recorder
+
+    @property
+    def inbox_state(self) -> InboxState:
+        return self._inbox_state
+
+    @property
+    def ingest_writer(self) -> IngestWriter:
+        return self._ingest_writer
+
+    def request_shutdown(self) -> None:
+        self._shutdown_event.set()
+
+    @contextmanager
+    def _fcntl_lock(self):
+        """Acquire a non-blocking flock; raise BlockingIOError if held."""
+        self._lock_path.parent.mkdir(parents=True, exist_ok=True)
+        fh = open(self._lock_path, "w")
+        try:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            yield
+        finally:
+            try:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+            except Exception:
+                pass
+            fh.close()
+
+    def _resolve_inbox_folders(self) -> list[Path]:
+        out: list[Path] = []
+        for folder in self._config.inbox_folders:
+            folder_path = (
+                folder if folder.is_absolute() else self._project_root / folder
+            )
+            out.append(folder_path)
+        return out
+
+    async def tick_once(self, reason: str = "manual") -> HeartbeatRun:
+        """Execute a single tick. Always returns a HeartbeatRun (never raises)."""
+        run_id = uuid.uuid4().hex
+        started_at = _utcnow_iso()
+        t0 = time.perf_counter()
+
+        # In-process single-flight (AC6).
+        if self._asyncio_lock.locked():
+            return self._record_skipped(
+                run_id, started_at, reason="tick-in-flight"
+            )
+
+        async with self._asyncio_lock:
+            try:
+                with self._fcntl_lock():
+                    return await self._tick_locked(run_id, started_at, t0, reason)
+            except BlockingIOError:
+                return self._record_skipped(
+                    run_id, started_at, reason="tick-in-flight"
+                )
+
+    async def _tick_locked(
+        self,
+        run_id: str,
+        started_at: str,
+        t0: float,
+        reason: str,
+    ) -> HeartbeatRun:
+        errors: list[str] = []
+        ingested: list[IngestResult] = []
+
+        # Phase A — Scan
+        folders = self._resolve_inbox_folders()
+        try:
+            new_paths = self._inbox_state.scan(folders)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"scan failed: {exc}")
+            logger.warning("Scan failed: %s", exc)
+            new_paths = []
+
+        # Phase B — Ingest
+        for path in new_paths:
+            try:
+                result = self._ingest_writer.write(path)
+                ingested.append(result)
+                if result.status == "ok":
+                    self._inbox_state.mark_ingested(
+                        path, target_table=result.table, status="ok"
+                    )
+                elif result.status == "quarantined":
+                    try:
+                        moved = quarantine_file(path, self._project_root / self._config.quarantine_dir)
+                        result.file = str(moved)
+                    except Exception as exc:  # noqa: BLE001
+                        errors.append(f"quarantine move failed: {exc}")
+                    self._inbox_state.mark_quarantined(
+                        path,
+                        reason=result.error or "quarantined",
+                        target_table=result.table,
+                    )
+                else:
+                    self._inbox_state.mark_failed(path, target_table=result.table)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"ingest exception for {path}: {exc}")
+                logger.exception("Unexpected ingest exception for %s", path)
+                ingested.append(
+                    IngestResult(
+                        file=str(path),
+                        table="",
+                        target=self._ingest_writer.target,  # type: ignore[arg-type]
+                        status="failed",
+                        error=str(exc),
+                    )
+                )
+        try:
+            self._inbox_state.save()
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"inbox_state.save failed: {exc}")
+
+        # AC5 idempotency gate
+        has_new_ok = any(r.status == "ok" for r in ingested)
+        run_phases = has_new_ok or reason != "interval"
+
+        dag_result = DagResult()
+        exposure_results: list[ExposureResult] = []
+
+        if run_phases:
+            dag_result = self._run_dag(errors)
+            exposure_results = self._run_exposures(errors)
+
+        finished_at = _utcnow_iso()
+        duration_ms = int((time.perf_counter() - t0) * 1000)
+
+        run = make_run(
+            run_id=run_id,
+            started_at=started_at,
+            finished_at=finished_at,
+            duration_ms=duration_ms,
+            ingested=ingested,
+            dag=dag_result,
+            exposure=exposure_results,
+            errors=errors,
+            reason=reason if not has_new_ok and reason == "interval" else None,
+        )
+        try:
+            self._recorder.append(run)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("RunRecorder append failed: %s", exc)
+        # Proactive Telegram notification — env-var gated, best-effort.
+        # Never imports python-telegram-bot or seeknal.ask.gateway code
+        # (Principle 5 / lint contract); uses stdlib urllib to POST to
+        # api.telegram.org directly.
+        try:
+            from seeknal.heartbeat.tick_notifier import notify_tick
+
+            notify_tick(run, project_name=self._config.project_name)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("tick notification failed: %s", exc)
+        return run
+
+    def _run_dag(self, errors: list[str]) -> DagResult:
+        try:
+            from seeknal.workflow.dag import DAGBuilder
+            from seeknal.workflow.runner import DAGRunner
+            from seeknal.workflow.executors.base import ExecutionContext
+            from seeknal.workflow.manifest_builder import build_manifest_from_dag
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"DAG imports failed: {exc}")
+            return DagResult()
+
+        try:
+            dag_builder = DAGBuilder(
+                project_path=self._project_root,
+                profile_path=self._config.profile_path,
+            )
+            dag_builder.build()
+            manifest = build_manifest_from_dag(
+                dag_builder, self._config.project_name
+            )
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"DAG build failed: {exc}\n{traceback.format_exc()}")
+            return DagResult()
+
+        try:
+            exec_context = ExecutionContext(
+                project_name=self._config.project_name,
+                workspace_path=self._project_root,
+                target_path=self._project_root / "target",
+                profile_path=self._config.profile_path,
+                env_name=os.getenv("SEEKNAL_ENV"),
+            )
+            runner = DAGRunner(
+                manifest=manifest,
+                target_path=self._project_root / "target",
+                exec_context=exec_context,
+            )
+            summary = runner.run()
+            return DagResult(
+                nodes_attempted=summary.total_nodes,
+                nodes_skipped=summary.skipped_nodes,
+                nodes_failed=summary.failed_nodes,
+                fingerprints=dict(summary.fingerprints),
+                per_node=[
+                    {
+                        "node_id": nr.node_id,
+                        "status": nr.status.value,
+                        "duration": nr.duration,
+                        "row_count": nr.row_count,
+                    }
+                    for nr in summary.results
+                ],
+            )
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"DAG run failed: {exc}")
+            logger.exception("DAGRunner.run failed")
+            return DagResult(nodes_failed=1)
+
+    def _run_exposures(self, errors: list[str]) -> list[ExposureResult]:
+        results: list[ExposureResult] = []
+        try:
+            from seeknal.workflow.dag import DAGBuilder
+            from seeknal.workflow.executors.base import (
+                ExecutionContext,
+                ExecutionStatus,
+            )
+            from seeknal.workflow.executors.exposure_executor import (
+                ExposureExecutor,
+            )
+            from seeknal.workflow.manifest_builder import build_manifest_from_dag
+            from seeknal.dag.manifest import NodeType
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"Exposure imports failed: {exc}")
+            return results
+
+        try:
+            dag_builder = DAGBuilder(
+                project_path=self._project_root,
+                profile_path=self._config.profile_path,
+            )
+            dag_builder.build()
+            manifest = build_manifest_from_dag(
+                dag_builder, self._config.project_name
+            )
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"Exposure manifest build failed: {exc}")
+            return results
+
+        exec_context = ExecutionContext(
+            project_name=self._config.project_name,
+            workspace_path=self._project_root,
+            target_path=self._project_root / "target",
+            profile_path=self._config.profile_path,
+            env_name=os.getenv("SEEKNAL_ENV"),
+        )
+
+        exposures = [
+            n for n in manifest.nodes.values() if n.node_type == NodeType.EXPOSURE
+        ]
+        for node in exposures:
+            try:
+                executor = ExposureExecutor(node, exec_context)
+                exec_result = executor.run()
+                status = (
+                    "ok"
+                    if exec_result.status == ExecutionStatus.SUCCESS
+                    else "failed"
+                )
+                target = str(node.config.get("target", "?")) if node.config else "?"
+                results.append(
+                    ExposureResult(
+                        node=node.id,
+                        target=target,
+                        status=status,  # type: ignore[arg-type]
+                        error=exec_result.error_message,
+                    )
+                )
+                if status == "failed":
+                    errors.append(
+                        f"Exposure {node.id} failed: {exec_result.error_message}"
+                    )
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"Exposure node {node.id} crashed: {exc}")
+                results.append(
+                    ExposureResult(
+                        node=node.id,
+                        target="?",
+                        status="failed",
+                        error=str(exc),
+                    )
+                )
+        return results
+
+    def _record_skipped(
+        self, run_id: str, started_at: str, *, reason: str
+    ) -> HeartbeatRun:
+        finished_at = _utcnow_iso()
+        run = make_run(
+            run_id=run_id,
+            started_at=started_at,
+            finished_at=finished_at,
+            duration_ms=0,
+            ingested=[],
+            dag=DagResult(),
+            exposure=[],
+            errors=[],
+            reason=reason,
+            status="skipped",
+        )
+        try:
+            self._recorder.append(run)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("RunRecorder append failed: %s", exc)
+        return run
+
+    async def run_forever(self) -> None:
+        """Loop until shutdown_event. Handles SIGTERM/SIGINT gracefully."""
+        if not self._config.enabled or self._config.interval_seconds <= 0:
+            logger.info(
+                "Heartbeat disabled (enabled=%s, interval=%ss); exiting.",
+                self._config.enabled,
+                self._config.interval_seconds,
+            )
+            return
+
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            try:
+                loop.add_signal_handler(sig, self._shutdown_event.set)
+            except (NotImplementedError, ValueError):  # Windows / non-main thread
+                pass
+
+        while not self._shutdown_event.is_set():
+            try:
+                await self.tick_once(reason="interval")
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("Unexpected tick crash: %s", exc)
+            try:
+                await asyncio.wait_for(
+                    self._shutdown_event.wait(),
+                    timeout=self._config.interval_seconds,
+                )
+                break
+            except asyncio.TimeoutError:
+                continue

--- a/src/seeknal/heartbeat/runner.py
+++ b/src/seeknal/heartbeat/runner.py
@@ -307,11 +307,20 @@ class HeartbeatRunner:
                 exec_context=exec_context,
             )
             summary = runner.run()
+            # ExecutionSummary has no `fingerprints`; the DAGRunner stores the
+            # per-node fingerprints it computed this run on `_current_fingerprints`
+            # as fingerprint objects. DagResult wants dict[str, str], so map each
+            # to its `.combined` hash.
+            raw_fingerprints = getattr(runner, "_current_fingerprints", {}) or {}
+            fingerprints = {
+                nid: getattr(fp, "combined", str(fp))
+                for nid, fp in raw_fingerprints.items()
+            }
             return DagResult(
                 nodes_attempted=summary.total_nodes,
                 nodes_skipped=summary.skipped_nodes,
                 nodes_failed=summary.failed_nodes,
-                fingerprints=dict(summary.fingerprints),
+                fingerprints=fingerprints,
                 per_node=[
                     {
                         "node_id": nr.node_id,

--- a/src/seeknal/heartbeat/tick_notifier.py
+++ b/src/seeknal/heartbeat/tick_notifier.py
@@ -1,0 +1,193 @@
+"""Proactive Telegram notifier for heartbeat tick summaries.
+
+Sends a single short message to a configured Telegram chat after every
+heartbeat tick so operators see ingest/DAG/exposure activity without
+polling ``runs.jsonl``. Best-effort: any failure is logged at WARNING
+and swallowed — a Telegram outage must never crash the heartbeat daemon
+(Principle 4: best-effort over fail-stop).
+
+The module uses ``urllib.request`` from stdlib to call Telegram's HTTP
+Bot API directly. It does NOT import the ``python-telegram-bot``
+library and does NOT import any code under ``seeknal.ask.gateway`` —
+this keeps the heartbeat daemon's deterministic core insulated from
+the agent surface (Principle 5: file boundary) and satisfies the lint
+contract in ``tests/heartbeat/test_telegram_bridge.py::
+test_no_telegram_imports_in_heartbeat``.
+
+Configuration (environment variables, read at notification time):
+
+- ``TELEGRAM_BOT_TOKEN``: the bot's API token. Required; absent → no-op.
+- ``HEARTBEAT_TELEGRAM_CHAT_ID``: the target chat. Required; absent → no-op.
+- ``HEARTBEAT_TELEGRAM_NOTIFY``: optional toggle. ``"0"`` / ``"false"``
+  / ``"off"`` disables notifications even when token and chat are set.
+  Any other value (or unset) enables them when both required vars exist.
+
+The notifier is intentionally configured via env vars rather than
+``HEARTBEAT.md`` because the chat id is operator-specific (one chat
+per deployment) while the rest of HEARTBEAT.md describes project-level
+behavior shared across deployments.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Hard cap on message length. Telegram's documented limit is 4096
+# characters for plain text; staying well under that leaves room for
+# any HTML escaping. Truncated messages get a "(truncated)" suffix.
+_MAX_TEXT_LEN = 3500
+
+# Hard timeout on the Telegram POST. We never want to block a tick on
+# an unresponsive network — observability is a nice-to-have, not a
+# blocker for the deterministic core.
+_TIMEOUT_SECONDS = 8.0
+
+
+def _disabled_via_env() -> bool:
+    """Return True when ``HEARTBEAT_TELEGRAM_NOTIFY`` explicitly disables."""
+    raw = os.environ.get("HEARTBEAT_TELEGRAM_NOTIFY")
+    if raw is None:
+        return False
+    return raw.strip().lower() in {"0", "false", "off", "no", "disabled"}
+
+
+def _resolve_credentials() -> tuple[str | None, str | None]:
+    """Return ``(token, chat_id)`` from env, or ``(None, None)`` if absent."""
+    token = os.environ.get("TELEGRAM_BOT_TOKEN", "").strip()
+    chat_id = os.environ.get("HEARTBEAT_TELEGRAM_CHAT_ID", "").strip()
+    if not token or not chat_id:
+        return None, None
+    return token, chat_id
+
+
+def format_tick_message(run: Any, project_name: str | None = None) -> str:
+    """Render a HeartbeatRun into a compact human-readable Telegram message.
+
+    Defensive against partial run records — every field is read via
+    ``getattr`` so a future schema addition (e.g. classifier entries)
+    does not crash the notifier on older records.
+    """
+    status = getattr(run, "status", "unknown")
+    duration_ms = getattr(run, "duration_ms", 0)
+    ingested = getattr(run, "ingested", []) or []
+    dag = getattr(run, "dag", None)
+    exposures = getattr(run, "exposure", []) or []
+    errors = getattr(run, "errors", []) or []
+    run_id = getattr(run, "run_id", "")[:12]  # short for readability
+
+    icon = {"ok": "🫀", "partial": "⚠️", "skipped": "⏸"}.get(status, "❔")
+    header_proj = f" — {project_name}" if project_name else ""
+    lines = [f"{icon} Heartbeat{header_proj} ({status})"]
+    lines.append(f"run: {run_id}  ·  {duration_ms}ms")
+
+    if ingested:
+        ok = [i for i in ingested if getattr(i, "status", "") == "ok"]
+        bad = [i for i in ingested if getattr(i, "status", "") != "ok"]
+        if ok:
+            for it in ok[:3]:
+                table = getattr(it, "table", "?")
+                rows = getattr(it, "rows", 0)
+                lines.append(f"+ {table} ({rows} rows)")
+            if len(ok) > 3:
+                lines.append(f"  ... +{len(ok) - 3} more ingested")
+        if bad:
+            for it in bad[:3]:
+                fname = getattr(it, "file", "?")
+                reason = getattr(it, "reason", None) or getattr(it, "error", "?")
+                # Keep just basename so the line stays short.
+                fname_short = fname.rsplit("/", 1)[-1] if "/" in fname else fname
+                lines.append(f"! quarantined: {fname_short} ({reason})")
+    else:
+        lines.append("- no new files")
+
+    if dag is not None:
+        nodes_attempted = getattr(dag, "nodes_attempted", 0)
+        nodes_failed = getattr(dag, "nodes_failed", 0)
+        if nodes_failed:
+            lines.append(f"DAG: {nodes_failed} failed / {nodes_attempted} attempted")
+        elif nodes_attempted:
+            lines.append(f"DAG: {nodes_attempted} ok")
+
+    if exposures:
+        ok_exp = sum(1 for e in exposures if getattr(e, "status", "") == "ok")
+        fail_exp = len(exposures) - ok_exp
+        if fail_exp:
+            lines.append(f"exposure: {ok_exp} ok, {fail_exp} failed")
+        elif ok_exp:
+            lines.append(f"exposure: {ok_exp} ok")
+
+    if errors:
+        # Cap the error block so a noisy traceback doesn't blow the message budget.
+        for err in errors[:2]:
+            err_short = str(err)
+            if len(err_short) > 200:
+                err_short = err_short[:197] + "..."
+            lines.append(f"! {err_short}")
+        if len(errors) > 2:
+            lines.append(f"  ... +{len(errors) - 2} more errors")
+
+    text = "\n".join(lines)
+    if len(text) > _MAX_TEXT_LEN:
+        text = text[: _MAX_TEXT_LEN - 14] + "\n(truncated)"
+    return text
+
+
+def notify_tick(run: Any, project_name: str | None = None) -> bool:
+    """Best-effort Telegram notification for one heartbeat tick.
+
+    Returns ``True`` when the message was POSTed successfully, ``False``
+    otherwise (including the no-op cases: missing env vars, explicitly
+    disabled, or network/API failure). Never raises.
+
+    The caller (``HeartbeatRunner._tick_locked``) ignores the return
+    value — observability is best-effort by design.
+    """
+    if _disabled_via_env():
+        return False
+
+    token, chat_id = _resolve_credentials()
+    if token is None or chat_id is None:
+        return False
+
+    try:
+        text = format_tick_message(run, project_name=project_name)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[heartbeat] tick message formatting failed: %s", exc)
+        return False
+
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    payload = urllib.parse.urlencode(
+        {"chat_id": chat_id, "text": text, "disable_web_page_preview": "true"}
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=_TIMEOUT_SECONDS) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+            data = json.loads(body) if body else {}
+        if data.get("ok") is True:
+            return True
+        logger.warning(
+            "[heartbeat] Telegram API returned ok=false: %s",
+            data.get("description", body[:200]),
+        )
+        return False
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, json.JSONDecodeError) as exc:
+        logger.warning("[heartbeat] Telegram notification failed: %s", exc)
+        return False
+
+
+__all__ = ["format_tick_message", "notify_tick"]

--- a/src/seeknal/heartbeat/tick_notifier.py
+++ b/src/seeknal/heartbeat/tick_notifier.py
@@ -179,6 +179,9 @@ def notify_tick(run: Any, project_name: str | None = None) -> bool:
             body = resp.read().decode("utf-8", errors="replace")
             data = json.loads(body) if body else {}
         if data.get("ok") is True:
+            logger.info(
+                "[heartbeat] tick notification delivered to chat %s", chat_id
+            )
             return True
         logger.warning(
             "[heartbeat] Telegram API returned ok=false: %s",

--- a/src/seeknal/workflow/executors/transform_executor.py
+++ b/src/seeknal/workflow/executors/transform_executor.py
@@ -225,8 +225,15 @@ class TransformExecutor(BaseExecutor):
                     cache_path = self.context.target_path / "cache" / kind / f"{name}.parquet"
                     if cache_path.exists():
                         try:
+                            # Register schema-qualified ("source"."name") so a
+                            # transform's `FROM source.name` resolves. A quoted
+                            # literal view "source.name" would NOT — DuckDB
+                            # parses the unquoted reference as schema.table.
+                            # This also matches the existence check above
+                            # (`SELECT 1 FROM {ref}`), which is schema-qualified.
+                            conn.execute(f'CREATE SCHEMA IF NOT EXISTS "{kind}"')
                             conn.execute(
-                                f"CREATE OR REPLACE VIEW \"{ref}\" AS "
+                                f'CREATE OR REPLACE VIEW "{kind}"."{name}" AS '
                                 f"SELECT * FROM read_parquet('{cache_path}')"
                             )
                             logger.info(f"Loaded cached view: {ref} from {cache_path}")

--- a/tests/ask/test_config.py
+++ b/tests/ask/test_config.py
@@ -167,7 +167,10 @@ def test_performance_defaults_and_overrides():
 
 def test_agent_harness_defaults_preserve_current_ask_behavior():
     auto = get_auto_summarization_config({})
-    assert auto["enabled"] is True
+    # auto_summarization now defaults OFF: its history compaction could leave the
+    # message history ending in a ModelResponse and crash pydantic-ai's
+    # "history must end with a ModelRequest" invariant. Opt-in only.
+    assert auto["enabled"] is False
     assert auto["context_manager"] == "auto"
     assert auto["eviction_token_limit"] == 20000
     assert auto["patch_tool_calls"] is True

--- a/tests/ask/test_harness_robustness.py
+++ b/tests/ask/test_harness_robustness.py
@@ -1,0 +1,144 @@
+"""Regression tests for the F1 + F3 Ask harness robustness fixes.
+
+Covers:
+- F1a: ensure_trailing_model_request guards pydantic-ai's "history must end with a
+       ModelRequest" invariant (the auto_summarization crash).
+- F1c: the Ask FunctionToolset gets a real retry budget (max_retries >= 3).
+- F1d: auto_summarization defaults OFF, but explicit settings are honored.
+- F3 : testing.run_agent_answer seeds the per-turn governor so grounding /
+       anti-fabrication guards are active in test mode (the vip_churn hallucination).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    UserPromptPart,
+)
+
+from seeknal.ask.processors import ensure_trailing_model_request
+
+
+def _req(text: str = "q") -> ModelRequest:
+    return ModelRequest(parts=[UserPromptPart(content=text)])
+
+
+def _resp(text: str = "a") -> ModelResponse:
+    return ModelResponse(parts=[TextPart(content=text)])
+
+
+# --- F1a -------------------------------------------------------------------
+
+def test_guard_trims_trailing_model_response():
+    req, resp = _req(), _resp()
+    assert ensure_trailing_model_request([req, resp]) == [req]
+
+
+def test_guard_trims_multiple_trailing_responses():
+    req, r1, r2 = _req(), _resp("1"), _resp("2")
+    assert ensure_trailing_model_request([req, r1, r2]) == [req]
+
+
+def test_guard_noop_on_well_formed_history():
+    msgs = [_req("a"), _resp("b"), _req("c")]
+    assert ensure_trailing_model_request(msgs) == msgs
+
+
+def test_guard_handles_empty():
+    assert ensure_trailing_model_request([]) == []
+
+
+def test_guard_never_returns_empty():
+    # All-response history must not be emptied (would break the run differently).
+    only_resp = [_resp()]
+    assert ensure_trailing_model_request(only_resp) == only_resp
+
+
+def test_guard_registered_last_in_history_processors():
+    # The guard must run AFTER the compaction processors / summarizer.
+    import inspect
+
+    import seeknal.ask.agents.agent as agent_mod
+
+    src = inspect.getsource(agent_mod.create_agent)
+    assert "history_processors.append(ensure_trailing_model_request)" in src
+    # ...and after the SqlResultCompactor append (so it is the last processor).
+    assert src.index("SqlResultCompactor(") < src.index(
+        "history_processors.append(ensure_trailing_model_request)"
+    )
+
+
+# --- F1c -------------------------------------------------------------------
+
+def test_ask_toolset_has_retry_budget():
+    from seeknal.ask.agents.tools.toolset import create_ask_toolset
+
+    for mode in ("full", "analysis"):
+        ts = create_ask_toolset(mode=mode)
+        assert ts.max_retries is not None and ts.max_retries >= 3, mode
+
+
+# --- F1d -------------------------------------------------------------------
+
+def test_auto_summarization_defaults_off_when_omitted():
+    from seeknal.ask.config import get_auto_summarization_config
+
+    assert get_auto_summarization_config({})["enabled"] is False
+
+
+def test_auto_summarization_explicit_settings_honored():
+    from seeknal.ask.config import get_auto_summarization_config
+
+    on = {"agent_harness": {"auto_summarization": {"enabled": True}}}
+    off = {"agent_harness": {"auto_summarization": {"enabled": False}}}
+    assert get_auto_summarization_config(on)["enabled"] is True
+    assert get_auto_summarization_config(off)["enabled"] is False
+
+
+def test_init_template_defaults_auto_summarization_off():
+    # The generated seeknal_agent.yml must not ship the crash-prone default ON.
+    import inspect
+
+    import seeknal.cli.main as main_mod
+
+    src = inspect.getsource(main_mod)
+    block = src[src.index("auto_summarization:"):src.index("context_manager: auto")]
+    assert "enabled: false" in block
+    assert "enabled: true" not in block
+
+
+# --- F3 --------------------------------------------------------------------
+
+def test_run_agent_answer_seeds_turn_governor(monkeypatch):
+    import seeknal.ask.agents.agent as agent_mod
+    import seeknal.ask.agents.tools._context as ctx_mod
+    import seeknal.ask.testing as testing
+
+    calls: dict = {}
+    monkeypatch.setattr(
+        ctx_mod, "reset_turn_governor",
+        lambda q=None: calls.__setitem__("governor_question", q),
+    )
+    monkeypatch.setattr(
+        ctx_mod, "reset_report_approval",
+        lambda: calls.__setitem__("report_reset", True),
+    )
+    # Stub agent construction + the agent call; echo the prompt back so we can
+    # assert the call order didn't drop the prompt.
+    monkeypatch.setattr(
+        agent_mod, "create_agent",
+        lambda *a, **k: ("AGENT", "DEPS", [], None),
+    )
+    monkeypatch.setattr(
+        agent_mod, "ask",
+        lambda agent, deps, history, prompt: f"ANSWER::{prompt}",
+    )
+
+    out = testing.run_agent_answer(Path("/tmp/does-not-matter"), "untung hari ini?")
+
+    assert out == "ANSWER::untung hari ini?"
+    assert calls.get("governor_question") == "untung hari ini?"
+    assert calls.get("report_reset") is True

--- a/tests/ask/test_telegram_channel.py
+++ b/tests/ask/test_telegram_channel.py
@@ -205,3 +205,107 @@ async def test_handle_message_uses_public_session_when_configured(tmp_path):
 
     channel._run_agent.assert_awaited()
     assert channel._run_agent.await_args.args[0] == "public-session"
+
+
+# ---------------------------------------------------------------------------
+# Document upload: suffix categories + ZIP extraction safety
+# ---------------------------------------------------------------------------
+
+
+def test_upload_suffixes_accept_png_pdf_txt_zip():
+    """png/pdf/txt/zip must be accepted document types (not rejected)."""
+    from seeknal.ask.gateway.channels.telegram import (
+        _ARCHIVE_SUFFIXES,
+        _TABULAR_SUFFIXES,
+        _UPLOAD_ALLOWED_SUFFIXES,
+        _VISION_DOC_SUFFIXES,
+    )
+
+    for ext in (".png", ".pdf", ".txt", ".zip"):
+        assert ext in _UPLOAD_ALLOWED_SUFFIXES, f"{ext} should be accepted"
+    # Categories are disjoint — a suffix routes to exactly one path.
+    assert not (_TABULAR_SUFFIXES & _VISION_DOC_SUFFIXES)
+    assert not (_TABULAR_SUFFIXES & _ARCHIVE_SUFFIXES)
+    assert not (_VISION_DOC_SUFFIXES & _ARCHIVE_SUFFIXES)
+    # The union is exactly the allow-list.
+    assert (
+        _TABULAR_SUFFIXES | _VISION_DOC_SUFFIXES | _ARCHIVE_SUFFIXES
+    ) == _UPLOAD_ALLOWED_SUFFIXES
+    # png/pdf/txt route to the vision path; zip is its own category.
+    assert {".png", ".pdf", ".txt"} <= _VISION_DOC_SUFFIXES
+    assert ".zip" in _ARCHIVE_SUFFIXES
+
+
+def test_extract_archive_valid_zip(tmp_path):
+    """A normal ZIP extracts to a subdir and lists its members."""
+    import zipfile
+
+    channel = TelegramChannel(Path(tmp_path), token="token")
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    zip_path = staging / "batch.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("a.csv", "x,y\n1,2\n")
+        zf.writestr("nested/b.txt", "hello")
+
+    extract_dir, members, err = channel._extract_archive(zip_path, staging)
+
+    assert err is None
+    assert extract_dir is not None and extract_dir.is_dir()
+    assert sorted(members) == ["a.csv", "nested/b.txt"]
+    assert (extract_dir / "a.csv").read_text() == "x,y\n1,2\n"
+    assert (extract_dir / "nested" / "b.txt").read_text() == "hello"
+
+
+def test_extract_archive_rejects_zip_slip(tmp_path):
+    """A member with a ../ path that escapes the extract dir aborts extraction."""
+    import zipfile
+
+    channel = TelegramChannel(Path(tmp_path), token="token")
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    zip_path = staging / "evil.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("../../escape.txt", "pwned")
+
+    extract_dir, members, err = channel._extract_archive(zip_path, staging)
+
+    assert extract_dir is None
+    assert members == []
+    assert err is not None and "escape" in err.lower()
+
+
+def test_extract_archive_rejects_too_many_entries(tmp_path):
+    """An archive over the entry-count cap is refused."""
+    import zipfile
+
+    from seeknal.ask.gateway.channels.telegram import _ARCHIVE_MAX_ENTRIES
+
+    channel = TelegramChannel(Path(tmp_path), token="token")
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    zip_path = staging / "bomb.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        for i in range(_ARCHIVE_MAX_ENTRIES + 1):
+            zf.writestr(f"f{i}.csv", "a\n1\n")
+
+    extract_dir, members, err = channel._extract_archive(zip_path, staging)
+
+    assert extract_dir is None
+    assert members == []
+    assert err is not None and str(_ARCHIVE_MAX_ENTRIES) in err
+
+
+def test_extract_archive_rejects_bad_zip(tmp_path):
+    """A non-ZIP file produces a clean error, not a crash."""
+    channel = TelegramChannel(Path(tmp_path), token="token")
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    not_a_zip = staging / "fake.zip"
+    not_a_zip.write_text("this is plainly not a zip archive")
+
+    extract_dir, members, err = channel._extract_archive(not_a_zip, staging)
+
+    assert extract_dir is None
+    assert members == []
+    assert err is not None and "zip" in err.lower()

--- a/tests/ask/test_toolset.py
+++ b/tests/ask/test_toolset.py
@@ -218,12 +218,15 @@ def test_create_agent_includes_ask_user_in_interactive_analysis_mode(tmp_path: P
         assert "Teach mode" in instructions
         assert "save_preference" in instructions
         assert "context/sql_pairs/<slug>.yml" in instructions
+        # auto_summarization defaults OFF, so the compaction processors are not
+        # wired; only the trailing-ModelRequest guard (always registered last) is.
+        from seeknal.ask.processors import ensure_trailing_model_request
+
         assert mock_create.call_args[1]["history_processors"] == [
-            mock_micro.return_value,
-            mock_sql.return_value,
+            ensure_trailing_model_request,
         ]
-        mock_micro.assert_called_once_with(keep_recent_turns=2)
-        mock_sql.assert_called_once_with(min_chars=250)
+        mock_micro.assert_not_called()
+        mock_sql.assert_not_called()
 
 
 def test_create_agent_applies_agent_harness_config(tmp_path: Path):
@@ -234,6 +237,7 @@ def test_create_agent_applies_agent_harness_config(tmp_path: Path):
             """\
             agent_harness:
               auto_summarization:
+                enabled: true
                 context_manager: false
                 context_manager_max_tokens: 128000
                 summarization_model: openai:gpt-4.1-mini
@@ -300,9 +304,14 @@ def test_create_agent_applies_agent_harness_config(tmp_path: Path):
         assert kwargs["cost_budget_usd"] == 2.5
         assert len(kwargs["hooks"]) == 1
         assert kwargs["hooks"][0].event.value == "pre_tool_use"
+        # The trailing-ModelRequest guard is always appended LAST, after the
+        # configured compaction processors.
+        from seeknal.ask.processors import ensure_trailing_model_request
+
         assert kwargs["history_processors"] == [
             mock_micro.return_value,
             mock_sql.return_value,
+            ensure_trailing_model_request,
         ]
         mock_micro.assert_called_once_with(keep_recent_turns=5)
         mock_sql.assert_called_once_with(min_chars=750)

--- a/tests/ask/test_verbatim_restate_gate.py
+++ b/tests/ask/test_verbatim_restate_gate.py
@@ -1,8 +1,9 @@
 """Tests for the verbatim re-ask short-circuit gate.
 
 When the user asks the IDENTICAL question twice in a row, the agent harness
-must short-circuit BEFORE any LLM/tool call and return the prior answer with
-a small bilingual restate notice. See ``.omc/specs/autopilot-verbatim-restate-gate.md``.
+must short-circuit BEFORE any LLM/tool call and return the prior answer
+verbatim — a silent cache, no banner or meta-commentary.
+See ``.omc/specs/autopilot-verbatim-restate-gate.md``.
 """
 from __future__ import annotations
 
@@ -125,18 +126,18 @@ def test_ac8_lookup_returns_none_when_prior_answer_empty(tmp_path: Path):
 
 
 # ---------------------------------------------------------------------------
-# AC-13: bilingual prefix
+# AC-13: restate is a silent passthrough (no banner)
 # ---------------------------------------------------------------------------
 
 
-def test_ac13_restate_response_contains_bilingual_notice():
-    """AC-13: the restate response includes Indonesian + English notice text."""
-    wrapped = build_verbatim_restate_response("Total = 42")
-    assert "Pertanyaan ini sama dengan giliran sebelumnya" in wrapped
-    assert "This question is the same as the prior turn" in wrapped
-    assert "Total = 42" in wrapped
-    assert "Jika Anda ingin data baru" in wrapped
-    assert "If you wanted fresh data" in wrapped
+def test_ac13_restate_response_returns_prior_answer_unchanged():
+    """The restate response is the prior answer verbatim — no banner, no
+    meta-commentary. A verbatim re-ask behaves as a silent cache."""
+    restate = build_verbatim_restate_response("Total = 42")
+    assert restate == "Total = 42"
+    # The old bilingual notice must not reappear.
+    assert "giliran sebelumnya" not in restate
+    assert "the same as the prior turn" not in restate
 
 
 # ---------------------------------------------------------------------------
@@ -199,20 +200,21 @@ def test_seed_empty_history_is_noop(tmp_path: Path):
     assert lookup_prior_turn_answer("anything") is None
 
 
-def test_seed_unwraps_restate_so_triple_ask_does_not_compound(tmp_path: Path):
-    """If the last answer in history is itself a wrapped restate, seeding must
-    store the canonical answer — never a restate-of-a-restate."""
-    ctx = _make_ctx(tmp_path)
+def test_seed_triple_ask_does_not_compound(tmp_path: Path):
+    """A restate returns the prior answer verbatim (no banner), so seeding
+    from a history whose last answer was itself a restate stores the exact
+    same canonical text — a triple-ask can never compound."""
+    _make_ctx(tmp_path)
     canonical = "Total NIE 2024: 50"
-    wrapped = build_verbatim_restate_response(canonical)
-    history = _history_pair("Berapa NIE 2024?", wrapped)
+    # A restate of `canonical` is byte-identical to `canonical`.
+    restated = build_verbatim_restate_response(canonical)
+    assert restated == canonical
+    history = _history_pair("Berapa NIE 2024?", restated)
 
     seed_prior_turn_from_history(history)
 
     stored = lookup_prior_turn_answer("Berapa NIE 2024?")
     assert stored == canonical
-    # The wrapper prefix/suffix must not have survived into the stored pair.
-    assert "sama dengan giliran sebelumnya" not in (stored or "")
 
 
 def test_seed_takes_the_most_recent_turn(tmp_path: Path):
@@ -313,7 +315,8 @@ async def _stream_ask_with_stub_one_pass(
 def test_ac9_verbatim_reask_short_circuits_without_calling_execute_sql(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """AC-9: identical question on turn 2 yields restate prefix, no tool calls."""
+    """AC-9: identical question on turn 2 returns the prior answer verbatim,
+    no tool calls — a silent cache, no banner."""
     ctx = _make_ctx(tmp_path)
     execute_sql = MagicMock()
 
@@ -335,10 +338,11 @@ def test_ac9_verbatim_reask_short_circuits_without_calling_execute_sql(
     assert execute_sql.call_count == 1, (
         "execute_sql must only be called for the FIRST turn"
     )
-    # Turn 1 returns the fresh answer; turn 2 returns the restate.
+    # Turn 1 returns the fresh answer; turn 2 returns the SAME answer
+    # verbatim — silent cache, no banner / meta-commentary.
     assert "42 NIE" in answers[0]
-    assert "Pertanyaan ini sama" in answers[1]
-    assert "A1: 42 NIE" in answers[1]
+    assert answers[1] == answers[0]
+    assert "Pertanyaan ini sama" not in answers[1]
 
 
 def test_ac10_different_questions_both_execute_normally(
@@ -382,12 +386,8 @@ def test_ac11_triple_identical_question_short_circuits_twice(
 
     assert one_pass_calls == 1, "Only the first turn invokes the agent loop"
     assert execute_sql.call_count == 1
-    assert "Pertanyaan ini sama" not in answers[0]
-    assert "Pertanyaan ini sama" in answers[1]
-    assert "Pertanyaan ini sama" in answers[2]
-    # Each restated turn still embeds the original answer.
-    assert "A1" in answers[1]
-    assert "A1" in answers[2]
+    # Every gated turn returns the prior answer verbatim — no banner.
+    assert answers[0] == answers[1] == answers[2] == "A1"
 
 
 def test_ac12_tool_error_payload_does_not_lock_in_bad_answer(
@@ -502,12 +502,11 @@ def test_ac14_streaming_gate_appends_synthesized_history_pair(
         p for p in appended_request.parts if isinstance(p, UserPromptPart)
     ]
     assert user_parts and user_parts[0].content == "Q1?"
-    # The synthesized response carries the bilingual restate text.
+    # The synthesized response carries the prior answer verbatim.
     text_parts = [p for p in appended_response.parts if isinstance(p, TextPart)]
     assert text_parts
     text_content = text_parts[0].content
-    assert "Pertanyaan ini sama" in text_content
-    assert "A1" in text_content
+    assert text_content == "A1"
 
 
 # ---------------------------------------------------------------------------
@@ -568,11 +567,11 @@ def test_ac15_gateway_gate_persists_synthesized_history(
 
     events = asyncio.run(_drive())
 
-    # Sanity — the gate did emit the restate answer event.
+    # Sanity — the gate did emit the restate answer event (prior answer
+    # verbatim, no banner).
     answer_events = [e for e in events if e.get("type") == "answer"]
     assert answer_events
-    assert "Pertanyaan ini sama" in answer_events[0]["data"]
-    assert "A1: 42 NIE" in answer_events[0]["data"]
+    assert answer_events[0]["data"] == "A1: 42 NIE"
 
     # The synthesized pair must be on disk via store.load_messages.
     loaded = store.load_messages(session_id)
@@ -585,23 +584,23 @@ def test_ac15_gateway_gate_persists_synthesized_history(
     ]
     assert user_parts and user_parts[0].content == "Q1?"
     text_parts = [p for p in appended_response.parts if isinstance(p, TextPart)]
-    assert text_parts and "Pertanyaan ini sama" in text_parts[0].content
-    assert "A1: 42 NIE" in text_parts[0].content
+    assert text_parts and text_parts[0].content == "A1: 42 NIE"
 
 
 # ---------------------------------------------------------------------------
-# AC-16: triple-ask does NOT recursively wrap the wrapper
+# AC-16: triple-ask stays canonical — every gated turn returns the same answer
 # ---------------------------------------------------------------------------
 
 
-def test_ac16_triple_ask_stores_unwrapped_prior_answer(
+def test_ac16_triple_ask_stores_canonical_prior_answer(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """AC-16: stored prior answer stays canonical across multiple gated turns.
+    """AC-16: the answer stays canonical across multiple gated turns.
 
-    Turn 1 records "A1". Turns 2 and 3 both short-circuit. The user-facing
-    restate IS the wrapped form, but ``_seeknal_prior_turn_answer`` after
-    turn 3 must still be exactly "A1" — never a wrapper-around-wrapper.
+    Turn 1 records "A1". Turns 2 and 3 both short-circuit. Because a
+    restate returns the prior answer verbatim (no banner), every turn's
+    answer is exactly "A1" and ``_seeknal_prior_turn_answer`` after turn
+    3 is still exactly "A1" — no compounding is even possible.
     """
     ctx = _make_ctx(tmp_path)
 
@@ -617,14 +616,9 @@ def test_ac16_triple_ask_stores_unwrapped_prior_answer(
 
     # Sanity: only the first turn invoked the agent loop.
     assert one_pass_calls == 1
-    # The restate returned to the user IS the wrapped form on turn 3.
-    assert "Pertanyaan ini sama" in answers[2]
-    assert "A1" in answers[2]
-    # But the stored prior answer is the canonical unwrapped value.
+    # Every turn returns the identical canonical answer — no banner.
+    assert answers[0] == answers[1] == answers[2] == "A1"
+    # The stored prior answer is still the canonical value.
     stored = getattr(ctx.repl, "_seeknal_prior_turn_answer", None)
-    assert stored == "A1", (
-        "Stored prior must remain the unwrapped original answer; otherwise a "
-        "triple-ask would recursively wrap the bilingual prefix/suffix."
-    )
-    # And it must NOT contain the bilingual markers — proving no compounding.
+    assert stored == "A1"
     assert "Pertanyaan ini sama" not in stored

--- a/tests/ask/test_verbatim_restate_gate.py
+++ b/tests/ask/test_verbatim_restate_gate.py
@@ -20,6 +20,7 @@ from seeknal.ask.agents.tools._context import (
     lookup_prior_turn_answer,
     record_prior_turn_answer,
     reset_turn_governor,
+    seed_prior_turn_from_history,
     set_tool_context,
 )
 
@@ -150,6 +151,90 @@ def test_reset_turn_governor_preserves_prior_turn_pair(tmp_path: Path):
     reset_turn_governor("Q2")
     assert getattr(ctx.repl, "_seeknal_prior_turn_question") == "q1"
     assert getattr(ctx.repl, "_seeknal_prior_turn_answer") == "A1"
+
+
+# ---------------------------------------------------------------------------
+# seed_prior_turn_from_history — gateway REPL-rebuild fix
+# ---------------------------------------------------------------------------
+# Regression for the gateway bug: create_agent rebuilds the REPL every turn,
+# so record_prior_turn_answer's in-memory pair never survives. The verbatim
+# gate was permanently dormant on gateway/Telegram sessions. seed_prior_turn_
+# from_history rehydrates the pair from the persisted message_history.
+
+
+def _history_pair(question: str, answer: str) -> list:
+    """Build a [ModelRequest, ModelResponse] message_history slice."""
+    from pydantic_ai.messages import (
+        ModelRequest,
+        ModelResponse,
+        TextPart,
+        UserPromptPart,
+    )
+
+    return [
+        ModelRequest(parts=[UserPromptPart(content=question)]),
+        ModelResponse(parts=[TextPart(content=answer)]),
+    ]
+
+
+def test_seed_populates_prior_turn_from_history(tmp_path: Path):
+    """A fresh REPL with no prior pair gets one seeded from message_history."""
+    ctx = _make_ctx(tmp_path)
+    history = _history_pair("Berapa NIE 2024?", "Total NIE 2024: 50")
+
+    # Fresh REPL — nothing recorded yet (simulates the per-turn rebuild).
+    assert lookup_prior_turn_answer("Berapa NIE 2024?") is None
+
+    seed_prior_turn_from_history(history)
+
+    # After seeding, the verbatim gate's lookup now resolves.
+    assert lookup_prior_turn_answer("Berapa NIE 2024?") == "Total NIE 2024: 50"
+
+
+def test_seed_empty_history_is_noop(tmp_path: Path):
+    """No history → nothing seeded, lookup stays None, no crash."""
+    _make_ctx(tmp_path)
+    seed_prior_turn_from_history([])
+    seed_prior_turn_from_history(None)
+    assert lookup_prior_turn_answer("anything") is None
+
+
+def test_seed_unwraps_restate_so_triple_ask_does_not_compound(tmp_path: Path):
+    """If the last answer in history is itself a wrapped restate, seeding must
+    store the canonical answer — never a restate-of-a-restate."""
+    ctx = _make_ctx(tmp_path)
+    canonical = "Total NIE 2024: 50"
+    wrapped = build_verbatim_restate_response(canonical)
+    history = _history_pair("Berapa NIE 2024?", wrapped)
+
+    seed_prior_turn_from_history(history)
+
+    stored = lookup_prior_turn_answer("Berapa NIE 2024?")
+    assert stored == canonical
+    # The wrapper prefix/suffix must not have survived into the stored pair.
+    assert "sama dengan giliran sebelumnya" not in (stored or "")
+
+
+def test_seed_takes_the_most_recent_turn(tmp_path: Path):
+    """With multiple turns in history, seeding uses the latest (question, answer)."""
+    from pydantic_ai.messages import (
+        ModelRequest,
+        ModelResponse,
+        TextPart,
+        UserPromptPart,
+    )
+
+    _make_ctx(tmp_path)
+    history = [
+        ModelRequest(parts=[UserPromptPart(content="old question")]),
+        ModelResponse(parts=[TextPart(content="old answer")]),
+        ModelRequest(parts=[UserPromptPart(content="new question")]),
+        ModelResponse(parts=[TextPart(content="new answer")]),
+    ]
+    seed_prior_turn_from_history(history)
+
+    assert lookup_prior_turn_answer("new question") == "new answer"
+    assert lookup_prior_turn_answer("old question") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_repl_clean_name_aliases.py
+++ b/tests/cli/test_repl_clean_name_aliases.py
@@ -1,0 +1,103 @@
+"""F2 regression tests: REPL registers clean (prefix-stripped) aliases for nodes.
+
+The Ask agent / manifest surface friendly node names (``channel_profitability``)
+but, before this fix, only the kind-prefixed view (``transform_channel_profitability``)
+was queryable — so the agent hit "table does not exist". These tests lock in that
+both the prefixed name AND the bare alias resolve, that sources are not clobbered,
+and that base-name collisions are handled deterministically.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+
+
+def _write_parquet(path: Path, sql: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = duckdb.connect()
+    safe = str(path).replace("'", "''")
+    con.execute(f"COPY ({sql}) TO '{safe}' (FORMAT PARQUET)")
+    con.close()
+
+
+def test_clean_name_aliases_registered(tmp_path: Path):
+    from seeknal.cli.repl import REPL
+
+    inter = tmp_path / "target" / "intermediate"
+    _write_parquet(inter / "transform_foo.parquet", "SELECT 1 AS a UNION ALL SELECT 2")
+    _write_parquet(inter / "source_bar.parquet", "SELECT 1 AS b UNION ALL SELECT 2 UNION ALL SELECT 3")
+
+    repl = REPL(project_path=tmp_path, skip_history=True)
+    try:
+        # Prefixed views still resolve (unchanged behavior).
+        assert repl.conn.execute("SELECT count(*) FROM transform_foo").fetchone()[0] == 2
+        assert repl.conn.execute("SELECT count(*) FROM source_bar").fetchone()[0] == 3
+        # F2: the clean prefix-stripped aliases now also resolve...
+        assert repl.conn.execute("SELECT count(*) FROM foo").fetchone()[0] == 2
+        assert repl.conn.execute("SELECT count(*) FROM bar").fetchone()[0] == 3
+        # ...and point at the same data as the prefixed view.
+        assert (
+            repl.conn.execute("SELECT count(*) FROM foo").fetchone()[0]
+            == repl.conn.execute("SELECT count(*) FROM transform_foo").fetchone()[0]
+        )
+    finally:
+        repl.conn.close()
+
+
+def test_clean_alias_collision_is_deterministic_and_non_clobbering(tmp_path: Path):
+    from seeknal.cli.repl import REPL
+
+    inter = tmp_path / "target" / "intermediate"
+    # Same base name "baz" for a source and a transform — a genuine collision.
+    _write_parquet(inter / "source_baz.parquet", "SELECT 'src' AS k")
+    _write_parquet(inter / "transform_baz.parquet", "SELECT 'xfm' AS k UNION ALL SELECT 'xfm2'")
+
+    repl = REPL(project_path=tmp_path, skip_history=True)
+    try:
+        # Both prefixed views remain available to disambiguate.
+        assert repl.conn.execute("SELECT count(*) FROM source_baz").fetchone()[0] == 1
+        assert repl.conn.execute("SELECT count(*) FROM transform_baz").fetchone()[0] == 2
+        # The bare alias resolves deterministically to the alphabetically-first
+        # kind (source < transform) — never ambiguous, never a clobber error.
+        assert repl.conn.execute("SELECT count(*) FROM baz").fetchone()[0] == 1
+        assert repl.conn.execute("SELECT k FROM baz").fetchone()[0] == "src"
+    finally:
+        repl.conn.close()
+
+
+def test_clean_alias_does_not_shadow_legacy_cache_node(tmp_path: Path):
+    """A bare alias must never pre-empt a real, distinct legacy cache node."""
+    from seeknal.cli.repl import REPL
+
+    inter = tmp_path / "target" / "intermediate"
+    cache = tmp_path / "target" / "cache"
+    _write_parquet(inter / "transform_orders.parquet", "SELECT 1 AS a UNION ALL SELECT 2 UNION ALL SELECT 3")
+    _write_parquet(cache / "orders.parquet", "SELECT 99 AS a")  # distinct legacy node
+
+    repl = REPL(project_path=tmp_path, skip_history=True)
+    try:
+        assert repl.conn.execute("SELECT count(*) FROM transform_orders").fetchone()[0] == 3
+        # `orders` resolves to the REAL cache node, not the transform alias.
+        assert repl.conn.execute("SELECT a FROM orders").fetchone()[0] == 99
+        assert repl.conn.execute("SELECT count(*) FROM orders").fetchone()[0] == 1
+    finally:
+        repl.conn.close()
+
+
+def test_clean_alias_does_not_shadow_consolidated_entity(tmp_path: Path):
+    """A `transform_entity_*` node must not shadow the consolidated `entity_*` view."""
+    from seeknal.cli.repl import REPL
+
+    inter = tmp_path / "target" / "intermediate"
+    fs = tmp_path / "target" / "feature_store" / "customer"
+    _write_parquet(inter / "transform_entity_customer.parquet", "SELECT 1 AS a UNION ALL SELECT 2")
+    _write_parquet(fs / "features.parquet", "SELECT 7 AS customer_id")  # canonical entity
+
+    repl = REPL(project_path=tmp_path, skip_history=True)
+    try:
+        # `entity_customer` resolves to the consolidated entity, not the transform.
+        assert repl.conn.execute("SELECT customer_id FROM entity_customer").fetchone()[0] == 7
+        assert repl.conn.execute("SELECT count(*) FROM transform_entity_customer").fetchone()[0] == 2
+    finally:
+        repl.conn.close()

--- a/tests/dag/test_manifest.py
+++ b/tests/dag/test_manifest.py
@@ -216,3 +216,37 @@ class TestManifest:
         has_cycle, cycle_path = manifest.detect_cycles()
         assert has_cycle is True
         assert len(cycle_path) > 0
+
+    def test_adjacency_cache_reflects_edges_added_after_first_query(self):
+        """Regression: adjacency must stay correct when edges are added
+        after the cache has been warmed.
+
+        ``build_manifest_from_dag`` adds every node first, then every edge.
+        Adding a node warms the adjacency cache (via cache invalidation),
+        so the cache gets populated while the graph still has no edges.
+        Partial per-node invalidation used to leave stale empty entries —
+        ``get_downstream_nodes`` only rebuilt when the cache was *entirely*
+        empty — so every node reported zero downstream. Kahn's algorithm in
+        ``DAGRunner`` then misreported a perfectly acyclic DAG as cyclic.
+        """
+        manifest = Manifest(project="test_project")
+        manifest.add_node(Node(id="source.a", name="a", node_type=NodeType.SOURCE))
+        manifest.add_node(
+            Node(id="transform.b", name="b", node_type=NodeType.TRANSFORM)
+        )
+        manifest.add_node(
+            Node(id="exposure.c", name="c", node_type=NodeType.EXPOSURE)
+        )
+
+        # Warm the caches while the graph still has no edges.
+        assert manifest.get_downstream_nodes("source.a") == set()
+
+        # Edges are added after the nodes (and after the cache was warmed).
+        manifest.add_edge("source.a", "transform.b")
+        manifest.add_edge("transform.b", "exposure.c")
+
+        # Adjacency must reflect the new edges, not the stale empty snapshot.
+        assert manifest.get_downstream_nodes("source.a") == {"transform.b"}
+        assert manifest.get_downstream_nodes("transform.b") == {"exposure.c"}
+        assert manifest.get_upstream_nodes("exposure.c") == {"transform.b"}
+        assert manifest.get_upstream_nodes("transform.b") == {"source.a"}

--- a/uv.lock
+++ b/uv.lock
@@ -4213,7 +4213,7 @@ wheels = [
 
 [[package]]
 name = "seeknal"
-version = "2.9.5"
+version = "2.9.6"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },

--- a/uv.lock
+++ b/uv.lock
@@ -4213,7 +4213,7 @@ wheels = [
 
 [[package]]
 name = "seeknal"
-version = "2.9.2"
+version = "2.9.5"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary

- Wires the new `seeknal heartbeat` CLI sub-app (`start` / `tick` / `status` / `review`) and scaffolds `HEARTBEAT.md` + `inbox/` in `seeknal init`; admin sub-app added alongside.
- Adds the heartbeat daemon (Scan → Ingest → DAG → Exposure → Record → Notify), the Telegram → inbox bridge, and proactive Telegram tick notifications via stdlib `urllib` (Principle 5 — heartbeat never imports telegram code; enforced by lint test).
- Adds manifest-aware Telegram **photo** intake routing — when the photo caption matches an ingestion-manifest `file_pattern`, the bot skips `propose_record_table` and writes straight into `ingest_<target_table>`. Multi-matches collapsing the same target table no longer abort.
- **Fixes three seeknal-core bugs** that prevented `seeknal heartbeat tick` from completing the full DAG-run for any project with transforms (release 2.9.6, commit aadff48):
  - `Manifest` adjacency cache invalidation — partial per-node `pop` left stale entries; the lazy rebuild only fires when the cache is *entirely* empty, so popped keys returned `set()` and Kahn's algorithm misreported acyclic DAGs as `"DAG contains cycles"`. Now clears both caches in one shot. Regression test in `tests/dag/test_manifest.py`.
  - `heartbeat/runner.py::_run_dag` referenced `summary.fingerprints` — not on `ExecutionSummary`. Now reads from `runner._current_fingerprints` and maps to `.combined` hashes.
  - Cached transform-input views were registered as quoted-literal `"source.x"` while the existence check and transform SQL use schema-qualified `source.x` (parsed by DuckDB as `schema.table`). Now emits `CREATE SCHEMA IF NOT EXISTS` + schema-qualified view.
- Verbatim re-ask gate is now a silent passthrough — `build_verbatim_restate_response(prior_answer)` returns the prior answer unchanged; the bilingual banner ("Pertanyaan ini sama dengan giliran sebelumnya / This question is the same as the prior turn") is gone. Gateway and one-shot paths both flow through the same gate. Also accepts png/pdf/txt/zip uploads on the gateway side.
- Bumps release to **2.9.6** with a CHANGELOG entry, publishes `docs/cli/heartbeat.md`, and adds a **Smart Inbox / Daemon** category to `docs/cli/index.md`.

## Test plan

- [ ] `pytest tests/dag/test_manifest.py tests/heartbeat/ tests/workflow/test_transform_executor.py tests/ask/test_verbatim_restate_gate.py` — manifest cache regression + heartbeat runner + transform executor + verbatim restate gate.
- [ ] `seeknal run --profile profiles.yml` on a project with transforms succeeds, then `seeknal heartbeat tick --profile profiles.yml` completes with `status=ok, dag_failed=0, exposure=N`.
- [ ] Drop a `retail_expenses_inbox.csv` into `inbox/`, run a tick, and confirm the downstream transforms + any `file`-type exposure (e.g. a finance-snapshot JSON) reflect the new rows.
- [ ] Telegram QA: forward a photo with a caption matching a manifest route → bot replies `Tercatat …` and `[telegram] manifest route matched` appears in the gateway log; forward an unsupported suffix → polite reject without staging.
- [ ] Verbatim re-ask: send the same text question twice in a row → second reply is byte-identical to the first, no bilingual banner; gateway log shows the gate short-circuits without re-running the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)