### PR TITLE
Ask harness robustness (F1) + clean-name table aliases (F2) + test-mode grounding (F3) — v2.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.7] - 2026-06-01
+
+Ask agent harness robustness + table-name discoverability — fixes that make
+`seeknal ask chat` reliable for multi-turn consultant use and let the agent query
+the friendly node names it is shown.
+
+### Fixed
+
+- **Ask chat crash on context compaction (F1)** — the `auto_summarization` history
+  processors could leave the message history ending in a `ModelResponse`, tripping
+  pydantic-ai's "Processed history must end with a `ModelRequest`" invariant and
+  crashing ~27% of chat / ask-test turns. A final `ensure_trailing_model_request`
+  history processor now guarantees the invariant; `stream_ask` and the gateway
+  `_generate` degrade gracefully on `UserError` / `UnexpectedModelBehavior` instead
+  of crashing; the Ask `FunctionToolset` now allows `max_retries=3` so one SQL
+  self-correction retry no longer kills the turn. `auto_summarization` now defaults
+  OFF in `seeknal init` and the config default, and is crash-safe to re-enable.
+- **Fabricated answers in `ask test` mode (F3)** — `testing.run_agent_answer` did not
+  seed the per-turn governor, so `current_question` stayed `None` and the grounding /
+  anti-fabrication guards silently disabled. It now calls `reset_report_approval` +
+  `reset_turn_governor`, mirroring the live chat/gateway paths.
+- **Stale `__version__`** — `seeknal.__version__` was 2.9.5 while `pyproject.toml`
+  was 2.9.6; both now track the release version.
+
+### Added
+
+- **Clean table-name aliases (F2)** — nodes registered as `transform_X` / `source_X` /
+  `model_X` are now also queryable under their bare node name (`X`) via a final
+  catalog-aware registration pass in the REPL, so the name the Ask agent is shown in
+  the manifest / `list_tables` is the name it can query. Aliases never shadow a real
+  relation (legacy cache view, consolidated `entity_`, `ingest_`, or attached table);
+  base-name collisions resolve deterministically (`source_` before `transform_`).
+
 ## [2.9.6] - 2026-05-24
 
 Heartbeat smart-inbox loop — three seeknal-core bugs that blocked

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "seeknal"
-version = "2.9.6"
+version = "2.9.7"
 description = "All-in-one platform for data and AI/ML engineering"
 authors = [
     {name = "Fitra Kacamarga"}

--- a/src/seeknal/__init__.py
+++ b/src/seeknal/__init__.py
@@ -29,7 +29,7 @@ Example:
 For more information, see the documentation at https://seeknal.readthedocs.io/
 """
 
-__version__ = "2.9.5"
+__version__ = "2.9.7"
 
 # Export validation functions
 from .validation import (

--- a/src/seeknal/ask/agents/agent.py
+++ b/src/seeknal/ask/agents/agent.py
@@ -208,7 +208,11 @@ def create_agent(
     from seeknal.ask.agents.subagents import get_subagent_configs
     from seeknal.ask.agents.tools.ask_user import interactive_ask_user
     from seeknal.ask.agents.tools.toolset import create_ask_toolset
-    from seeknal.ask.processors import MicrocompactProcessor, SqlResultCompactor
+    from seeknal.ask.processors import (
+        MicrocompactProcessor,
+        SqlResultCompactor,
+        ensure_trailing_model_request,
+    )
     from seeknal.ask.security import configure_safe_connection
     from seeknal.cli.repl import REPL
     from seeknal.ask.config import (
@@ -499,6 +503,13 @@ a plain-language follow-up in the final response; do not call `ask_user`.
             )
         )
 
+    # Safety net — registered LAST so it runs after every other processor and the
+    # context-manager summarizer: guarantee the processed history ends with a
+    # ModelRequest so compaction/summarization can never trip pydantic-ai's
+    # "Processed history must end with a `ModelRequest`" invariant and crash the
+    # turn. No-op on well-formed history.
+    history_processors.append(ensure_trailing_model_request)
+
     plan_enabled = _resolve_auto_bool(
         plan_config["enabled"],
         default=(environment == "interactive" and not analysis_toolset),
@@ -674,10 +685,15 @@ def compact_history_for_analysis_mode(message_history: list) -> None:
     except RuntimeError:
         return
 
-    from seeknal.ask.processors import MicrocompactProcessor, SqlResultCompactor
+    from seeknal.ask.processors import (
+        MicrocompactProcessor,
+        SqlResultCompactor,
+        ensure_trailing_model_request,
+    )
 
     compacted = MicrocompactProcessor(keep_recent_turns=1)(message_history)
     compacted = SqlResultCompactor(min_chars=250)(compacted)
+    compacted = ensure_trailing_model_request(compacted)
     message_history.clear()
     message_history.extend(compacted)
 

--- a/src/seeknal/ask/agents/tools/toolset.py
+++ b/src/seeknal/ask/agents/tools/toolset.py
@@ -191,4 +191,9 @@ def create_ask_toolset(
     return FunctionToolset(
         tools=tools,
         id=toolset_id,
+        # pydantic-ai's FunctionToolset defaults to max_retries=1. The SQL
+        # security / self-correction hooks raise ModelRetry on a bad query, so a
+        # single retry exhaustion would raise UnexpectedModelBehavior and kill the
+        # whole turn. Give the model room to self-correct before failing.
+        max_retries=3,
     )

--- a/src/seeknal/ask/config.py
+++ b/src/seeknal/ask/config.py
@@ -334,7 +334,12 @@ def get_auto_summarization_config(config: dict[str, Any]) -> dict[str, Any]:
     sql_compactor = _get_mapping(section, "sql_result_compactor")
 
     return {
-        "enabled": _coerce_bool(section.get("enabled"), True),
+        # Default OFF: the context-management history processors can leave the
+        # message history ending in a ModelResponse, which trips pydantic-ai's
+        # "Processed history must end with a `ModelRequest`" invariant. It is
+        # opt-in until/unless explicitly enabled (the trailing-ModelRequest guard
+        # in agents/agent.py makes it crash-safe when a project does enable it).
+        "enabled": _coerce_bool(section.get("enabled"), False),
         "context_manager": _coerce_auto_bool(section.get("context_manager"), "auto"),
         "context_manager_max_tokens": _coerce_int(
             section.get("context_manager_max_tokens"), None

--- a/src/seeknal/ask/gateway/server.py
+++ b/src/seeknal/ask/gateway/server.py
@@ -694,6 +694,42 @@ async def _run_agent_inner(
         record_prior_turn_answer(question=question, answer=answer)
         yield {"type": "answer", "data": answer}
 
+    except Exception as exc:
+        # Recoverable harness errors must not 500 the gateway turn:
+        #  - UserError "Processed history must end with a `ModelRequest`"
+        #    (context compaction/summarization left a ModelResponse tail), and
+        #  - UnexpectedModelBehavior "exceeded max retries" (a tool gave up).
+        # Repair the history tail and answer from gathered evidence; re-raise
+        # anything else unchanged.
+        from pydantic_ai.exceptions import (
+            UnexpectedModelBehavior,
+            UserError,
+        )
+
+        _exc_msg = str(exc).lower()
+        if not (
+            isinstance(exc, (UserError, UnexpectedModelBehavior))
+            and (
+                "processed history must end with" in _exc_msg
+                or "exceeded max retries" in _exc_msg
+                or "max retries count" in _exc_msg
+                or "exceeded maximum retries" in _exc_msg
+            )
+        ):
+            raise
+        from seeknal.ask.agents.tools._context import synthesize_evidence_fallback
+
+        # Answer deterministically from evidence already gathered — no further
+        # model call, so the broken history is never re-fed. Nothing reads
+        # message_history after this branch (the finally block saves only when a
+        # run `result` exists), so repairing it here would be dead code.
+        answer = synthesize_evidence_fallback(
+            "a recoverable harness error interrupted the run; "
+            "answering from the evidence gathered so far"
+        )
+        record_prior_turn_answer(question=question, answer=answer)
+        yield {"type": "answer", "data": answer}
+
     finally:
         # Always save conversation — even when the consumer closes the generator
         # early (e.g. Telegram breaking on answer event). Without this, session

--- a/src/seeknal/ask/processors.py
+++ b/src/seeknal/ask/processors.py
@@ -55,6 +55,32 @@ def _get_turn_index(messages: list[ModelMessage], msg_idx: int) -> int:
     return max(current_turn, 0)
 
 
+def ensure_trailing_model_request(
+    messages: list[ModelMessage],
+) -> list[ModelMessage]:
+    """Guarantee the processed history ends with a ``ModelRequest``.
+
+    pydantic-ai's ``_prepare_request`` raises
+    ``UserError('Processed history must end with a `ModelRequest`.')`` when the
+    message list handed to the next model request ends in a ``ModelResponse``.
+    Upstream context management (the LLM summarizer / eviction, or any history
+    processor) can leave such a tail. Registered as the LAST history processor,
+    this trims any trailing non-``ModelRequest`` messages so the invariant holds
+    instead of crashing the whole turn. It is a no-op on well-formed history and
+    never returns an empty list.
+    """
+    if not messages or isinstance(messages[-1], ModelRequest):
+        return messages
+    trimmed = list(messages)
+    while trimmed and not isinstance(trimmed[-1], ModelRequest):
+        trimmed.pop()
+    # If history was reduced to all non-ModelRequest messages, trimming alone
+    # cannot satisfy the invariant; return the original (non-empty) list and let
+    # the streaming/gateway recovery handler degrade gracefully rather than send
+    # an empty history.
+    return trimmed or messages
+
+
 @dataclass
 class MicrocompactProcessor:
     """Tier 1: Replace old tool results with a short placeholder.

--- a/src/seeknal/ask/streaming.py
+++ b/src/seeknal/ask/streaming.py
@@ -1064,6 +1064,45 @@ async def stream_ask(
                 )
                 record_prior_turn_answer(question=question, answer=fallback)
                 return fallback
+
+            # Recoverable harness errors must NOT crash the chat turn. Two cases:
+            #  - UserError "Processed history must end with a `ModelRequest`"
+            #    (context compaction/summarization left a ModelResponse tail), and
+            #  - UnexpectedModelBehavior "exceeded max retries" (a tool gave up).
+            # Repair the history tail and answer from gathered evidence instead.
+            from pydantic_ai.exceptions import (
+                UnexpectedModelBehavior,
+                UserError,
+            )
+
+            _exc_msg = str(exc).lower()
+            if isinstance(exc, (UserError, UnexpectedModelBehavior)) and (
+                "processed history must end with" in _exc_msg
+                or "exceeded max retries" in _exc_msg
+                or "max retries count" in _exc_msg
+                or "exceeded maximum retries" in _exc_msg
+            ):
+                from seeknal.ask.processors import ensure_trailing_model_request
+
+                repaired = ensure_trailing_model_request(message_history)
+                message_history.clear()
+                message_history.extend(repaired)
+                try:
+                    fallback = await _stream_evidence_synthesis(
+                        agent,
+                        deps,
+                        message_history,
+                        "a recoverable harness error interrupted the run; "
+                        "answering from the evidence gathered so far",
+                        console,
+                    )
+                except Exception:
+                    from seeknal.ask.agents.agent import _NO_RESPONSE
+
+                    _show_answer(console, _NO_RESPONSE)
+                    fallback = _NO_RESPONSE
+                record_prior_turn_answer(question=question, answer=fallback)
+                return fallback
             raise
         # Update message history in place
         message_history.clear()

--- a/src/seeknal/ask/testing.py
+++ b/src/seeknal/ask/testing.py
@@ -338,7 +338,12 @@ def run_agent_answer(
     """Run the real Ask agent once in a headless environment."""
     from seeknal.ask.agents.agent import ask as agent_ask
     from seeknal.ask.agents.agent import create_agent
-    from seeknal.ask.agents.tools._context import get_tool_context, set_tool_context
+    from seeknal.ask.agents.tools._context import (
+        get_tool_context,
+        reset_report_approval,
+        reset_turn_governor,
+        set_tool_context,
+    )
 
     try:
         previous_context = get_tool_context()
@@ -352,6 +357,13 @@ def run_agent_answer(
             model=model,
             environment="gateway",
         )
+        # Seed the per-turn governor exactly as the live chat/gateway paths do
+        # (stream_ask in streaming.py, _generate in gateway/server.py). create_agent has already
+        # installed the ToolContext. Without this, ctx.current_question stays None
+        # and the grounding / anti-fabrication guards silently disable, letting the
+        # agent fabricate answers in test mode that it would never produce live.
+        reset_report_approval()
+        reset_turn_governor(prompt)
         return agent_ask(agent, deps, message_history, prompt)
     finally:
         if previous_context is not None:

--- a/src/seeknal/cli/main.py
+++ b/src/seeknal/cli/main.py
@@ -943,7 +943,11 @@ discovery_cache_ttl_seconds: 300
 # limits, hook behavior, planning, or delegation need project-specific policy.
 agent_harness:
   auto_summarization:
-    enabled: true
+    # Off by default: history compaction can break the pydantic-ai
+    # "history must end with a ModelRequest" invariant and crash chat turns.
+    # Safe to enable for long/low-cost sessions (a trailing-request guard
+    # protects it), but opt in deliberately.
+    enabled: false
     context_manager: auto
     context_manager_max_tokens:
     eviction_token_limit: 20000

--- a/src/seeknal/cli/repl.py
+++ b/src/seeknal/cli/repl.py
@@ -202,6 +202,13 @@ class REPL:
         except Exception as e:
             warnings.warn(f"REPL: Failed to register ask-ingested tables: {e}")
 
+        # Phase 4 (final): clean prefix-stripped aliases for queryable nodes. Runs
+        # last so it sees every real relation and never shadows one.
+        try:
+            self._register_clean_aliases()
+        except Exception as e:
+            warnings.warn(f"REPL: Failed to register clean-name aliases: {e}")
+
     def _register_parquets(self) -> None:
         """Phase 1: Register intermediate parquets as DuckDB views.
 
@@ -248,6 +255,11 @@ class REPL:
         becomes view ``transform_orders_cleaned``). The kind prefix is kept so that
         nodes of different types with the same name don't collide.
 
+        Clean prefix-stripped aliases (so the friendly node name the Ask agent is
+        shown is directly queryable) are NOT created here — they are added by
+        _register_clean_aliases() as a final, catalog-aware pass so an alias can
+        never shadow a real relation registered by another phase.
+
         Args:
             directory: Directory to scan for .parquet files.
             registered_names: Already-registered view names (skipped, updated in place).
@@ -290,6 +302,42 @@ class REPL:
                 self._registered_parquets += 1
             except Exception:
                 pass
+
+    def _register_clean_aliases(self) -> None:
+        """Final pass: expose clean, prefix-stripped aliases for project nodes.
+
+        Intermediate parquets register as ``{kind}_{name}`` views (e.g.
+        ``transform_channel_profitability``), but the Ask manifest / list_tables
+        surface the bare node name (``channel_profitability``). Register a bare
+        alias for each prefixed node — but ONLY when that bare name is not already
+        a real relation in the catalog, so an alias never shadows a source/cache
+        view, a consolidated ``entity_`` view, an ``ingest_`` view, or any other
+        registered relation. Runs after every other registration phase so the full
+        catalog is visible. Collisions between two prefixed nodes sharing a base
+        name resolve deterministically (sorted: ``source_`` < ``transform_``).
+        """
+        kind_prefixes = ("transform_", "source_", "model_")
+        try:
+            rows = self.conn.execute(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = 'main'"
+            ).fetchall()
+        except Exception:
+            return
+        existing = {row[0] for row in rows}
+        for view_name in sorted(existing):
+            for prefix in kind_prefixes:
+                if view_name.startswith(prefix):
+                    alias = view_name[len(prefix):]
+                    if alias and alias not in existing:
+                        try:
+                            self.conn.execute(
+                                f'CREATE VIEW "{alias}" AS SELECT * FROM "{view_name}"'
+                            )
+                            existing.add(alias)
+                        except Exception:
+                            pass  # best-effort; the prefixed name still works
+                    break
 
     def _register_consolidated_entities(self) -> None:
         """Phase 1b: Register consolidated entity parquets as DuckDB views.

--- a/tests/ask/test_config.py
+++ b/tests/ask/test_config.py
@@ -167,7 +167,10 @@ def test_performance_defaults_and_overrides():
 
 def test_agent_harness_defaults_preserve_current_ask_behavior():
     auto = get_auto_summarization_config({})
-    assert auto["enabled"] is True
+    # auto_summarization now defaults OFF: its history compaction could leave the
+    # message history ending in a ModelResponse and crash pydantic-ai's
+    # "history must end with a ModelRequest" invariant. Opt-in only.
+    assert auto["enabled"] is False
     assert auto["context_manager"] == "auto"
     assert auto["eviction_token_limit"] == 20000
     assert auto["patch_tool_calls"] is True

--- a/tests/ask/test_harness_robustness.py
+++ b/tests/ask/test_harness_robustness.py
@@ -1,0 +1,144 @@
+"""Regression tests for the F1 + F3 Ask harness robustness fixes.
+
+Covers:
+- F1a: ensure_trailing_model_request guards pydantic-ai's "history must end with a
+       ModelRequest" invariant (the auto_summarization crash).
+- F1c: the Ask FunctionToolset gets a real retry budget (max_retries >= 3).
+- F1d: auto_summarization defaults OFF, but explicit settings are honored.
+- F3 : testing.run_agent_answer seeds the per-turn governor so grounding /
+       anti-fabrication guards are active in test mode (the vip_churn hallucination).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    UserPromptPart,
+)
+
+from seeknal.ask.processors import ensure_trailing_model_request
+
+
+def _req(text: str = "q") -> ModelRequest:
+    return ModelRequest(parts=[UserPromptPart(content=text)])
+
+
+def _resp(text: str = "a") -> ModelResponse:
+    return ModelResponse(parts=[TextPart(content=text)])
+
+
+# --- F1a -------------------------------------------------------------------
+
+def test_guard_trims_trailing_model_response():
+    req, resp = _req(), _resp()
+    assert ensure_trailing_model_request([req, resp]) == [req]
+
+
+def test_guard_trims_multiple_trailing_responses():
+    req, r1, r2 = _req(), _resp("1"), _resp("2")
+    assert ensure_trailing_model_request([req, r1, r2]) == [req]
+
+
+def test_guard_noop_on_well_formed_history():
+    msgs = [_req("a"), _resp("b"), _req("c")]
+    assert ensure_trailing_model_request(msgs) == msgs
+
+
+def test_guard_handles_empty():
+    assert ensure_trailing_model_request([]) == []
+
+
+def test_guard_never_returns_empty():
+    # All-response history must not be emptied (would break the run differently).
+    only_resp = [_resp()]
+    assert ensure_trailing_model_request(only_resp) == only_resp
+
+
+def test_guard_registered_last_in_history_processors():
+    # The guard must run AFTER the compaction processors / summarizer.
+    import inspect
+
+    import seeknal.ask.agents.agent as agent_mod
+
+    src = inspect.getsource(agent_mod.create_agent)
+    assert "history_processors.append(ensure_trailing_model_request)" in src
+    # ...and after the SqlResultCompactor append (so it is the last processor).
+    assert src.index("SqlResultCompactor(") < src.index(
+        "history_processors.append(ensure_trailing_model_request)"
+    )
+
+
+# --- F1c -------------------------------------------------------------------
+
+def test_ask_toolset_has_retry_budget():
+    from seeknal.ask.agents.tools.toolset import create_ask_toolset
+
+    for mode in ("full", "analysis"):
+        ts = create_ask_toolset(mode=mode)
+        assert ts.max_retries is not None and ts.max_retries >= 3, mode
+
+
+# --- F1d -------------------------------------------------------------------
+
+def test_auto_summarization_defaults_off_when_omitted():
+    from seeknal.ask.config import get_auto_summarization_config
+
+    assert get_auto_summarization_config({})["enabled"] is False
+
+
+def test_auto_summarization_explicit_settings_honored():
+    from seeknal.ask.config import get_auto_summarization_config
+
+    on = {"agent_harness": {"auto_summarization": {"enabled": True}}}
+    off = {"agent_harness": {"auto_summarization": {"enabled": False}}}
+    assert get_auto_summarization_config(on)["enabled"] is True
+    assert get_auto_summarization_config(off)["enabled"] is False
+
+
+def test_init_template_defaults_auto_summarization_off():
+    # The generated seeknal_agent.yml must not ship the crash-prone default ON.
+    import inspect
+
+    import seeknal.cli.main as main_mod
+
+    src = inspect.getsource(main_mod)
+    block = src[src.index("auto_summarization:"):src.index("context_manager: auto")]
+    assert "enabled: false" in block
+    assert "enabled: true" not in block
+
+
+# --- F3 --------------------------------------------------------------------
+
+def test_run_agent_answer_seeds_turn_governor(monkeypatch):
+    import seeknal.ask.agents.agent as agent_mod
+    import seeknal.ask.agents.tools._context as ctx_mod
+    import seeknal.ask.testing as testing
+
+    calls: dict = {}
+    monkeypatch.setattr(
+        ctx_mod, "reset_turn_governor",
+        lambda q=None: calls.__setitem__("governor_question", q),
+    )
+    monkeypatch.setattr(
+        ctx_mod, "reset_report_approval",
+        lambda: calls.__setitem__("report_reset", True),
+    )
+    # Stub agent construction + the agent call; echo the prompt back so we can
+    # assert the call order didn't drop the prompt.
+    monkeypatch.setattr(
+        agent_mod, "create_agent",
+        lambda *a, **k: ("AGENT", "DEPS", [], None),
+    )
+    monkeypatch.setattr(
+        agent_mod, "ask",
+        lambda agent, deps, history, prompt: f"ANSWER::{prompt}",
+    )
+
+    out = testing.run_agent_answer(Path("/tmp/does-not-matter"), "untung hari ini?")
+
+    assert out == "ANSWER::untung hari ini?"
+    assert calls.get("governor_question") == "untung hari ini?"
+    assert calls.get("report_reset") is True

--- a/tests/ask/test_toolset.py
+++ b/tests/ask/test_toolset.py
@@ -218,12 +218,15 @@ def test_create_agent_includes_ask_user_in_interactive_analysis_mode(tmp_path: P
         assert "Teach mode" in instructions
         assert "save_preference" in instructions
         assert "context/sql_pairs/<slug>.yml" in instructions
+        # auto_summarization defaults OFF, so the compaction processors are not
+        # wired; only the trailing-ModelRequest guard (always registered last) is.
+        from seeknal.ask.processors import ensure_trailing_model_request
+
         assert mock_create.call_args[1]["history_processors"] == [
-            mock_micro.return_value,
-            mock_sql.return_value,
+            ensure_trailing_model_request,
         ]
-        mock_micro.assert_called_once_with(keep_recent_turns=2)
-        mock_sql.assert_called_once_with(min_chars=250)
+        mock_micro.assert_not_called()
+        mock_sql.assert_not_called()
 
 
 def test_create_agent_applies_agent_harness_config(tmp_path: Path):
@@ -234,6 +237,7 @@ def test_create_agent_applies_agent_harness_config(tmp_path: Path):
             """\
             agent_harness:
               auto_summarization:
+                enabled: true
                 context_manager: false
                 context_manager_max_tokens: 128000
                 summarization_model: openai:gpt-4.1-mini
@@ -300,9 +304,14 @@ def test_create_agent_applies_agent_harness_config(tmp_path: Path):
         assert kwargs["cost_budget_usd"] == 2.5
         assert len(kwargs["hooks"]) == 1
         assert kwargs["hooks"][0].event.value == "pre_tool_use"
+        # The trailing-ModelRequest guard is always appended LAST, after the
+        # configured compaction processors.
+        from seeknal.ask.processors import ensure_trailing_model_request
+
         assert kwargs["history_processors"] == [
             mock_micro.return_value,
             mock_sql.return_value,
+            ensure_trailing_model_request,
         ]
         mock_micro.assert_called_once_with(keep_recent_turns=5)
         mock_sql.assert_called_once_with(min_chars=750)

--- a/tests/cli/test_repl_clean_name_aliases.py
+++ b/tests/cli/test_repl_clean_name_aliases.py
@@ -1,0 +1,103 @@
+"""F2 regression tests: REPL registers clean (prefix-stripped) aliases for nodes.
+
+The Ask agent / manifest surface friendly node names (``channel_profitability``)
+but, before this fix, only the kind-prefixed view (``transform_channel_profitability``)
+was queryable — so the agent hit "table does not exist". These tests lock in that
+both the prefixed name AND the bare alias resolve, that sources are not clobbered,
+and that base-name collisions are handled deterministically.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+
+
+def _write_parquet(path: Path, sql: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = duckdb.connect()
+    safe = str(path).replace("'", "''")
+    con.execute(f"COPY ({sql}) TO '{safe}' (FORMAT PARQUET)")
+    con.close()
+
+
+def test_clean_name_aliases_registered(tmp_path: Path):
+    from seeknal.cli.repl import REPL
+
+    inter = tmp_path / "target" / "intermediate"
+    _write_parquet(inter / "transform_foo.parquet", "SELECT 1 AS a UNION ALL SELECT 2")
+    _write_parquet(inter / "source_bar.parquet", "SELECT 1 AS b UNION ALL SELECT 2 UNION ALL SELECT 3")
+
+    repl = REPL(project_path=tmp_path, skip_history=True)
+    try:
+        # Prefixed views still resolve (unchanged behavior).
+        assert repl.conn.execute("SELECT count(*) FROM transform_foo").fetchone()[0] == 2
+        assert repl.conn.execute("SELECT count(*) FROM source_bar").fetchone()[0] == 3
+        # F2: the clean prefix-stripped aliases now also resolve...
+        assert repl.conn.execute("SELECT count(*) FROM foo").fetchone()[0] == 2
+        assert repl.conn.execute("SELECT count(*) FROM bar").fetchone()[0] == 3
+        # ...and point at the same data as the prefixed view.
+        assert (
+            repl.conn.execute("SELECT count(*) FROM foo").fetchone()[0]
+            == repl.conn.execute("SELECT count(*) FROM transform_foo").fetchone()[0]
+        )
+    finally:
+        repl.conn.close()
+
+
+def test_clean_alias_collision_is_deterministic_and_non_clobbering(tmp_path: Path):
+    from seeknal.cli.repl import REPL
+
+    inter = tmp_path / "target" / "intermediate"
+    # Same base name "baz" for a source and a transform — a genuine collision.
+    _write_parquet(inter / "source_baz.parquet", "SELECT 'src' AS k")
+    _write_parquet(inter / "transform_baz.parquet", "SELECT 'xfm' AS k UNION ALL SELECT 'xfm2'")
+
+    repl = REPL(project_path=tmp_path, skip_history=True)
+    try:
+        # Both prefixed views remain available to disambiguate.
+        assert repl.conn.execute("SELECT count(*) FROM source_baz").fetchone()[0] == 1
+        assert repl.conn.execute("SELECT count(*) FROM transform_baz").fetchone()[0] == 2
+        # The bare alias resolves deterministically to the alphabetically-first
+        # kind (source < transform) — never ambiguous, never a clobber error.
+        assert repl.conn.execute("SELECT count(*) FROM baz").fetchone()[0] == 1
+        assert repl.conn.execute("SELECT k FROM baz").fetchone()[0] == "src"
+    finally:
+        repl.conn.close()
+
+
+def test_clean_alias_does_not_shadow_legacy_cache_node(tmp_path: Path):
+    """A bare alias must never pre-empt a real, distinct legacy cache node."""
+    from seeknal.cli.repl import REPL
+
+    inter = tmp_path / "target" / "intermediate"
+    cache = tmp_path / "target" / "cache"
+    _write_parquet(inter / "transform_orders.parquet", "SELECT 1 AS a UNION ALL SELECT 2 UNION ALL SELECT 3")
+    _write_parquet(cache / "orders.parquet", "SELECT 99 AS a")  # distinct legacy node
+
+    repl = REPL(project_path=tmp_path, skip_history=True)
+    try:
+        assert repl.conn.execute("SELECT count(*) FROM transform_orders").fetchone()[0] == 3
+        # `orders` resolves to the REAL cache node, not the transform alias.
+        assert repl.conn.execute("SELECT a FROM orders").fetchone()[0] == 99
+        assert repl.conn.execute("SELECT count(*) FROM orders").fetchone()[0] == 1
+    finally:
+        repl.conn.close()
+
+
+def test_clean_alias_does_not_shadow_consolidated_entity(tmp_path: Path):
+    """A `transform_entity_*` node must not shadow the consolidated `entity_*` view."""
+    from seeknal.cli.repl import REPL
+
+    inter = tmp_path / "target" / "intermediate"
+    fs = tmp_path / "target" / "feature_store" / "customer"
+    _write_parquet(inter / "transform_entity_customer.parquet", "SELECT 1 AS a UNION ALL SELECT 2")
+    _write_parquet(fs / "features.parquet", "SELECT 7 AS customer_id")  # canonical entity
+
+    repl = REPL(project_path=tmp_path, skip_history=True)
+    try:
+        # `entity_customer` resolves to the consolidated entity, not the transform.
+        assert repl.conn.execute("SELECT customer_id FROM entity_customer").fetchone()[0] == 7
+        assert repl.conn.execute("SELECT count(*) FROM transform_entity_customer").fetchone()[0] == 2
+    finally:
+        repl.conn.close()


### PR DESCRIPTION
## Summary

Three fixes to the seeknal **Ask** agent harness that make `seeknal ask chat` reliable for
multi-turn consultant use and let the agent query the friendly table names it is shown. Bumps
the version **2.9.6 → 2.9.7**.

- **F1 — Ask chat crash on context compaction.** The `auto_summarization` history processors
  could leave the message history ending in a `ModelResponse`, tripping pydantic-ai's
  "Processed history must end with a `ModelRequest`" invariant and crashing ~27% of chat /
  ask-test turns. Adds a final `ensure_trailing_model_request` history-processor guard;
  broadens `stream_ask` + gateway `_generate` to degrade gracefully on
  `UserError` / `UnexpectedModelBehavior`; gives the Ask `FunctionToolset` `max_retries=3`;
  defaults `auto_summarization` OFF (now crash-safe to re-enable).
- **F3 — fabricated answers in `ask test` mode.** `testing.run_agent_answer` did not seed the
  per-turn governor, so `current_question` stayed `None` and the grounding / anti-fabrication
  guards silently disabled. Now seeds `reset_report_approval` + `reset_turn_governor`.
- **F2 — clean table-name aliases.** Nodes registered as `transform_X` / `source_X` / `model_X`
  are now also queryable under their bare node name (`X`) via a final catalog-aware REPL pass.
  Aliases never shadow a real relation (cache view, consolidated `entity_`, `ingest_`, attached
  table); base-name collisions resolve deterministically.
- **chore(release): 2.9.7** — bump `pyproject.toml`, sync the stale `src/seeknal/__init__.py`
  (was 2.9.5), and add the CHANGELOG entry.

## Tests
- New: `tests/ask/test_harness_robustness.py` (11), `tests/cli/test_repl_clean_name_aliases.py` (4); updated `test_config.py` / `test_toolset.py`.
- 80 REPL/entity tests pass; 1265 ask tests collect clean.
- Live tmux `seeknal ask chat` with `auto_summarization` **ON**: 4/4 scenarios answered, **0 crashes** (vs 100% before), grounded answers (real `VIP-C-*` ids), clean names resolved.

## Reviewed
code-reviewer (opus) on both diffs — no blocking findings; MEDIUM items addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)