### PR TITLE
fix(ask): validate `query` alias in execute_sql security hook

### DIFF
--- a/src/seeknal/ask/agents/hooks.py
+++ b/src/seeknal/ask/agents/hooks.py
@@ -34,7 +34,12 @@ async def _sql_security_handler(hook_input: HookInput) -> HookResult:
     try:
         from seeknal.ask.security import validate_sql_for_agent
 
-        sql = hook_input.tool_input.get("sql", "")
+        # execute_sql accepts either `sql` or the `query` alias; mirror that fallback
+        # here so the PRE_TOOL_USE hook validates the SQL the tool will actually run.
+        # (Without this, a model that passes only `query=` yields sql=None and
+        # validate_sql_for_agent(None) raises AttributeError, hard-blocking every query.)
+        tool_input = hook_input.tool_input or {}
+        sql = tool_input.get("sql") or tool_input.get("query") or ""
         validate_sql_for_agent(sql)
         return HookResult(allow=True)
     except ValueError as e:

--- a/tests/ask/test_hooks.py
+++ b/tests/ask/test_hooks.py
@@ -96,6 +96,39 @@ class TestSqlSecurityHook:
         result = asyncio.run(_sql_security_handler(hook_input))
         assert isinstance(result, HookResult)
 
+    # -- `query` alias: execute_sql accepts `sql` OR `query`; the hook must validate
+    #    whichever the tool will actually run (regression for the query-alias hard-block) --
+
+    def test_allows_valid_select_via_query_alias(self):
+        """A model that passes only `query=` (no `sql`) must still be allowed."""
+        hook_input = HookInput(
+            event=HookEvent.PRE_TOOL_USE.value,
+            tool_name="execute_sql",
+            tool_input={"query": "SELECT * FROM customers"},
+        )
+        result = asyncio.run(_sql_security_handler(hook_input))
+        assert result.allow is True
+
+    def test_allows_query_alias_when_sql_is_none(self):
+        """Regression: sql=None + query=... must not hard-block (was NoneType.strip())."""
+        hook_input = HookInput(
+            event=HookEvent.PRE_TOOL_USE.value,
+            tool_name="execute_sql",
+            tool_input={"sql": None, "query": "SELECT 1"},
+        )
+        result = asyncio.run(_sql_security_handler(hook_input))
+        assert result.allow is True
+
+    def test_blocks_dangerous_function_via_query_alias(self):
+        """The guard must still validate the aliased SQL, not wave it through."""
+        hook_input = HookInput(
+            event=HookEvent.PRE_TOOL_USE.value,
+            tool_name="execute_sql",
+            tool_input={"query": "SELECT read_parquet('/etc/passwd')"},
+        )
+        result = asyncio.run(_sql_security_handler(hook_input))
+        assert result.allow is False
+
 
 # ---------------------------------------------------------------------------
 # POST_TOOL_USE: SQL self-correction hook tests


### PR DESCRIPTION
## Summary
The `execute_sql` PRE_TOOL_USE security hook (`_sql_security_handler`) only read `tool_input["sql"]`, but `execute_sql` also accepts a `query` alias (and pydantic-ai serializes the unused `sql` parameter as `null`). This caused two distinct problems:

1. **Reliability — every aliased query hard-blocked.** A model that calls `execute_sql(query="…")` sends `{"sql": None, "query": "…"}`. The hook passed `None` to `validate_sql_for_agent()`, which raised `AttributeError: 'NoneType' object has no attribute 'strip'`. The handler's blanket `except Exception` converted this into a hard `allow=False` ("Unexpected validation error: …"), so the agent could **never execute any SQL** — it writes correct SQL, gets blocked on every attempt, and gives up. Observed live with `openai:gpt-4o`.

2. **Security — read-only guard bypass.** Dangerous SQL sent via `query=` with no `sql` key was validated as `""` (empty) and **allowed**, skipping the read-only function/keyword denylist entirely. e.g. `execute_sql(query="SELECT read_parquet('/etc/passwd')")` passed the guard.

## Fix
Mirror `execute_sql`'s own `sql → query` fallback (`execute_sql.py`) inside the hook, so it validates the SQL the tool will actually run:

```python
tool_input = hook_input.tool_input or {}
sql = tool_input.get("sql") or tool_input.get("query") or ""
validate_sql_for_agent(sql)
```

## Tests
Adds 3 regression tests to `tests/ask/test_hooks.py`:
- `test_allows_valid_select_via_query_alias`
- `test_allows_query_alias_when_sql_is_none` (the exact NoneType repro)
- `test_blocks_dangerous_function_via_query_alias` (the bypass)

Verified: full file **27 passed** with the fix; the two security/repro tests **fail without it**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)