### PR TITLE
feat(atlas): data-access governance — gate + gov/auth CLI (v2.10.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,15 @@ SEEKNAL_USER_CONFIG_PATH="${HOME}/.seeknal/config.toml"
 # Optional: Turso database for production
 # TURSO_DATABASE_URL="libsql://your-database.turso.io"
 # TURSO_AUTH_TOKEN="your-turso-auth-token"
+
+# Optional: Atlas data governance.
+# Setting ATLAS_API_URL activates governance — apply-time policy checks and
+# runtime data-access enforcement (source sample reads are access-checked and
+# sensitive columns masked via the Atlas backend). Unset = inactive; reads pass
+# through unchanged.
+# ATLAS_API_URL="http://atlas-dev-server:8000"
+# ATLAS_API_TOKEN="<optional bearer token>"
+# ATLAS_FAIL_OPEN="false"            # default fail-closed: deny when Atlas is unreachable
+# ATLAS_ACTOR="you@example.com"      # defaults to the OS user
+# SEEKNAL_PROJECT_NAME="my_project"
+# ATLAS_ENVIRONMENT="dev"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.0] - 2026-06-05
+
+Atlas data-access governance — first-class, config-activated access enforcement for
+`seeknal run` and the Ask SQL path, plus the requester/owner access-request CLI loop.
+Previously available only on the `feat/atlas-access-request-flow` branch; now mainline.
+
+### Added
+
+- **Config-activated runtime governance gate** — when `ATLAS_API_URL` is set, a pre-run
+  access check enforces `can_select` (via the Atlas backend / OpenFGA) for every source
+  node a run reads. Denial aborts the run with exit code 1 and a `seeknal gov
+  request-access` hint, **before any data is read**. With `ATLAS_API_URL` unset the gate
+  is a no-op — fully backward compatible.
+- **`seeknal gov request-access <table>`** — request access to a governed dataset through
+  the Atlas governance API (`--reason`, `--access read|write`, `--duration`).
+- **`seeknal auth login` / `status` / `logout`** — authenticate against the Atlas Keycloak
+  realm via PKCE loopback; credentials are cached at `~/.config/seeknal/credentials.json`
+  and supply the per-user identity (token + `sub`) used for access checks.
+- **Governed Ask SQL execution** — `execute_sql` / REPL reads run through the same
+  access-check and apply column masking when the backend reports masked columns.
+
+### Notes
+
+- Activation is opt-in via `ATLAS_API_URL` (+ `KEYCLOAK_ISSUER` for login). The gate fails
+  **closed** on denial; set `ATLAS_FAIL_OPEN=true` to allow on transport error.
+
 ## [2.9.7] - 2026-06-01
 
 Ask agent harness robustness + table-name discoverability — fixes that make

--- a/docs/cli/apply.md
+++ b/docs/cli/apply.md
@@ -64,6 +64,37 @@ If Atlas denies the policy check, the local file is not moved. If Atlas fails
 after the local write, the local artifact remains in place and `seeknal apply`
 exits with an error so the sync issue is visible.
 
+## Runtime data-access governance
+
+The same Atlas configuration also activates **runtime** governance for data reads.
+When `ATLAS_API_URL` is set, Seeknal delegates read decisions to the Atlas backend
+(OpenFGA-backed) instead of trusting local configuration:
+
+- Source **sample reads** (`seeknal source sync`, the `preview` context template) are
+  access-checked per table, and any columns Atlas classifies as sensitive are masked
+  before sample rows are written into the Ask context.
+- The gate is **fail-closed**: a denied decision *or* an unreachable Atlas yields no
+  rows (the preview degrades to "Preview unavailable"). Set `ATLAS_FAIL_OPEN=true`
+  only where availability must outweigh enforcement.
+- When `ATLAS_API_URL` is unset, governance is inactive and reads pass through
+  unchanged.
+
+Relevant environment variables:
+
+```bash
+export ATLAS_API_URL="http://atlas-dev-server:8000"   # activates governance
+export ATLAS_API_TOKEN="<optional bearer token>"
+export ATLAS_FAIL_OPEN="false"                        # default: fail-closed
+export ATLAS_ACTOR="alice@example.com"                # defaults to the OS user
+```
+
+Inspect or test decisions from the CLI:
+
+```bash
+seeknal atlas governance status                       # is enforcement active?
+seeknal atlas governance check prod.gold.customer --action read
+```
+
 ## Examples
 
 ### Apply a draft file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "seeknal"
-version = "2.9.7"
+version = "2.10.0"
 description = "All-in-one platform for data and AI/ML engineering"
 authors = [
     {name = "Fitra Kacamarga"}

--- a/src/seeknal/__init__.py
+++ b/src/seeknal/__init__.py
@@ -29,7 +29,7 @@ Example:
 For more information, see the documentation at https://seeknal.readthedocs.io/
 """
 
-__version__ = "2.9.7"
+__version__ = "2.10.0"
 
 # Export validation functions
 from .validation import (

--- a/src/seeknal/ask/agents/tools/execute_sql.py
+++ b/src/seeknal/ask/agents/tools/execute_sql.py
@@ -262,6 +262,27 @@ def execute_sql(
     has_more_rows = len(rows) > effective_limit
     trimmed_rows = rows[:effective_limit]
 
+    # Runtime governance: when Atlas is configured (ATLAS_API_URL), access-check the
+    # tables this query references and mask sensitive columns before results reach the
+    # model. Inactive (passthrough) when Atlas is not configured. A denial is surfaced
+    # to the agent as a tool message rather than raising.
+    from seeknal.integrations.atlas_client import AtlasPolicyDenied
+    from seeknal.integrations.atlas_governance import (
+        create_governance_gate_from_env,
+        govern_query,
+    )
+
+    _gov_gate = create_governance_gate_from_env()
+    if _gov_gate is not None:
+        try:
+            trimmed_rows = govern_query(
+                _gov_gate, sql=sql, columns=columns, rows=trimmed_rows
+            )
+        except AtlasPolicyDenied as denial:
+            result = f"Access denied by Atlas governance policy: {denial}"
+            record_tool_result("execute_sql", result, args={"sql": sql})
+            return result
+
     # Resolve the real total only when we actually hit the cap — saves the
     # round-trip for normal-sized results.
     total_rows: int | None = None

--- a/src/seeknal/cli/atlas.py
+++ b/src/seeknal/cli/atlas.py
@@ -607,6 +607,78 @@ def governance_audit_logs(
         raise typer.Exit(1)
 
 
+@governance_app.command("status")
+def governance_status():
+    """Show whether runtime Atlas governance enforcement is active.
+
+    Enforcement activates when ``ATLAS_API_URL`` is configured. When active, Seeknal
+    delegates data-access decisions and column masking to the Atlas backend on every
+    governed read — the rules live in Atlas, not in editable local files.
+
+    Example:
+        seeknal atlas governance status
+    """
+    from seeknal.integrations.atlas_governance import create_governance_gate_from_env
+
+    gate = create_governance_gate_from_env()
+    typer.echo("")
+    typer.echo(typer.style("Atlas Runtime Governance", bold=True))
+    typer.echo("=" * 40)
+    if gate is None:
+        _echo_warning("Inactive — ATLAS_API_URL is not set.")
+        typer.echo("Reads pass through ungoverned. Set ATLAS_API_URL to enable enforcement.")
+        typer.echo("")
+        return
+    _echo_success("Active — access decisions delegated to Atlas.")
+    typer.echo(f"  Endpoint:  {gate.config.base_url}")
+    typer.echo(f"  Token:     {'set' if gate.config.token else '(none)'}")
+    typer.echo(f"  Fail mode: {'fail-open' if gate.fail_open else 'fail-closed'}")
+    typer.echo("")
+
+
+@governance_app.command("check")
+def governance_check(
+    resource: str = typer.Argument(
+        ..., help="Resource identifier, e.g. prod.gold.customer"
+    ),
+    action: str = typer.Option(
+        "read", "--action", "-a", help="Action to check (read, write, ...)"
+    ),
+    actor: Optional[str] = typer.Option(
+        None, "--actor", help="Actor (defaults to ATLAS_ACTOR or the current user)"
+    ),
+):
+    """Check the Atlas access decision for a resource (exit 1 if denied).
+
+    Uses the configured Atlas backend (``ATLAS_API_URL``). The exit code is scriptable:
+    a non-zero exit means access is denied, so this can gate shell pipelines.
+
+    Example:
+        seeknal atlas governance check prod.gold.customer --action read
+    """
+    from seeknal.integrations.atlas_governance import create_governance_gate_from_env
+
+    gate = create_governance_gate_from_env()
+    if gate is None:
+        _echo_error("Atlas governance is not configured (set ATLAS_API_URL).")
+        raise typer.Exit(2)
+
+    decision = gate.check_access(resource=resource, action=action, actor=actor)
+    typer.echo("")
+    if decision.allowed:
+        _echo_success(f"ALLOW  {action} {resource}")
+        if decision.masked_columns:
+            typer.echo(f"  Masked columns: {', '.join(decision.masked_columns)}")
+        typer.echo(f"  Classification: {decision.classification}")
+        typer.echo("")
+    else:
+        _echo_error(f"DENY   {action} {resource}")
+        if decision.reason:
+            typer.echo(f"  Reason: {decision.reason}")
+        typer.echo("")
+        raise typer.Exit(1)
+
+
 # =============================================================================
 # Lineage Commands
 # =============================================================================

--- a/src/seeknal/cli/auth.py
+++ b/src/seeknal/cli/auth.py
@@ -1,0 +1,429 @@
+"""
+Seeknal CLI - Keycloak/OIDC authentication.
+
+A command group for logging the engine user in against the Atlas Keycloak realm
+using the OAuth 2.0 Authorization Code flow with PKCE (S256) over a localhost
+loopback redirect. The resulting tokens are written to the seeknal credentials
+file so the governance gate and ``seeknal gov`` commands can attribute requests
+to the logged-in user.
+
+Usage:
+    seeknal auth login
+    seeknal auth login --no-browser
+    seeknal auth status
+    seeknal auth logout
+
+The Keycloak ``seeknal-cli`` client is public (no secret) with PKCE S256 and the
+standard authorization-code flow enabled; RFC 8628 device flow is *not* enabled,
+so login uses a browser-based loopback redirect on ``http://127.0.0.1:8765/callback``.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import http.server
+import json
+import os
+import secrets
+import threading
+import urllib.parse
+import webbrowser
+from pathlib import Path
+from typing import Any, Optional
+
+import httpx
+import typer
+
+from seeknal.integrations.atlas_governance import (
+    credentials_path,
+    user_email_from_credentials,
+    user_sub_from_credentials,
+)
+from seeknal.ui.output import echo_error, echo_info, echo_success, echo_warning
+
+auth_app = typer.Typer(
+    name="auth",
+    help="Authenticate against the Atlas Keycloak realm (login, status, logout).",
+)
+
+#: Default Keycloak issuer for the Atlas realm (overridable via KEYCLOAK_ISSUER).
+_DEFAULT_ISSUER = "http://localhost:8080/realms/atlas"
+#: Default public OIDC client id (overridable via SEEKNAL_OIDC_CLIENT_ID).
+_DEFAULT_CLIENT_ID = "seeknal-cli"
+#: Default loopback redirect port; the registered redirect URIs use 8765.
+_DEFAULT_REDIRECT_PORT = 8765
+#: Seconds to wait for the OIDC discovery / token endpoints before giving up.
+_HTTP_TIMEOUT_SECONDS = 30.0
+#: Seconds to wait for the browser to complete the redirect before aborting login.
+_CALLBACK_TIMEOUT_SECONDS = 300.0
+
+
+def _issuer() -> str:
+    """Return the configured Keycloak issuer URL (trailing slash stripped)."""
+
+    return (os.getenv("KEYCLOAK_ISSUER", "").strip() or _DEFAULT_ISSUER).rstrip("/")
+
+
+def _client_id() -> str:
+    """Return the configured public OIDC client id."""
+
+    return os.getenv("SEEKNAL_OIDC_CLIENT_ID", "").strip() or _DEFAULT_CLIENT_ID
+
+
+def _redirect_port() -> int:
+    """Return the loopback redirect port (env override falls back to the default)."""
+
+    raw = os.getenv("SEEKNAL_OIDC_REDIRECT_PORT", "").strip()
+    if not raw:
+        return _DEFAULT_REDIRECT_PORT
+    try:
+        return int(raw)
+    except ValueError:
+        return _DEFAULT_REDIRECT_PORT
+
+
+def _redirect_uri(port: int) -> str:
+    """Build the loopback redirect URI for ``port`` (matches Keycloak config)."""
+
+    return f"http://127.0.0.1:{port}/callback"
+
+
+def _pkce_pair() -> tuple[str, str]:
+    """Generate a PKCE ``(code_verifier, code_challenge)`` pair using S256.
+
+    The verifier is a high-entropy URL-safe random string (RFC 7636 §4.1) and the
+    challenge is the base64url-encoded SHA-256 of the verifier with padding removed
+    (RFC 7636 §4.2). Both are returned as ASCII strings.
+
+    Returns:
+        A ``(code_verifier, code_challenge)`` tuple.
+    """
+
+    verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode("ascii")
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+def _discover_endpoints(issuer: str, *, client: httpx.Client | None = None) -> dict[str, Any]:
+    """Fetch the OIDC discovery document from ``<issuer>/.well-known/openid-configuration``.
+
+    Args:
+        issuer: The Keycloak realm issuer URL.
+        client: Optional pre-built httpx client (used in tests). When ``None`` a
+            one-shot request is made.
+
+    Returns:
+        The parsed discovery document, which carries ``authorization_endpoint`` and
+        ``token_endpoint`` among other fields.
+
+    Raises:
+        httpx.HTTPError: If the discovery request fails.
+    """
+
+    url = f"{issuer}/.well-known/openid-configuration"
+    if client is not None:
+        response = client.get(url, timeout=_HTTP_TIMEOUT_SECONDS)
+    else:
+        response = httpx.get(url, timeout=_HTTP_TIMEOUT_SECONDS)
+    response.raise_for_status()
+    return response.json()
+
+
+def _build_authorize_url(
+    endpoints: dict[str, Any],
+    *,
+    client_id: str,
+    redirect_uri: str,
+    code_challenge: str,
+    state: str,
+    scope: str = "openid email profile",
+) -> str:
+    """Build the OIDC authorization-endpoint URL for the PKCE code flow.
+
+    Args:
+        endpoints: The OIDC discovery document (must contain ``authorization_endpoint``).
+        client_id: The public OIDC client id.
+        redirect_uri: The loopback redirect URI registered with Keycloak.
+        code_challenge: The S256 PKCE challenge derived from the verifier.
+        state: Opaque CSRF state echoed back on the redirect.
+        scope: Space-delimited OIDC scopes (default requests an id token + email/profile).
+
+    Returns:
+        The fully-qualified authorization URL to open in the browser.
+    """
+
+    authorization_endpoint = endpoints["authorization_endpoint"]
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "scope": scope,
+        "state": state,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    }
+    return f"{authorization_endpoint}?{urllib.parse.urlencode(params)}"
+
+
+def _exchange_code(
+    token_endpoint: str,
+    *,
+    code: str,
+    code_verifier: str,
+    client_id: str,
+    redirect_uri: str,
+    client: httpx.Client | None = None,
+) -> dict[str, Any]:
+    """Exchange an authorization ``code`` for tokens at the token endpoint.
+
+    Uses ``grant_type=authorization_code`` with the PKCE ``code_verifier``. The
+    client is public (no secret), so no client authentication is sent.
+
+    Args:
+        token_endpoint: The OIDC token endpoint URL.
+        code: The authorization code captured from the loopback redirect.
+        code_verifier: The PKCE verifier matching the challenge sent on authorize.
+        client_id: The public OIDC client id.
+        redirect_uri: The redirect URI used on the authorize request (must match).
+        client: Optional pre-built httpx client (used in tests).
+
+    Returns:
+        The parsed token response (``access_token``, ``refresh_token``, ...).
+
+    Raises:
+        httpx.HTTPError: If the token request fails.
+    """
+
+    data = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "client_id": client_id,
+        "code_verifier": code_verifier,
+    }
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    if client is not None:
+        response = client.post(
+            token_endpoint, data=data, headers=headers, timeout=_HTTP_TIMEOUT_SECONDS
+        )
+    else:
+        response = httpx.post(
+            token_endpoint, data=data, headers=headers, timeout=_HTTP_TIMEOUT_SECONDS
+        )
+    response.raise_for_status()
+    return response.json()
+
+
+def _write_credentials(tokens: dict[str, Any]) -> Path:
+    """Persist the OIDC token response to the seeknal credentials file.
+
+    Writes ``access_token``, ``refresh_token``, ``expires_in`` and
+    ``refresh_expires_in`` as JSON. The parent directory is created mode ``0700``
+    and the file itself is written mode ``0600`` so the tokens are not world- or
+    group-readable.
+
+    Args:
+        tokens: The token response from :func:`_exchange_code`.
+
+    Returns:
+        The path the credentials were written to.
+    """
+
+    path = credentials_path()
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    payload = {
+        "access_token": tokens.get("access_token"),
+        "refresh_token": tokens.get("refresh_token"),
+        "expires_in": tokens.get("expires_in"),
+        "refresh_expires_in": tokens.get("refresh_expires_in"),
+    }
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    os.chmod(path, 0o600)
+    return path
+
+
+class _CallbackHandler(http.server.BaseHTTPRequestHandler):
+    """Single-shot HTTP handler that captures the OIDC redirect query params."""
+
+    # Populated on the server instance by ``_capture_authorization_code``.
+    server_version = "seeknal-auth/1.0"
+
+    def do_GET(self) -> None:  # noqa: N802 (http.server API)
+        """Record the ``code``/``state``/``error`` from the redirect and respond."""
+
+        parsed = urllib.parse.urlparse(self.path)
+        query = urllib.parse.parse_qs(parsed.query)
+        self.server.oidc_result = {  # type: ignore[attr-defined]
+            "code": query.get("code", [None])[0],
+            "state": query.get("state", [None])[0],
+            "error": query.get("error", [None])[0],
+            "error_description": query.get("error_description", [None])[0],
+        }
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.end_headers()
+        body = (
+            "<html><body><h2>Seeknal login complete.</h2>"
+            "<p>You may close this tab and return to the terminal.</p></body></html>"
+        )
+        self.wfile.write(body.encode("utf-8"))
+
+    def log_message(self, *args: Any) -> None:  # noqa: D401 (silence default logging)
+        """Suppress the default stderr request logging."""
+
+
+def _capture_authorization_code(port: int, *, timeout: float = _CALLBACK_TIMEOUT_SECONDS) -> dict:
+    """Run a one-shot loopback HTTP server and return the captured redirect params.
+
+    Starts an :class:`http.server.HTTPServer` bound to ``127.0.0.1:port`` in a
+    background thread, services exactly one request (the OIDC redirect), and shuts
+    down. The returned dict carries ``code``/``state``/``error``.
+
+    Args:
+        port: The loopback port to bind (must match the registered redirect URI).
+        timeout: Seconds to wait for the redirect before giving up.
+
+    Returns:
+        The captured redirect parameters, or an ``error`` of ``"timeout"`` if no
+        request arrived in time.
+    """
+
+    server = http.server.HTTPServer(("127.0.0.1", port), _CallbackHandler)
+    server.oidc_result = None  # type: ignore[attr-defined]
+
+    thread = threading.Thread(target=server.handle_request, daemon=True)
+    thread.start()
+    thread.join(timeout=timeout)
+    server.server_close()
+
+    result = getattr(server, "oidc_result", None)
+    if not result:
+        return {"code": None, "state": None, "error": "timeout"}
+    return result
+
+
+@auth_app.command("login")
+def login(
+    no_browser: bool = typer.Option(
+        False,
+        "--no-browser",
+        help="Print the authorization URL instead of opening a browser.",
+    ),
+) -> None:
+    """Log in via the Keycloak Authorization Code + PKCE loopback flow.
+
+    Discovers the OIDC endpoints from the issuer well-known document, generates a
+    PKCE verifier/challenge and CSRF state, opens (or prints) the authorization URL,
+    captures the redirect on the loopback port, exchanges the code for tokens, and
+    writes them to the credentials file. Prints the logged-in subject and email on
+    success; exits with code 1 on any failure.
+    """
+
+    issuer = _issuer()
+    client_id = _client_id()
+    port = _redirect_port()
+    redirect_uri = _redirect_uri(port)
+
+    try:
+        endpoints = _discover_endpoints(issuer)
+    except httpx.HTTPError as exc:
+        echo_error(f"OIDC discovery failed for {issuer}: {exc}")
+        raise typer.Exit(1)
+
+    token_endpoint = endpoints.get("token_endpoint")
+    if not token_endpoint or "authorization_endpoint" not in endpoints:
+        echo_error("OIDC discovery document is missing authorization/token endpoints.")
+        raise typer.Exit(1)
+
+    verifier, challenge = _pkce_pair()
+    state = secrets.token_urlsafe(24)
+    authorize_url = _build_authorize_url(
+        endpoints,
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        code_challenge=challenge,
+        state=state,
+    )
+
+    if no_browser:
+        echo_info("Open this URL in your browser to log in:")
+        typer.echo(authorize_url)
+    else:
+        echo_info(f"Opening browser for login (listening on {redirect_uri})...")
+        webbrowser.open(authorize_url)
+
+    result = _capture_authorization_code(port)
+
+    if result.get("error"):
+        detail = result.get("error_description") or result["error"]
+        echo_error(f"Login failed: {detail}")
+        raise typer.Exit(1)
+    if result.get("state") != state:
+        echo_error("Login failed: state mismatch (possible CSRF); aborting.")
+        raise typer.Exit(1)
+    code = result.get("code")
+    if not code:
+        echo_error("Login failed: no authorization code returned.")
+        raise typer.Exit(1)
+
+    try:
+        tokens = _exchange_code(
+            token_endpoint,
+            code=code,
+            code_verifier=verifier,
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+        )
+    except httpx.HTTPError as exc:
+        echo_error(f"Token exchange failed: {exc}")
+        raise typer.Exit(1)
+
+    if not tokens.get("access_token"):
+        echo_error("Token exchange returned no access token.")
+        raise typer.Exit(1)
+
+    path = _write_credentials(tokens)
+
+    sub = user_sub_from_credentials()
+    email = user_email_from_credentials()
+    echo_success(f"Logged in as {email or sub or '(unknown)'}")
+    echo_info(f"sub: {sub or '(none)'} | credentials: {path}")
+
+
+@auth_app.command("status")
+def status() -> None:
+    """Print whether the user is authenticated, with their sub and email.
+
+    Reads the stored access token's claims. Exits with code 1 (and prints
+    ``authenticated: no``) when no usable credentials are present.
+    """
+
+    sub = user_sub_from_credentials()
+    email = user_email_from_credentials()
+    if not sub and not email:
+        echo_warning("authenticated: no")
+        raise typer.Exit(1)
+    echo_success("authenticated: yes")
+    echo_info(f"sub: {sub or '(none)'}")
+    echo_info(f"email: {email or '(none)'}")
+
+
+@auth_app.command("logout")
+def logout() -> None:
+    """Delete the seeknal credentials file, logging the user out locally.
+
+    A missing credentials file is treated as already logged out (success).
+    """
+
+    path = credentials_path()
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        echo_info("Already logged out (no credentials file).")
+        return
+    except OSError as exc:
+        echo_error(f"Failed to remove credentials: {exc}")
+        raise typer.Exit(1)
+    echo_success(f"Logged out (removed {path}).")

--- a/src/seeknal/cli/gov.py
+++ b/src/seeknal/cli/gov.py
@@ -1,0 +1,135 @@
+"""
+Seeknal CLI - Atlas data-access governance.
+
+A command group for interacting with the Atlas governance backend from the engine
+side. The first command lets a user request access to a dataset; the request is
+created server-side and returned with an auto-assigned id (e.g. ``AR-12``).
+
+Usage:
+    seeknal gov request-access warehouse.namespace.table --reason "need it for X"
+    seeknal gov request-access prod.gold.customer --reason "..." --access write
+    seeknal gov request-access prod.gold.customer --reason "..." --duration 30d
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+import httpx
+import typer
+
+from seeknal.integrations.atlas_governance import (
+    user_email_from_credentials,
+    user_token_from_credentials,
+)
+from seeknal.ui.output import echo_error, echo_info, echo_success
+
+gov_app = typer.Typer(
+    name="gov",
+    help="Atlas data-access governance (request access, etc.).",
+)
+
+#: Seconds to wait for the Atlas governance API before giving up.
+_REQUEST_TIMEOUT_SECONDS = 30.0
+
+
+def _atlas_base_url() -> str:
+    """Resolve the Atlas API base URL from the environment.
+
+    Honours ``SEEKNAL_API_URL`` first, then ``ATLAS_API_URL``, defaulting to the
+    local dev server. A trailing slash is stripped so paths join cleanly.
+    """
+
+    base = os.getenv("SEEKNAL_API_URL") or os.getenv("ATLAS_API_URL") or "http://localhost:8000"
+    return base.rstrip("/")
+
+
+def _requester_email() -> str:
+    """Best-effort caller identity for the request body.
+
+    Prefers the email/username claim from the logged-in credentials token, falling
+    back to the ``USER`` environment variable, then an empty string.
+    """
+
+    return user_email_from_credentials() or os.getenv("USER", "")
+
+
+@gov_app.command("request-access")
+def request_access(
+    dataset: str = typer.Argument(
+        ...,
+        help="Fully-qualified table, e.g. warehouse.namespace.table.",
+    ),
+    reason: str = typer.Option(
+        ...,
+        "--reason",
+        help="Justification for the access request.",
+    ),
+    access: str = typer.Option(
+        "read",
+        "--access",
+        help="Access type requested (e.g. read, write).",
+    ),
+    duration: str = typer.Option(
+        "90d",
+        "--duration",
+        help="Requested grant duration (e.g. 90d).",
+    ),
+    urn: Optional[str] = typer.Option(
+        None,
+        "--urn",
+        help="Optional entity URN for the dataset.",
+    ),
+    priority: str = typer.Option(
+        "medium",
+        "--priority",
+        help="Request priority (e.g. low, medium, high).",
+    ),
+) -> None:
+    """Request access to a dataset via the Atlas governance backend.
+
+    Builds a governance access-request body and ``POST``s it to
+    ``{API}/governance/access-requests``. When the user has logged in, the stored
+    access token is sent as a bearer credential so the request is attributed to
+    them. On success the created request id and status are printed; a non-2xx
+    response prints an error and exits with code 1.
+    """
+
+    body: dict[str, Any] = {
+        "requester": _requester_email(),
+        "entityName": dataset,
+        "entityUrn": urn or "",
+        "requestedAccess": access,
+        "reason": reason,
+        "duration": duration,
+        "priority": priority,
+        "type": "dataset",
+    }
+
+    headers = {"Content-Type": "application/json"}
+    token = user_token_from_credentials()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    url = f"{_atlas_base_url()}/governance/access-requests"
+    try:
+        response = httpx.post(url, json=body, headers=headers, timeout=_REQUEST_TIMEOUT_SECONDS)
+    except httpx.HTTPError as exc:
+        echo_error(f"Access request failed: {exc}")
+        raise typer.Exit(1)
+
+    if not (200 <= response.status_code < 300):
+        detail = response.text.strip() or f"HTTP {response.status_code}"
+        echo_error(f"Access request rejected ({response.status_code}): {detail}")
+        raise typer.Exit(1)
+
+    try:
+        record = response.json()
+    except ValueError:
+        record = {}
+
+    request_id = record.get("id") or "(unknown)"
+    status = record.get("status") or "pending"
+    echo_success(f"Access request {request_id} created for {dataset}")
+    echo_info(f"Status: {status} | access: {access} | duration: {duration}")

--- a/src/seeknal/cli/main.py
+++ b/src/seeknal/cli/main.py
@@ -235,6 +235,12 @@ from seeknal.cli.gov import gov_app  # ty: ignore[unresolved-import]
 
 app.add_typer(gov_app, name="gov")
 
+# Keycloak/OIDC authentication (login, status, logout). Stdlib + httpx only, so it
+# is registered unconditionally regardless of whether Atlas governance is configured.
+from seeknal.cli.auth import auth_app  # ty: ignore[unresolved-import]
+
+app.add_typer(auth_app, name="auth")
+
 # Virtual environment management
 env_app = typer.Typer(
     help="Virtual environments for safe pipeline development (plan/apply/promote)"
@@ -634,6 +640,13 @@ from seeknal.ui.output import echo_success as _ui_echo_success
 from seeknal.ui.output import echo_error as _ui_echo_error
 from seeknal.ui.output import echo_warning as _ui_echo_warning
 from seeknal.ui.output import echo_info as _ui_echo_info
+
+# Atlas runtime governance gate factory. Imported at module scope so tests can
+# monkeypatch ``seeknal.cli.main.create_governance_gate_from_env``. Stdlib + httpx
+# only; returns ``None`` (governance inactive) unless ATLAS_API_URL is set.
+from seeknal.integrations.atlas_governance import (  # ty: ignore[unresolved-import]
+    create_governance_gate_from_env,
+)
 
 
 def _echo_success(message: str):
@@ -1577,6 +1590,104 @@ classifier:
         raise typer.Exit(1)
 
 
+def _source_fqtn(node: Any) -> Optional[str]:
+    """Resolve a source node's fully-qualified table id for governance checks.
+
+    Source nodes carry their config in ``node.config`` (an alias for the parsed
+    YAML). The resolution prefers the most-qualified identifier available:
+
+    * If ``config.table`` is already three-part (``warehouse.namespace.table`` /
+      ``catalog.namespace.table``, e.g. the Iceberg ``atlas.qa_iceberg.signal_events``
+      form), it is used verbatim.
+    * Otherwise, if a warehouse/catalog name is resolvable from ``config`` (the
+      ``warehouse`` key, or ``params.warehouse``/``params.catalog``), it is prepended
+      to ``table`` to make the id as qualified as the engine can determine here.
+    * Otherwise the bare ``config.table`` (e.g. ``namespace.table`` or a single name)
+      is returned.
+
+    Warehouse-context assumption: when no warehouse/catalog is resolvable from the
+    node config (common for csv/postgresql sources, whose ``table`` is a path or
+    ``schema.table``), we fall back to the most-qualified string available. Atlas-side
+    normalization is expected to canonicalize the remaining qualifier (project/env
+    defaults) when matching the resource against policy.
+
+    Args:
+        node: A DAG source node exposing ``config`` (parsed YAML) and ``kind``.
+
+    Returns:
+        The resolved table id, or ``None`` when the node carries no table and so
+        identifies no governed resource (such nodes are skipped by the caller).
+    """
+
+    config = getattr(node, "config", None) or {}
+    table = config.get("table")
+    if not isinstance(table, str) or not table.strip():
+        return None
+    table = table.strip()
+
+    # Already fully qualified (warehouse.namespace.table) -> use as-is.
+    if table.count(".") >= 2:
+        return table
+
+    params = config.get("params") or {}
+    warehouse = (
+        config.get("warehouse")
+        or (params.get("warehouse") if isinstance(params, dict) else None)
+        or (params.get("catalog") if isinstance(params, dict) else None)
+    )
+    if isinstance(warehouse, str) and warehouse.strip():
+        return f"{warehouse.strip()}.{table}"
+
+    # No warehouse/catalog context resolvable from node config; emit the most
+    # qualified string we have. Atlas-side normalization covers the remainder.
+    return table
+
+
+def _enforce_pre_run(nodes_to_run: set, dag_builder: Any, gate: Any) -> None:
+    """Enforce Atlas read access for every source node about to run.
+
+    For each node in ``nodes_to_run`` whose type is ``SOURCE``, the fully-qualified
+    table id is resolved via :func:`_source_fqtn` and access-checked against the
+    Atlas gate. A denial aborts the whole run with exit code 1 and a hint pointing
+    the user at ``seeknal gov request-access``.
+
+    Args:
+        nodes_to_run: Set of node ids selected for execution.
+        dag_builder: The built DAG (``dag_builder.nodes`` maps id -> source node).
+        gate: An active governance gate, or ``None`` to skip enforcement entirely
+            (Atlas not configured -> no behavior change).
+
+    Raises:
+        typer.Exit: With code 1 when Atlas denies read access to a source.
+    """
+
+    if gate is None:
+        return
+
+    from seeknal.dag.manifest import NodeType
+    from seeknal.integrations.atlas_client import AtlasPolicyDenied
+    from seeknal.integrations.atlas_governance import user_sub_from_credentials
+
+    actor = user_sub_from_credentials()
+
+    for node_id in nodes_to_run:
+        node = dag_builder.nodes.get(node_id)
+        if node is None:
+            continue
+        node_type = getattr(node, "node_type", None) or getattr(node, "kind", None)
+        if node_type is not NodeType.SOURCE:
+            continue
+        fqtn = _source_fqtn(node)
+        if not fqtn:
+            continue
+        try:
+            gate.enforce_access(resource=fqtn, action="read", actor=actor)
+        except AtlasPolicyDenied as exc:
+            _echo_error(f"Access denied for source '{fqtn}': {exc}")
+            _echo_info(f'Run: seeknal gov request-access {fqtn} --reason "<why>"')
+            raise typer.Exit(1)
+
+
 @app.command()
 def run(
     dry_run: bool = typer.Option(
@@ -2130,6 +2241,13 @@ def _run_yaml_pipeline(
     if not nodes_to_run:
         _echo_success("No changes detected. Nothing to run.")
         return
+
+    # Atlas pre-run access enforcement. When Atlas is configured (ATLAS_API_URL set)
+    # the gate is non-None and every source node about to run is access-checked; a
+    # denial aborts the run. When Atlas is not configured the gate is None and this
+    # is a no-op (full backward compatibility, no behavior change). The factory is
+    # referenced via the module global so tests can monkeypatch it.
+    _enforce_pre_run(nodes_to_run, dag_builder, create_governance_gate_from_env())
 
     _echo_info(f"Nodes to run: {len(nodes_to_run)}")
 

--- a/src/seeknal/cli/main.py
+++ b/src/seeknal/cli/main.py
@@ -300,17 +300,25 @@ app.add_typer(intervals_app, name="intervals")
 # =============================================================================
 # Heartbeat daemon (HEARTBEAT.md polling + smart inbox + DAG/exposure)
 # =============================================================================
-from seeknal.cli.heartbeat import app as heartbeat_app  # noqa: E402
+try:
+    from seeknal.cli.heartbeat import app as heartbeat_app  # noqa: E402
 
-app.add_typer(heartbeat_app, name="heartbeat")
+    app.add_typer(heartbeat_app, name="heartbeat")
+except ImportError:
+    # Optional command group — skip if the module is not present in this build.
+    pass
 
 
 # =============================================================================
 # Admin (Ask access policy + admin approval queue)
 # =============================================================================
-from seeknal.cli.admin import app as admin_app  # noqa: E402
+try:
+    from seeknal.cli.admin import app as admin_app  # noqa: E402
 
-app.add_typer(admin_app, name="admin")
+    app.add_typer(admin_app, name="admin")
+except ImportError:
+    # Optional command group — skip if the module is not present in this build.
+    pass
 
 
 # =============================================================================

--- a/src/seeknal/cli/main.py
+++ b/src/seeknal/cli/main.py
@@ -110,20 +110,19 @@ class SuggestGroup(_typer_core.TyperGroup):
                 raise
             cmd_name = args[0] if args else None
             if cmd_name is not None:
-                matches = get_close_matches(
-                    cmd_name, self.list_commands(ctx), n=3, cutoff=0.4
-                )
+                matches = get_close_matches(cmd_name, self.list_commands(ctx), n=3, cutoff=0.4)
                 if matches:
                     suggestion = ", ".join(f"'{m}'" for m in matches)
                     msg = f"No such command '{cmd_name}'.\n\nDid you mean: {suggestion}?"
                     raise type(e)(msg) from e
             raise
 
+
 # Load .env file if present (for local development)
 # This makes environment variables available for all CLI commands
 try:
     from dotenv import load_dotenv  # ty: ignore[unresolved-import]
-    
+
     # Try to find .env in current directory or up to 3 parent directories
     cwd = Path.cwd()
     for path in [cwd] + list(cwd.parents)[:3]:
@@ -155,7 +154,9 @@ def main_callback(
         is_eager=True,
     ),
     no_animation: bool = typer.Option(False, "--no-animation", help="Disable all animations"),
-    theme: str = typer.Option("", "--theme", help="UI theme: dark, light, dark-ansi, light-ansi, auto"),
+    theme: str = typer.Option(
+        "", "--theme", help="UI theme: dark, light, dark-ansi, light-ansi, auto"
+    ),
 ):
     """Seeknal — All-in-one platform for data and AI/ML engineering."""
     if no_animation:
@@ -228,8 +229,16 @@ from seeknal.cli.docs import docs_app  # ty: ignore[unresolved-import]
 
 app.add_typer(docs_app, name="docs")
 
+# Atlas data-access governance (request-access, etc.). Uses only stdlib + httpx,
+# so it is registered unconditionally (not behind the atlas-optional guard).
+from seeknal.cli.gov import gov_app  # ty: ignore[unresolved-import]
+
+app.add_typer(gov_app, name="gov")
+
 # Virtual environment management
-env_app = typer.Typer(help="Virtual environments for safe pipeline development (plan/apply/promote)")
+env_app = typer.Typer(
+    help="Virtual environments for safe pipeline development (plan/apply/promote)"
+)
 app.add_typer(env_app, name="env")
 
 # Entity consolidation management
@@ -277,7 +286,7 @@ Examples:
   seeknal intervals pending feature_group.user_features --start 2024-01-01
   seeknal intervals restatement-add feature_group.user_features --start 2024-01-01 --end 2024-01-31
   seeknal intervals backfill feature_group.user_features --start 2024-01-01 --end 2024-01-31
-"""
+""",
 )
 app.add_typer(intervals_app, name="intervals")
 
@@ -304,10 +313,12 @@ app.add_typer(admin_app, name="admin")
 # The Atlas command group is loaded dynamically if atlas-data-platform is installed.
 # This allows Seeknal to work standalone while providing Atlas features when available.
 
+
 def _register_atlas_commands():
     """Register Atlas commands if atlas-data-platform is available."""
     try:
         from seeknal.cli.atlas import atlas_app
+
         app.add_typer(atlas_app, name="atlas")
     except ImportError:
         # Atlas not installed, add a placeholder command
@@ -336,19 +347,27 @@ _register_atlas_commands()
 # =============================================================================
 # The Ask command group is loaded dynamically so broken/minimal environments get a useful error.
 
+
 def _register_ask_commands():
     """Register Ask commands if pydantic-deep dependencies are available."""
     try:
         from seeknal.cli.ask import ask_app
+
         app.add_typer(ask_app, name="ask")
     except ImportError:
+
         @app.command("ask", hidden=True)
         def ask_not_installed():
             """AI-powered data analysis (not installed).
 
             Install with: pip install --upgrade seeknal
             """
-            typer.echo(typer.style("✗ Seeknal Ask dependencies are missing from this environment.", fg=typer.colors.RED))
+            typer.echo(
+                typer.style(
+                    "✗ Seeknal Ask dependencies are missing from this environment.",
+                    fg=typer.colors.RED,
+                )
+            )
             typer.echo("")
             typer.echo("Install with:")
             typer.echo(typer.style("  pip install --upgrade seeknal", fg=typer.colors.CYAN))
@@ -373,9 +392,7 @@ prefect_app = typer.Typer(
 
 @prefect_app.command("serve")
 def prefect_serve(
-    project_path: Path = typer.Option(
-        ".", "--project-path", "-p", help="Path to seeknal project"
-    ),
+    project_path: Path = typer.Option(".", "--project-path", "-p", help="Path to seeknal project"),
     name: Optional[str] = typer.Option(
         None, "--name", "-n", help="Deployment name (default: project directory name)"
     ),
@@ -385,34 +402,26 @@ def prefect_serve(
     interval: Optional[int] = typer.Option(
         None, "--interval", "-i", help="Interval in seconds between runs"
     ),
-    full: bool = typer.Option(
-        False, "--full/--no-full", help="Force full refresh (ignore cache)"
-    ),
+    full: bool = typer.Option(False, "--full/--no-full", help="Force full refresh (ignore cache)"),
     continue_on_error: bool = typer.Option(
-        False, "--continue-on-error/--no-continue-on-error",
-        help="Continue after node failures"
+        False, "--continue-on-error/--no-continue-on-error", help="Continue after node failures"
     ),
     max_workers: int = typer.Option(
-        0, "--max-workers", "-w",
-        help="Max parallel tasks per layer (0=auto)"
+        0, "--max-workers", "-w", help="Max parallel tasks per layer (0=auto)"
     ),
-    env: Optional[str] = typer.Option(
-        None, "--env", "-e", help="Environment name"
-    ),
-    profile: Optional[str] = typer.Option(
-        None, "--profile", help="Profile path"
-    ),
+    env: Optional[str] = typer.Option(None, "--env", "-e", help="Environment name"),
+    profile: Optional[str] = typer.Option(None, "--profile", help="Profile path"),
     start_date: Optional[str] = typer.Option(
-        None, "--start-date",
-        help="Start date for filtering (YYYY-MM-DD). Available as {{ start_date }} in transform SQL"
+        None,
+        "--start-date",
+        help="Start date for filtering (YYYY-MM-DD). Available as {{ start_date }} in transform SQL",
     ),
     end_date: Optional[str] = typer.Option(
-        None, "--end-date",
-        help="End date for filtering (YYYY-MM-DD). Available as {{ end_date }} in transform SQL"
+        None,
+        "--end-date",
+        help="End date for filtering (YYYY-MM-DD). Available as {{ end_date }} in transform SQL",
     ),
-    params: Optional[str] = typer.Option(
-        None, "--params", help="JSON string of parameters"
-    ),
+    params: Optional[str] = typer.Option(None, "--params", help="JSON string of parameters"),
 ):
     """Start a long-running process serving the pipeline as a Prefect flow."""
     import json as _json
@@ -440,51 +449,34 @@ def prefect_serve(
 
 @prefect_app.command("deploy")
 def prefect_deploy(
-    project_path: Path = typer.Option(
-        ".", "--project-path", "-p", help="Path to seeknal project"
-    ),
-    work_pool: str = typer.Option(
-        ..., "--work-pool", help="Prefect work pool name (required)"
-    ),
-    name: Optional[str] = typer.Option(
-        None, "--name", "-n", help="Deployment name"
-    ),
+    project_path: Path = typer.Option(".", "--project-path", "-p", help="Path to seeknal project"),
+    work_pool: str = typer.Option(..., "--work-pool", help="Prefect work pool name (required)"),
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Deployment name"),
     cron: Optional[str] = typer.Option(
         None, "--cron", "-c", help='Cron schedule (e.g., "0 2 * * *")'
     ),
-    interval: Optional[int] = typer.Option(
-        None, "--interval", "-i", help="Interval in seconds"
-    ),
+    interval: Optional[int] = typer.Option(None, "--interval", "-i", help="Interval in seconds"),
     exposure: Optional[str] = typer.Option(
         None, "--exposure", help="Deploy a report exposure by name"
     ),
-    full: bool = typer.Option(
-        False, "--full/--no-full", help="Force full refresh"
-    ),
+    full: bool = typer.Option(False, "--full/--no-full", help="Force full refresh"),
     continue_on_error: bool = typer.Option(
-        False, "--continue-on-error/--no-continue-on-error",
-        help="Continue after node failures"
+        False, "--continue-on-error/--no-continue-on-error", help="Continue after node failures"
     ),
-    max_workers: int = typer.Option(
-        0, "--max-workers", "-w", help="Max parallel tasks (0=auto)"
-    ),
-    env: Optional[str] = typer.Option(
-        None, "--env", "-e", help="Environment name"
-    ),
-    profile: Optional[str] = typer.Option(
-        None, "--profile", help="Profile path"
-    ),
+    max_workers: int = typer.Option(0, "--max-workers", "-w", help="Max parallel tasks (0=auto)"),
+    env: Optional[str] = typer.Option(None, "--env", "-e", help="Environment name"),
+    profile: Optional[str] = typer.Option(None, "--profile", help="Profile path"),
     start_date: Optional[str] = typer.Option(
-        None, "--start-date",
-        help="Start date for filtering (YYYY-MM-DD). Available as {{ start_date }} in transform SQL"
+        None,
+        "--start-date",
+        help="Start date for filtering (YYYY-MM-DD). Available as {{ start_date }} in transform SQL",
     ),
     end_date: Optional[str] = typer.Option(
-        None, "--end-date",
-        help="End date for filtering (YYYY-MM-DD). Available as {{ end_date }} in transform SQL"
+        None,
+        "--end-date",
+        help="End date for filtering (YYYY-MM-DD). Available as {{ end_date }} in transform SQL",
     ),
-    params: Optional[str] = typer.Option(
-        None, "--params", help="JSON string of parameters"
-    ),
+    params: Optional[str] = typer.Option(None, "--params", help="JSON string of parameters"),
 ):
     """Deploy the pipeline (or a report exposure) to Prefect Server/Cloud."""
     import json as _json
@@ -518,12 +510,8 @@ def prefect_deploy(
 
 @prefect_app.command("generate")
 def prefect_generate(
-    project_path: Path = typer.Option(
-        ".", "--project-path", "-p", help="Path to seeknal project"
-    ),
-    max_workers: int = typer.Option(
-        8, "--max-workers", "-w", help="Max parallel tasks"
-    ),
+    project_path: Path = typer.Option(".", "--project-path", "-p", help="Path to seeknal project"),
+    max_workers: int = typer.Option(8, "--max-workers", "-w", help="Max parallel tasks"),
     output: Path = typer.Option(
         None, "--output", "-o", help="Output path (default: prefect.yaml in project root)"
     ),
@@ -563,18 +551,20 @@ def _register_prefect_commands():
     """Register Prefect commands with optional dependency guard."""
     try:
         from seeknal.workflow.prefect_integration import PREFECT_AVAILABLE
+
         # Always register the commands — they handle the ImportError themselves
         app.add_typer(prefect_app, name="prefect")
     except Exception:
+
         @app.command("prefect", hidden=True)
         def prefect_not_installed():
             """Prefect orchestration (not installed).
 
             Install with: pip install seeknal[prefect]
             """
-            typer.echo(typer.style(
-                "✗ Prefect orchestration is not available.", fg=typer.colors.RED
-            ))
+            typer.echo(
+                typer.style("✗ Prefect orchestration is not available.", fg=typer.colors.RED)
+            )
             typer.echo("")
             typer.echo("Install with:")
             typer.echo(typer.style("  pip install seeknal[prefect]", fg=typer.colors.CYAN))
@@ -587,6 +577,7 @@ _register_prefect_commands()
 
 class OutputFormat(str, Enum):
     """Output format options."""
+
     TABLE = "table"
     JSON = "json"
     YAML = "yaml"
@@ -594,6 +585,7 @@ class OutputFormat(str, Enum):
 
 class ResourceType(str, Enum):
     """Resource types for listing."""
+
     PROJECTS = "projects"
     WORKSPACES = "workspaces"
     ENTITIES = "entities"
@@ -603,11 +595,13 @@ class ResourceType(str, Enum):
 
 class DeleteResourceType(str, Enum):
     """Resource types for deletion."""
+
     FEATURE_GROUP = "feature-group"
 
 
 class ValidationModeChoice(str, Enum):
     """Validation mode options for validate-features command."""
+
     WARN = "warn"
     FAIL = "fail"
 
@@ -621,6 +615,7 @@ def _get_version() -> str:
 
     try:
         from seeknal import __version__
+
         return __version__
     except ImportError:
         return "1.0.0"
@@ -696,7 +691,9 @@ def parse_date_safely(date_str: str, param_name: str = "date") -> datetime:
         # Validate future dates (max 1 year ahead from today)
         max_future_date = datetime.now() + timedelta(days=365)
         if dt > max_future_date:
-            _echo_error(f"Invalid {param_name}: Date {dt.strftime('%Y-%m-%d')} is more than 1 year in the future")
+            _echo_error(
+                f"Invalid {param_name}: Date {dt.strftime('%Y-%m-%d')} is more than 1 year in the future"
+            )
             raise typer.Exit(1)
 
         return dt
@@ -704,7 +701,9 @@ def parse_date_safely(date_str: str, param_name: str = "date") -> datetime:
     except ValueError as e:
         # Catch parsing errors from fromisoformat
         if "invalid" in str(e).lower() or "out of range" in str(e).lower():
-            _echo_error(f"Invalid {param_name}: {date_str}. Use YYYY-MM-DD or ISO timestamp (YYYY-MM-DDTHH:MM:SS)")
+            _echo_error(
+                f"Invalid {param_name}: {date_str}. Use YYYY-MM-DD or ISO timestamp (YYYY-MM-DDTHH:MM:SS)"
+            )
         else:
             _echo_error(f"Invalid {param_name}: {e}")
         raise typer.Exit(1)
@@ -734,6 +733,7 @@ def handle_cli_error(error_message: str = "Operation failed"):
         def init(name: str):
             # Command logic here
     """
+
     def decorator(func: Callable) -> Callable:
         @wraps(func)
         def wrapper(*args, **kwargs):
@@ -744,7 +744,9 @@ def handle_cli_error(error_message: str = "Operation failed"):
             except Exception as e:
                 _echo_error(f"{error_message}: {e}")
                 raise typer.Exit(1)
+
         return wrapper
+
     return decorator
 
 
@@ -780,23 +782,27 @@ def _build_manifest_from_dag(dag_builder, project_name: str):
 
     manifest = Manifest(project=project_name)
     for node_id, node in dag_builder.nodes.items():
-        kind_str = node.kind.value if hasattr(node.kind, 'value') else str(node.kind)
+        kind_str = node.kind.value if hasattr(node.kind, "value") else str(node.kind)
         manifest_node_type = node_type_map.get(kind_str, ManifestNodeType.SOURCE)
         # Extract columns dict from YAML data
         raw_columns = {}
-        if hasattr(node, 'yaml_data'):
+        if hasattr(node, "yaml_data"):
             raw_columns = node.yaml_data.get("columns", {}) or {}
 
-        manifest.add_node(Node(
-            id=node_id,
-            name=node.name,
-            node_type=manifest_node_type,
-            description=node.yaml_data.get("description") if hasattr(node, 'yaml_data') else None,
-            tags=list(node.tags) if hasattr(node, 'tags') and node.tags else [],
-            columns=raw_columns,
-            config=node.yaml_data if hasattr(node, 'yaml_data') else {},
-            file_path=node.file_path if hasattr(node, 'file_path') else None,
-        ))
+        manifest.add_node(
+            Node(
+                id=node_id,
+                name=node.name,
+                node_type=manifest_node_type,
+                description=node.yaml_data.get("description")
+                if hasattr(node, "yaml_data")
+                else None,
+                tags=list(node.tags) if hasattr(node, "tags") and node.tags else [],
+                columns=raw_columns,
+                config=node.yaml_data if hasattr(node, "yaml_data") else {},
+                file_path=node.file_path if hasattr(node, "file_path") else None,
+            )
+        )
 
     for node_id in dag_builder.nodes:
         for downstream_id in dag_builder.get_downstream(node_id):
@@ -814,6 +820,7 @@ def info():
     typer.echo(f"Python version: {sys.version.split()[0]}")
     try:
         import pyspark
+
         pyspark_version = pyspark.__version__
     except ImportError:
         pyspark_version = "not installed (optional; install seeknal[spark])"
@@ -830,9 +837,7 @@ def _scaffold_ask_skills(project_path: Path) -> None:
     bundled ``SKILL.md`` into ``<project>/seeknal/skills/`` so users
     can edit/extend them per-project without touching the package.
     """
-    builtin_root = (
-        Path(__file__).resolve().parent.parent / "ask" / "builtin_skills"
-    )
+    builtin_root = Path(__file__).resolve().parent.parent / "ask" / "builtin_skills"
     if not builtin_root.is_dir():
         return  # No built-ins shipped (unexpected, but don't fail init)
 
@@ -1337,20 +1342,12 @@ rather than inventing one-off checks.
 @app.command()
 def init(
     name: str = typer.Option(
-        None, "--name", "-n",
-        help="Project name (defaults to current directory name)"
+        None, "--name", "-n", help="Project name (defaults to current directory name)"
     ),
-    description: str = typer.Option(
-        "", "--description", "-d",
-        help="Project description"
-    ),
-    path: Path = typer.Option(
-        Path("."), "--path", "-p",
-        help="Project path"
-    ),
+    description: str = typer.Option("", "--description", "-d", help="Project description"),
+    path: Path = typer.Option(Path("."), "--path", "-p", help="Project path"),
     force: bool = typer.Option(
-        False, "--force", "-f",
-        help="Overwrite existing project configuration"
+        False, "--force", "-f", help="Overwrite existing project configuration"
     ),
 ):
     """Initialize a new Seeknal project with dbt-style structure.
@@ -1544,6 +1541,7 @@ classifier:
 
         # Also create the legacy Project for database compatibility
         from seeknal.project import Project
+
         if description and isinstance(description, str):
             project = Project(name=name, description=description)
         else:
@@ -1582,102 +1580,93 @@ classifier:
 @app.command()
 def run(
     dry_run: bool = typer.Option(
-        False, "--dry-run",
-        help="Show what would be executed without running"
+        False, "--dry-run", help="Show what would be executed without running"
     ),
     # YAML pipeline execution flags
     full: bool = typer.Option(
-        False, "--full", "-f",
-        help="Run all nodes regardless of state (ignore incremental run cache)"
+        False,
+        "--full",
+        "-f",
+        help="Run all nodes regardless of state (ignore incremental run cache)",
     ),
     nodes: Optional[List[str]] = typer.Option(
-        None, "--nodes", "-n",
-        help="Run specific nodes only (e.g., --nodes transform.clean_data)"
+        None, "--nodes", "-n", help="Run specific nodes only (e.g., --nodes transform.clean_data)"
     ),
     types: Optional[List[str]] = typer.Option(
-        None, "--types", "-t",
-        help="Filter by node types (e.g., --types transform,feature_group)"
+        None, "--types", "-t", help="Filter by node types (e.g., --types transform,feature_group)"
     ),
     tags: Optional[List[str]] = typer.Option(
-        None, "--tags",
-        help="Run only nodes with these tags (plus upstream deps). OR logic."
+        None, "--tags", help="Run only nodes with these tags (plus upstream deps). OR logic."
     ),
     exclude_tags: Optional[List[str]] = typer.Option(
-        None, "--exclude-tags",
-        help="Skip nodes with these tags"
+        None, "--exclude-tags", help="Skip nodes with these tags"
     ),
     continue_on_error: bool = typer.Option(
-        False, "--continue-on-error",
-        help="Continue execution after failures"
+        False, "--continue-on-error", help="Continue execution after failures"
     ),
-    retry: int = typer.Option(
-        0, "--retry", "-r",
-        help="Number of retries for failed nodes"
-    ),
+    retry: int = typer.Option(0, "--retry", "-r", help="Number of retries for failed nodes"),
     show_plan: bool = typer.Option(
-        False, "--show-plan", "-p",
-        help="Show execution plan without running"
+        False, "--show-plan", "-p", help="Show execution plan without running"
     ),
     # Parallel execution flags
     parallel: bool = typer.Option(
-        False, "--parallel",
-        help="Execute independent nodes in parallel (layer-based concurrency)"
+        False, "--parallel", help="Execute independent nodes in parallel (layer-based concurrency)"
     ),
     max_workers: int = typer.Option(
-        4, "--max-workers",
-        help="Maximum parallel workers (default: 4, max recommended: CPU count)"
+        4, "--max-workers", help="Maximum parallel workers (default: 4, max recommended: CPU count)"
     ),
     # Materialization flags
     materialize: Optional[bool] = typer.Option(
-        None, "--materialize/--no-materialize",
-        help="Enable/disable Iceberg materialization (overrides node config)"
+        None,
+        "--materialize/--no-materialize",
+        help="Enable/disable Iceberg materialization (overrides node config)",
     ),
     # Environment flag
     env: Optional[str] = typer.Option(
-        None, "--env",
-        help="Run in isolated virtual environment (requires a plan: seeknal env plan <name>)"
+        None,
+        "--env",
+        help="Run in isolated virtual environment (requires a plan: seeknal env plan <name>)",
     ),
     # Parameterization flags
     param_date: Optional[str] = typer.Option(
-        None, "--date",
-        help="Override date parameter (YYYY-MM-DD format)"
+        None, "--date", help="Override date parameter (YYYY-MM-DD format)"
     ),
     param_run_id: Optional[str] = typer.Option(
-        None, "--run-id",
-        help="Custom run ID for parameterization"
+        None, "--run-id", help="Custom run ID for parameterization"
     ),
     # Interval tracking flags
     start: Optional[str] = typer.Option(
-        None, "--start",
-        help="Start timestamp for interval execution (ISO format or YYYY-MM-DD)"
+        None, "--start", help="Start timestamp for interval execution (ISO format or YYYY-MM-DD)"
     ),
     end: Optional[str] = typer.Option(
-        None, "--end",
-        help="End timestamp for interval execution (ISO format or YYYY-MM-DD)"
+        None, "--end", help="End timestamp for interval execution (ISO format or YYYY-MM-DD)"
     ),
     backfill: bool = typer.Option(
-        False, "--backfill",
-        help="Execute backfill for all missing intervals in the date range"
+        False, "--backfill", help="Execute backfill for all missing intervals in the date range"
     ),
     restate: bool = typer.Option(
-        False, "--restate",
-        help="Process restatement intervals marked for reprocessing"
+        False, "--restate", help="Process restatement intervals marked for reprocessing"
     ),
     start_date: Optional[str] = typer.Option(
-        None, "--start-date",
-        help="Start date for filtering (YYYY-MM-DD). Available as {{ start_date }} in transform SQL"
+        None,
+        "--start-date",
+        help="Start date for filtering (YYYY-MM-DD). Available as {{ start_date }} in transform SQL",
     ),
     end_date: Optional[str] = typer.Option(
-        None, "--end-date",
-        help="End date for filtering (YYYY-MM-DD). Available as {{ end_date }} in transform SQL"
+        None,
+        "--end-date",
+        help="End date for filtering (YYYY-MM-DD). Available as {{ end_date }} in transform SQL",
     ),
     profile: Optional[str] = typer.Option(
-        None, "--profile",
-        help="Path to profiles.yml for source_defaults and connections (default: ~/.seeknal/profiles.yml)"
+        None,
+        "--profile",
+        help="Path to profiles.yml for source_defaults and connections (default: ~/.seeknal/profiles.yml)",
     ),
     verbose: bool = typer.Option(
-        False, "--verbose", "-v",
-        help="Show full tracebacks and subprocess output inline on failure; write detailed log file for all nodes"
+        False,
+        "--verbose",
+        "-v",
+        help="Show full tracebacks and subprocess output inline on failure; write detailed log file for all nodes",
     ),
 ):
     """Execute YAML/Python pipeline.
@@ -1756,6 +1745,7 @@ def run(
     # Environment mode: delegate to shared helper
     if env is not None:
         from pathlib import Path
+
         project_path = Path.cwd().resolve()
         _run_in_environment(
             env_name=env,
@@ -1849,9 +1839,13 @@ def _run_yaml_pipeline(
     from pathlib import Path
     from seeknal.workflow.dag import DAGBuilder, CycleDetectedError, MissingDependencyError
     from seeknal.workflow.state import (
-        RunState, load_state, save_state,
-        calculate_node_hash, get_nodes_to_run,
-        update_node_state, NodeStatus,
+        RunState,
+        load_state,
+        save_state,
+        calculate_node_hash,
+        get_nodes_to_run,
+        update_node_state,
+        NodeStatus,
         include_upstream_sources,
     )
     from seeknal.workflow.executors import get_executor, ExecutionContext
@@ -1959,6 +1953,7 @@ def _run_yaml_pipeline(
 
             try:
                 from seeknal.workflow.iceberg_metadata import get_current_snapshot_id
+
                 current_snap, _ = get_current_snapshot_id(
                     table_ref=table_ref,
                     params=yaml_data.get("params", {}),
@@ -1994,7 +1989,8 @@ def _run_yaml_pipeline(
         # Union: tag-matched nodes (+ upstream) AND explicitly named nodes (+ downstream)
         tag_set = set(tags)
         tag_matched = {
-            node_id for node_id in dag_builder.nodes
+            node_id
+            for node_id in dag_builder.nodes
             if any(t in tag_set for t in dag_builder.nodes[node_id].tags)
         }
         if not tag_matched:
@@ -2016,7 +2012,8 @@ def _run_yaml_pipeline(
         # Run only tag-matched nodes + their upstream dependencies
         tag_set = set(tags)
         tag_matched = {
-            node_id for node_id in dag_builder.nodes
+            node_id
+            for node_id in dag_builder.nodes
             if any(t in tag_set for t in dag_builder.nodes[node_id].tags)
         }
         if not tag_matched:
@@ -2043,8 +2040,7 @@ def _run_yaml_pipeline(
         # Filter by type
         type_set = set(types)
         nodes_to_run = {
-            node_id for node_id in nodes_to_run
-            if dag_builder.nodes[node_id].kind.value in type_set
+            node_id for node_id in nodes_to_run if dag_builder.nodes[node_id].kind.value in type_set
         }
 
     # Apply type filter on top of tags (narrowing)
@@ -2053,11 +2049,13 @@ def _run_yaml_pipeline(
         # Only narrow the tag-matched nodes, keep upstream deps regardless of type
         tag_set = set(tags)
         tag_matched = {
-            node_id for node_id in dag_builder.nodes
+            node_id
+            for node_id in dag_builder.nodes
             if any(t in tag_set for t in dag_builder.nodes[node_id].tags)
         }
         nodes_to_run = {
-            node_id for node_id in nodes_to_run
+            node_id
+            for node_id in nodes_to_run
             if node_id not in tag_matched or dag_builder.nodes[node_id].kind.value in type_set
         }
 
@@ -2068,7 +2066,8 @@ def _run_yaml_pipeline(
         if tags:
             tag_set_for_warn = set(tags)
             tag_matched_for_warn = {
-                node_id for node_id in dag_builder.nodes
+                node_id
+                for node_id in dag_builder.nodes
                 if any(t in tag_set_for_warn for t in dag_builder.nodes[node_id].tags)
             }
             for node_id in list(nodes_to_run):
@@ -2082,7 +2081,8 @@ def _run_yaml_pipeline(
                             )
                             break
         nodes_to_run = {
-            node_id for node_id in nodes_to_run
+            node_id
+            for node_id in nodes_to_run
             if not any(tag in exclude_set for tag in dag_builder.nodes[node_id].tags)
         }
 
@@ -2149,9 +2149,7 @@ def _run_yaml_pipeline(
             layers[layer].append(node_id)
 
         if layers:
-            widest_layer_num, widest_layer_nodes = max(
-                layers.items(), key=lambda x: len(x[1])
-            )
+            widest_layer_num, widest_layer_nodes = max(layers.items(), key=lambda x: len(x[1]))
             if len(widest_layer_nodes) > 3:
                 _echo_info(
                     f"Tip: This pipeline has {len(widest_layer_nodes)} independent nodes "
@@ -2167,14 +2165,16 @@ def _run_yaml_pipeline(
         # Build a Manifest from dag_builder for the DAGRunner
         _manifest = _Manifest(project=project_path.name)
         for node_id, node in dag_builder.nodes.items():
-            _manifest.add_node(_Node(
-                id=node_id,
-                name=node.name,
-                node_type=_NodeType(node.kind.value),
-                tags=list(node.tags) if node.tags else [],
-                config=node.yaml_data,
-                file_path=node.file_path,
-            ))
+            _manifest.add_node(
+                _Node(
+                    id=node_id,
+                    name=node.name,
+                    node_type=_NodeType(node.kind.value),
+                    tags=list(node.tags) if node.tags else [],
+                    config=node.yaml_data,
+                    file_path=node.file_path,
+                )
+            )
         for node_id in dag_builder.nodes:
             for downstream_id in dag_builder.get_downstream(node_id):
                 _manifest.add_edge(node_id, downstream_id)
@@ -2197,9 +2197,10 @@ def _run_yaml_pipeline(
 
         # Write run log for parallel execution
         from seeknal.workflow.run_logger import RunLogger as _RunLogger
+
         _run_logger = _RunLogger(
             target_path=target_path,
-            run_id=_runner.run_state.run_id if hasattr(_runner, 'run_state') else "",
+            run_id=_runner.run_state.run_id if hasattr(_runner, "run_state") else "",
             project_name=project_path.name,
             verbose=verbose,
             flags=["--parallel", "--verbose"] if verbose else ["--parallel"],
@@ -2236,6 +2237,7 @@ def _run_yaml_pipeline(
 
     # Step 5: Execute nodes in topological order
     import time
+
     start_time = time.time()
 
     # Initialize run state
@@ -2245,6 +2247,7 @@ def _run_yaml_pipeline(
 
     # Initialize run logger
     from seeknal.workflow.run_logger import RunLogger
+
     run_flags = []
     if verbose:
         run_flags.append("--verbose")
@@ -2283,13 +2286,17 @@ def _run_yaml_pipeline(
         # Check if we should run this node
         if node_id not in nodes_to_run:
             if node_id in run_state.nodes and run_state.nodes[node_id].is_success():
-                typer.echo(f"{idx}/{len(execution_order)}: {node.name} [{typer.style('CACHED', fg=typer.colors.BLUE)}]")
+                typer.echo(
+                    f"{idx}/{len(execution_order)}: {node.name} [{typer.style('CACHED', fg=typer.colors.BLUE)}]"
+                )
                 cached += 1
                 run_logger.log_node(node_id, "CACHED")
             continue
 
         # Execute the node
-        typer.echo(f"{idx}/{len(execution_order)}: {node.name} [{typer.style('RUNNING', fg=typer.colors.YELLOW)}]")
+        typer.echo(
+            f"{idx}/{len(execution_order)}: {node.name} [{typer.style('RUNNING', fg=typer.colors.YELLOW)}]"
+        )
 
         if dry_run:
             # Dry run - just show what would happen
@@ -2303,11 +2310,7 @@ def _run_yaml_pipeline(
 
         # Inject Iceberg watermark for incremental reads
         # Skip watermark on --full refresh so executor does a full scan
-        if (
-            node.kind.value == "source"
-            and node.yaml_data.get("source") == "iceberg"
-            and not full
-        ):
+        if node.kind.value == "source" and node.yaml_data.get("source") == "iceberg" and not full:
             # Check current run_state first, then fall back to old_state
             stored = run_state.nodes.get(node_id)
             if not stored and old_state:
@@ -2366,7 +2369,8 @@ def _run_yaml_pipeline(
 
                 successful += 1
                 run_logger.log_node(
-                    node_id, "SUCCESS",
+                    node_id,
+                    "SUCCESS",
                     duration_seconds=duration,
                     row_count=result.row_count,
                 )
@@ -2391,7 +2395,8 @@ def _run_yaml_pipeline(
                 )
                 failed += 1
                 run_logger.log_node(
-                    node_id, "FAILED",
+                    node_id,
+                    "FAILED",
                     duration_seconds=duration,
                     error_message=result.error_message,
                     output_log=result.output_log,
@@ -2411,7 +2416,8 @@ def _run_yaml_pipeline(
                     total_attempts = retry + 1  # initial + retries
                     # Log the initial failure as attempt 1
                     run_logger.log_node(
-                        node_id, "FAILED",
+                        node_id,
+                        "FAILED",
                         duration_seconds=duration,
                         error_message=result.error_message,
                         output_log=result.output_log,
@@ -2442,7 +2448,8 @@ def _run_yaml_pipeline(
                                 failed -= 1
                                 successful += 1
                                 run_logger.log_node(
-                                    node_id, "SUCCESS",
+                                    node_id,
+                                    "SUCCESS",
                                     duration_seconds=duration,
                                     row_count=result.row_count,
                                     attempt=attempt + 1,
@@ -2451,7 +2458,8 @@ def _run_yaml_pipeline(
                                 break
                             else:
                                 run_logger.log_node(
-                                    node_id, "FAILED",
+                                    node_id,
+                                    "FAILED",
                                     duration_seconds=time.time() - node_start,
                                     error_message=result.error_message,
                                     output_log=result.output_log,
@@ -2461,7 +2469,8 @@ def _run_yaml_pipeline(
                         except Exception as e:
                             typer.echo(f"  Retry {attempt} failed: {e}")
                             run_logger.log_node(
-                                node_id, "FAILED",
+                                node_id,
+                                "FAILED",
                                 duration_seconds=time.time() - node_start,
                                 error_message=str(e),
                                 attempt=attempt + 1,
@@ -2482,7 +2491,8 @@ def _run_yaml_pipeline(
             )
             failed += 1
             run_logger.log_node(
-                node_id, "FAILED",
+                node_id,
+                "FAILED",
                 duration_seconds=duration,
                 error_message=str(e),
             )
@@ -2544,6 +2554,7 @@ def _run_yaml_pipeline(
                         )
         except Exception as exc:
             import logging
+
             logging.getLogger(__name__).warning("Entity consolidation failed: %s", exc)
 
     # Step 7: Print summary
@@ -2587,11 +2598,17 @@ def _run_yaml_pipeline(
         typer.echo("")
         typer.echo(f"  Data Quality:   {_rule_total} rule(s)")
         if _rule_passed > 0:
-            typer.echo(f"                  {typer.style(str(_rule_passed) + ' passed', fg=typer.colors.GREEN)}")
+            typer.echo(
+                f"                  {typer.style(str(_rule_passed) + ' passed', fg=typer.colors.GREEN)}"
+            )
         if _rule_warns > 0:
-            typer.echo(f"                  {typer.style(str(_rule_warns) + ' warning(s)', fg=typer.colors.YELLOW, bold=True)}")
+            typer.echo(
+                f"                  {typer.style(str(_rule_warns) + ' warning(s)', fg=typer.colors.YELLOW, bold=True)}"
+            )
         if _rule_errors > 0:
-            typer.echo(f"                  {typer.style(str(_rule_errors) + ' error(s)', fg=typer.colors.RED, bold=True)}")
+            typer.echo(
+                f"                  {typer.style(str(_rule_errors) + ' error(s)', fg=typer.colors.RED, bold=True)}"
+            )
 
     typer.echo("=" * 60)
 
@@ -2617,25 +2634,15 @@ def _run_yaml_pipeline(
 
 @app.command("list")
 def list_resources(
-    resource_type: ResourceType = typer.Argument(
-        ..., help="Type of resource to list"
-    ),
-    project: Optional[str] = typer.Option(
-        None, "--project", "-p",
-        help="Filter by project name"
-    ),
-    format: OutputFormat = typer.Option(
-        OutputFormat.TABLE, "--format", "-f",
-        help="Output format"
-    ),
+    resource_type: ResourceType = typer.Argument(..., help="Type of resource to list"),
+    project: Optional[str] = typer.Option(None, "--project", "-p", help="Filter by project name"),
+    format: OutputFormat = typer.Option(OutputFormat.TABLE, "--format", "-f", help="Output format"),
 ):
     """List resources (projects, entities, feature-groups, etc.)."""
     from seeknal.project import Project
     from seeknal.entity import Entity
     from seeknal.featurestore.featurestore import OfflineStore
-    from seeknal.models import (
-        WorkspaceTable, FeatureGroupTable
-    )
+    from seeknal.models import WorkspaceTable, FeatureGroupTable
     from seeknal.request import get_db_session
     from sqlmodel import select
     from tabulate import tabulate
@@ -2663,8 +2670,10 @@ def list_resources(
                     typer.echo("No feature groups found.")
                 else:
                     headers = ["Name", "Description", "Version"]
-                    data = [[fg.name, fg.description or "", getattr(fg, "version", 1) or 1]
-                            for fg in feature_groups]
+                    data = [
+                        [fg.name, fg.description or "", getattr(fg, "version", 1) or 1]
+                        for fg in feature_groups
+                    ]
                     typer.echo(tabulate(data, headers=headers, tablefmt="simple"))
             case ResourceType.OFFLINE_STORES:
                 OfflineStore.list()
@@ -2677,15 +2686,15 @@ def list_resources(
 def show(
     resource_type: str = typer.Argument(..., help="Type of resource"),
     name: str = typer.Argument(..., help="Resource name"),
-    format: OutputFormat = typer.Option(
-        OutputFormat.TABLE, "--format", "-f",
-        help="Output format"
-    ),
+    format: OutputFormat = typer.Option(OutputFormat.TABLE, "--format", "-f", help="Output format"),
 ):
     """Show detailed information about a resource."""
     from seeknal.request import (
-        ProjectRequest, EntityRequest, FlowRequest,
-        FeatureGroupRequest, WorkspaceRequest
+        ProjectRequest,
+        EntityRequest,
+        FlowRequest,
+        FeatureGroupRequest,
+        WorkspaceRequest,
     )
     import json
 
@@ -2710,14 +2719,14 @@ def show(
 
         if format == OutputFormat.JSON:
             # Convert to dict and print as JSON
-            data = {k: v for k, v in resource.__dict__.items() if not k.startswith('_')}
+            data = {k: v for k, v in resource.__dict__.items() if not k.startswith("_")}
             typer.echo(json.dumps(data, indent=2, default=str))
         else:
             # Print as table
             typer.echo(f"\n{resource_type.title()}: {name}")
             typer.echo("-" * 40)
             for key, value in resource.__dict__.items():
-                if not key.startswith('_') and value is not None:
+                if not key.startswith("_") and value is not None:
                     typer.echo(f"  {key}: {value}")
 
     except Exception as e:
@@ -2727,10 +2736,7 @@ def show(
 
 @app.command()
 def validate(
-    config_path: Optional[Path] = typer.Option(
-        None, "--config", "-c",
-        help="Path to config file"
-    ),
+    config_path: Optional[Path] = typer.Option(None, "--config", "-c", help="Path to config file"),
 ):
     """Validate configurations and connections."""
     from seeknal.context import CONFIG_BASE_URL
@@ -2766,6 +2772,7 @@ def _build_range_validator(config):
     params = config.params or {}
     column = config.columns[0] if len(config.columns) == 1 else config.columns[0]
     from seeknal.feature_validation.validators import RangeValidator
+
     return RangeValidator(
         column=column,
         min_val=params.get("min_val"),
@@ -2779,7 +2786,7 @@ def _build_freshness_validator(config):
         raise ValueError("FreshnessValidator requires a column")
     from datetime import timedelta
     from seeknal.feature_validation.validators import FreshnessValidator
-    
+
     params = config.params or {}
     max_age_seconds = params.get("max_age_seconds", 86400)  # Default 24 hours
     return FreshnessValidator(
@@ -2800,6 +2807,7 @@ _VALIDATOR_REGISTRY = {
 def _build_null_validator(config):
     """Build a NullValidator from config."""
     from seeknal.feature_validation.validators import NullValidator
+
     params = config.params or {}
     return NullValidator(
         columns=config.columns or [],
@@ -2810,6 +2818,7 @@ def _build_null_validator(config):
 def _build_uniqueness_validator(config):
     """Build a UniquenessValidator from config."""
     from seeknal.feature_validation.validators import UniquenessValidator
+
     params = config.params or {}
     return UniquenessValidator(
         columns=config.columns or [],
@@ -2929,17 +2938,14 @@ def _format_field(field, symbol: str = "") -> str:
 
 @app.command("validate-features")
 def validate_features(
-    feature_group: str = typer.Argument(
-        ..., help="Name of the feature group to validate"
-    ),
+    feature_group: str = typer.Argument(..., help="Name of the feature group to validate"),
     mode: ValidationModeChoice = typer.Option(
-        ValidationModeChoice.FAIL, "--mode", "-m",
-        help="Validation mode: 'warn' logs failures and continues, 'fail' stops on first failure"
+        ValidationModeChoice.FAIL,
+        "--mode",
+        "-m",
+        help="Validation mode: 'warn' logs failures and continues, 'fail' stops on first failure",
     ),
-    verbose: bool = typer.Option(
-        False, "--verbose", "-v",
-        help="Show detailed validation results"
-    ),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed validation results"),
 ):
     """Validate feature group data quality.
 
@@ -2989,7 +2995,9 @@ def validate_features(
             raise typer.Exit(1)
 
         # Convert CLI mode to ValidationMode enum
-        validation_mode = ValidationMode.WARN if mode == ValidationModeChoice.WARN else ValidationMode.FAIL
+        validation_mode = (
+            ValidationMode.WARN if mode == ValidationModeChoice.WARN else ValidationMode.FAIL
+        )
 
         # Show validator count
         typer.echo(f"  Validators to run: {len(validators)}")
@@ -3026,7 +3034,11 @@ def validate_features(
 
         # Summary statistics
         passed_style = typer.style(str(summary.passed_count), fg=typer.colors.GREEN, bold=True)
-        failed_style = typer.style(str(summary.failed_count), fg=typer.colors.RED if summary.failed_count > 0 else typer.colors.GREEN, bold=True)
+        failed_style = typer.style(
+            str(summary.failed_count),
+            fg=typer.colors.RED if summary.failed_count > 0 else typer.colors.GREEN,
+            bold=True,
+        )
 
         typer.echo(f"  Total validators: {summary.total_validators}")
         typer.echo(f"  Passed:           {passed_style}")
@@ -3066,19 +3078,15 @@ def validate_features(
         _echo_error(f"Validation failed: {e}")
         if verbose:
             import traceback
+
             typer.echo(typer.style(traceback.format_exc(), dim=True))
         raise typer.Exit(1)
 
 
 @app.command()
 def debug(
-    feature_group: str = typer.Argument(
-        ..., help="Feature group name to debug"
-    ),
-    limit: int = typer.Option(
-        10, "--limit", "-l",
-        help="Number of rows to show"
-    ),
+    feature_group: str = typer.Argument(..., help="Feature group name to debug"),
+    limit: int = typer.Option(10, "--limit", "-l", help="Number of rows to show"),
 ):
     """Show sample data from a feature group for debugging."""
     from seeknal.featurestore.feature_group import FeatureGroup, HistoricalFeatures, FeatureLookup
@@ -3113,20 +3121,13 @@ def debug(
 
 @app.command()
 def clean(
-    feature_group: str = typer.Argument(
-        ..., help="Feature group name to clean"
-    ),
+    feature_group: str = typer.Argument(..., help="Feature group name to clean"),
     before_date: Optional[str] = typer.Option(
-        None, "--before", "-b",
-        help="Delete data before this date (YYYY-MM-DD)"
+        None, "--before", "-b", help="Delete data before this date (YYYY-MM-DD)"
     ),
-    ttl_days: Optional[int] = typer.Option(
-        None, "--ttl",
-        help="Delete data older than TTL days"
-    ),
+    ttl_days: Optional[int] = typer.Option(None, "--ttl", help="Delete data older than TTL days"),
     dry_run: bool = typer.Option(
-        False, "--dry-run",
-        help="Show what would be deleted without deleting"
+        False, "--dry-run", help="Show what would be deleted without deleting"
     ),
 ):
     """Clean old feature data based on TTL or date."""
@@ -3140,6 +3141,7 @@ def clean(
         cutoff = parse_date_safely(before_date, "before date")
     else:
         from datetime import timedelta
+
         cutoff = datetime.now() - timedelta(days=ttl_days)
 
     typer.echo(f"Cleaning feature group: {feature_group}")
@@ -3163,13 +3165,8 @@ def delete(
     resource_type: DeleteResourceType = typer.Argument(
         ..., help="Type of resource to delete (feature-group)"
     ),
-    name: str = typer.Argument(
-        ..., help="Name of the resource to delete"
-    ),
-    force: bool = typer.Option(
-        False, "--force", "-f",
-        help="Skip confirmation prompt"
-    ),
+    name: str = typer.Argument(..., help="Name of the resource to delete"),
+    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation prompt"),
 ):
     """Delete a resource (feature group) including storage and metadata."""
     from seeknal.featurestore.feature_group import FeatureGroup
@@ -3209,12 +3206,12 @@ def delete(
 
 @app.command("delete-table")
 def delete_table(
-    table_name: str = typer.Argument(
-        ..., help="Name of the online table to delete"
-    ),
+    table_name: str = typer.Argument(..., help="Name of the online table to delete"),
     force: bool = typer.Option(
-        False, "--force", "-f",
-        help="Force deletion without confirmation (bypass dependency warnings)"
+        False,
+        "--force",
+        "-f",
+        help="Force deletion without confirmation (bypass dependency warnings)",
     ),
 ):
     """Delete an online table and all associated data files.
@@ -3258,15 +3255,16 @@ def delete_table(
 
         # Step 3: Show warnings if dependencies exist
         if dependent_feature_groups:
-            _echo_warning(f"Table '{table_name}' has {len(dependent_feature_groups)} dependent feature group(s):")
+            _echo_warning(
+                f"Table '{table_name}' has {len(dependent_feature_groups)} dependent feature group(s):"
+            )
             for fg_name in dependent_feature_groups:
                 typer.echo(f"  - {fg_name}")
 
             if not force:
                 _echo_warning("Deleting this table may affect these feature groups.")
                 confirm = typer.confirm(
-                    "Are you sure you want to delete this table?",
-                    default=False
+                    "Are you sure you want to delete this table?", default=False
                 )
                 if not confirm:
                     _echo_info("Deletion cancelled")
@@ -3275,8 +3273,7 @@ def delete_table(
             # No dependencies, but still confirm unless --force
             if not force:
                 confirm = typer.confirm(
-                    f"Are you sure you want to delete table '{table_name}'?",
-                    default=False
+                    f"Are you sure you want to delete table '{table_name}'?", default=False
                 )
                 if not confirm:
                     _echo_info("Deletion cancelled")
@@ -3296,7 +3293,7 @@ def delete_table(
             lookup_key=entity_obj,
             online_store=OnlineStoreDuckDB(),
             project="default",  # TODO: Get from online_table.project_id if needed
-            id=online_table.id
+            id=online_table.id,
         )
 
         success = online_table_obj.delete()
@@ -3312,6 +3309,7 @@ def delete_table(
         _echo_error(f"Failed to delete table: {e}")
         raise typer.Exit(1)
 
+
 # Version subcommands
 @version_app.command("list")
 def version_list(
@@ -3319,12 +3317,10 @@ def version_list(
         ..., help="Name of the feature group to query versions for"
     ),
     format: OutputFormat = typer.Option(
-        OutputFormat.TABLE, "--format", "-f",
-        help="Output format: table (default), json, or yaml"
+        OutputFormat.TABLE, "--format", "-f", help="Output format: table (default), json, or yaml"
     ),
     limit: Optional[int] = typer.Option(
-        None, "--limit", "-l",
-        help="Maximum number of versions to display (most recent first)"
+        None, "--limit", "-l", help="Maximum number of versions to display (most recent first)"
     ),
 ):
     """
@@ -3381,16 +3377,12 @@ def version_list(
 
 @version_app.command("show")
 def version_show(
-    feature_group: str = typer.Argument(
-        ..., help="Name of the feature group to inspect"
-    ),
+    feature_group: str = typer.Argument(..., help="Name of the feature group to inspect"),
     version: Optional[int] = typer.Option(
-        None, "--version", "-v",
-        help="Specific version number to show (defaults to latest version)"
+        None, "--version", "-v", help="Specific version number to show (defaults to latest version)"
     ),
     format: OutputFormat = typer.Option(
-        OutputFormat.TABLE, "--format", "-f",
-        help="Output format: table (default), json, or yaml"
+        OutputFormat.TABLE, "--format", "-f", help="Output format: table (default), json, or yaml"
     ),
 ):
     """
@@ -3493,16 +3485,13 @@ def version_diff(
         ..., help="Name of the feature group to compare versions for"
     ),
     from_version: int = typer.Option(
-        ..., "--from", "-f",
-        help="Base version number to compare from (older version)"
+        ..., "--from", "-f", help="Base version number to compare from (older version)"
     ),
     to_version: int = typer.Option(
-        ..., "--to", "-t",
-        help="Target version number to compare to (newer version)"
+        ..., "--to", "-t", help="Target version number to compare to (newer version)"
     ),
     format: OutputFormat = typer.Option(
-        OutputFormat.TABLE, "--format",
-        help="Output format: table (default) or json"
+        OutputFormat.TABLE, "--format", help="Output format: table (default) or json"
     ),
 ):
     """
@@ -3564,19 +3553,28 @@ def version_diff(
 
                 # Display modified features
                 if modified:
-                    typer.echo("\n" + typer.style("Modified (~):", fg=typer.colors.YELLOW, bold=True))
+                    typer.echo(
+                        "\n" + typer.style("Modified (~):", fg=typer.colors.YELLOW, bold=True)
+                    )
                     for change in modified:
                         if isinstance(change, dict):
                             field_name = change.get("field", "unknown")
                             old_type = _format_field_type(change.get("old_type", "unknown"))
                             new_type = _format_field_type(change.get("new_type", "unknown"))
-                            typer.echo(typer.style(f"  ~ {field_name}: {old_type} → {new_type}", fg=typer.colors.YELLOW))
+                            typer.echo(
+                                typer.style(
+                                    f"  ~ {field_name}: {old_type} → {new_type}",
+                                    fg=typer.colors.YELLOW,
+                                )
+                            )
                         else:
                             typer.echo(typer.style(f"  ~ {change}", fg=typer.colors.YELLOW))
 
                 # Summary
                 typer.echo("\n" + "-" * 60)
-                typer.echo(f"Summary: {len(added)} added, {len(removed)} removed, {len(modified)} modified")
+                typer.echo(
+                    f"Summary: {len(added)} added, {len(removed)} removed, {len(modified)} modified"
+                )
 
     except ValueError as e:
         _echo_error(str(e))
@@ -3589,25 +3587,16 @@ def version_diff(
 @app.command()
 def parse(
     project: str = typer.Option(
-        None, "--project", "-p",
-        help="Project name (defaults to current directory name)"
+        None, "--project", "-p", help="Project name (defaults to current directory name)"
     ),
-    path: Path = typer.Option(
-        Path("."), "--path",
-        help="Project path to parse"
-    ),
+    path: Path = typer.Option(Path("."), "--path", help="Project path to parse"),
     target_path: Optional[Path] = typer.Option(
-        None, "--target", "-t",
-        help="Target directory for manifest (defaults to <path>/target)"
+        None, "--target", "-t", help="Target directory for manifest (defaults to <path>/target)"
     ),
     format: OutputFormat = typer.Option(
-        OutputFormat.TABLE, "--format", "-f",
-        help="Output format: table (default) or json"
+        OutputFormat.TABLE, "--format", "-f", help="Output format: table (default) or json"
     ),
-    no_diff: bool = typer.Option(
-        False, "--no-diff",
-        help="Skip comparison with previous manifest"
-    ),
+    no_diff: bool = typer.Option(False, "--no-diff", help="Skip comparison with previous manifest"),
 ):
     """
     Parse project and generate manifest.json.
@@ -3717,34 +3706,65 @@ def parse(
 
                     # Show added nodes
                     if diff.added_nodes:
-                        typer.echo(typer.style(f"  Added ({len(diff.added_nodes)}):", fg=typer.colors.GREEN))
+                        typer.echo(
+                            typer.style(
+                                f"  Added ({len(diff.added_nodes)}):", fg=typer.colors.GREEN
+                            )
+                        )
                         for node_id in sorted(diff.added_nodes.keys()):
                             typer.echo(typer.style(f"    + {node_id}", fg=typer.colors.GREEN))
 
                     # Show removed nodes
                     if diff.removed_nodes:
-                        typer.echo(typer.style(f"  Removed ({len(diff.removed_nodes)}):", fg=typer.colors.RED))
+                        typer.echo(
+                            typer.style(
+                                f"  Removed ({len(diff.removed_nodes)}):", fg=typer.colors.RED
+                            )
+                        )
                         for node_id in sorted(diff.removed_nodes.keys()):
                             typer.echo(typer.style(f"    - {node_id}", fg=typer.colors.RED))
 
                     # Show modified nodes
                     if diff.modified_nodes:
-                        typer.echo(typer.style(f"  Modified ({len(diff.modified_nodes)}):", fg=typer.colors.YELLOW))
+                        typer.echo(
+                            typer.style(
+                                f"  Modified ({len(diff.modified_nodes)}):", fg=typer.colors.YELLOW
+                            )
+                        )
                         for node_id in sorted(diff.modified_nodes.keys()):
                             change = diff.modified_nodes[node_id]
                             fields = ", ".join(change.changed_fields)
-                            typer.echo(typer.style(f"    ~ {node_id} ({fields})", fg=typer.colors.YELLOW))
+                            typer.echo(
+                                typer.style(f"    ~ {node_id} ({fields})", fg=typer.colors.YELLOW)
+                            )
 
                     # Show edge changes
                     if diff.added_edges:
-                        typer.echo(typer.style(f"  Added edges ({len(diff.added_edges)}):", fg=typer.colors.GREEN))
+                        typer.echo(
+                            typer.style(
+                                f"  Added edges ({len(diff.added_edges)}):", fg=typer.colors.GREEN
+                            )
+                        )
                         for edge in diff.added_edges:
-                            typer.echo(typer.style(f"    + {edge.from_node} -> {edge.to_node}", fg=typer.colors.GREEN))
+                            typer.echo(
+                                typer.style(
+                                    f"    + {edge.from_node} -> {edge.to_node}",
+                                    fg=typer.colors.GREEN,
+                                )
+                            )
 
                     if diff.removed_edges:
-                        typer.echo(typer.style(f"  Removed edges ({len(diff.removed_edges)}):", fg=typer.colors.RED))
+                        typer.echo(
+                            typer.style(
+                                f"  Removed edges ({len(diff.removed_edges)}):", fg=typer.colors.RED
+                            )
+                        )
                         for edge in diff.removed_edges:
-                            typer.echo(typer.style(f"    - {edge.from_node} -> {edge.to_node}", fg=typer.colors.RED))
+                            typer.echo(
+                                typer.style(
+                                    f"    - {edge.from_node} -> {edge.to_node}", fg=typer.colors.RED
+                                )
+                            )
 
                     typer.echo("")
                     typer.echo(f"Summary: {diff.summary()}")
@@ -3761,16 +3781,16 @@ def parse(
 def plan(
     env_name: Optional[str] = typer.Argument(
         None,
-        help="Environment name (optional). Without: show changes vs last run. With: create environment plan."
+        help="Environment name (optional). Without: show changes vs last run. With: create environment plan.",
     ),
     project_path: Path = typer.Option(".", help="Project directory"),
     tags: Optional[List[str]] = typer.Option(
-        None, "--tags",
-        help="Show only nodes with these tags (plus upstream deps). OR logic. Production mode only."
+        None,
+        "--tags",
+        help="Show only nodes with these tags (plus upstream deps). OR logic. Production mode only.",
     ),
     exclude_tags: Optional[List[str]] = typer.Option(
-        None, "--exclude-tags",
-        help="Hide nodes with these tags from the plan."
+        None, "--exclude-tags", help="Hide nodes with these tags from the plan."
     ),
 ):
     """Analyze changes and show execution plan.
@@ -3916,30 +3936,40 @@ def plan(
 
                 # Show edge changes
                 if diff.added_edges:
-                    typer.echo(typer.style(
-                        f"  Added edges ({len(diff.added_edges)}):", fg=typer.colors.GREEN
-                    ))
+                    typer.echo(
+                        typer.style(
+                            f"  Added edges ({len(diff.added_edges)}):", fg=typer.colors.GREEN
+                        )
+                    )
                     for edge in diff.added_edges:
-                        typer.echo(typer.style(
-                            f"    + {edge.from_node} -> {edge.to_node}", fg=typer.colors.GREEN
-                        ))
+                        typer.echo(
+                            typer.style(
+                                f"    + {edge.from_node} -> {edge.to_node}", fg=typer.colors.GREEN
+                            )
+                        )
 
                 if diff.removed_edges:
-                    typer.echo(typer.style(
-                        f"  Removed edges ({len(diff.removed_edges)}):", fg=typer.colors.RED
-                    ))
+                    typer.echo(
+                        typer.style(
+                            f"  Removed edges ({len(diff.removed_edges)}):", fg=typer.colors.RED
+                        )
+                    )
                     for edge in diff.removed_edges:
-                        typer.echo(typer.style(
-                            f"    - {edge.from_node} -> {edge.to_node}", fg=typer.colors.RED
-                        ))
+                        typer.echo(
+                            typer.style(
+                                f"    - {edge.from_node} -> {edge.to_node}", fg=typer.colors.RED
+                            )
+                        )
 
                 # Hint for detailed diff
                 if diff.modified_nodes:
                     typer.echo("")
-                    typer.echo(typer.style(
-                        "  Tip: Run 'seeknal diff <type>/<name>' for detailed YAML diff",
-                        fg=typer.colors.RESET,
-                    ))
+                    typer.echo(
+                        typer.style(
+                            "  Tip: Run 'seeknal diff <type>/<name>' for detailed YAML diff",
+                            fg=typer.colors.RESET,
+                        )
+                    )
             else:
                 _echo_info("No changes detected since last parse")
         else:
@@ -3982,14 +4012,12 @@ def plan(
         if tags and env_name is None:
             tag_set = set(tags)
             tag_matched = {
-                node_id for node_id in dag_builder.nodes
+                node_id
+                for node_id in dag_builder.nodes
                 if any(t in tag_set for t in dag_builder.nodes[node_id].tags)
             }
             if not tag_matched:
-                _echo_warning(
-                    f"No nodes found with tags: {', '.join(tags)}. "
-                    "Showing full plan."
-                )
+                _echo_warning(f"No nodes found with tags: {', '.join(tags)}. " "Showing full plan.")
             else:
                 # Auto-include all transitive upstream deps
                 with_upstream = set(tag_matched)
@@ -4001,12 +4029,14 @@ def plan(
             exclude_set = set(exclude_tags)
             if plan_filter_set is not None:
                 plan_filter_set = {
-                    node_id for node_id in plan_filter_set
+                    node_id
+                    for node_id in plan_filter_set
                     if not any(t in exclude_set for t in dag_builder.nodes[node_id].tags)
                 }
             else:
                 plan_filter_set = {
-                    node_id for node_id in dag_builder.nodes
+                    node_id
+                    for node_id in dag_builder.nodes
                     if not any(t in exclude_set for t in dag_builder.nodes[node_id].tags)
                 }
 
@@ -4113,20 +4143,27 @@ def diff_command(
         typer.echo("")
         if result.category:
             cat_labels = {
-                ChangeCategory.BREAKING: ("BREAKING (downstream rebuild required)", typer.colors.RED),
-                ChangeCategory.NON_BREAKING: ("NON_BREAKING (rebuild this node)", typer.colors.YELLOW),
+                ChangeCategory.BREAKING: (
+                    "BREAKING (downstream rebuild required)",
+                    typer.colors.RED,
+                ),
+                ChangeCategory.NON_BREAKING: (
+                    "NON_BREAKING (rebuild this node)",
+                    typer.colors.YELLOW,
+                ),
                 ChangeCategory.METADATA: ("METADATA (no rebuild needed)", typer.colors.BLUE),
             }
-            label, color = cat_labels.get(
-                result.category, ("UNKNOWN", typer.colors.RESET)
-            )
+            label, color = cat_labels.get(result.category, ("UNKNOWN", typer.colors.RESET))
             typer.echo(typer.style(f"  Category: {label}", fg=color, bold=True))
 
         if result.downstream_count > 0 and result.category == ChangeCategory.BREAKING:
-            typer.echo(typer.style(
-                f"  Impact: {result.downstream_count} downstream node(s) affected",
-                fg=typer.colors.YELLOW, bold=True,
-            ))
+            typer.echo(
+                typer.style(
+                    f"  Impact: {result.downstream_count} downstream node(s) affected",
+                    fg=typer.colors.YELLOW,
+                    bold=True,
+                )
+            )
             downstream = engine.get_downstream_nodes(result.node_id)
             for ds_id in downstream[:5]:
                 typer.echo(typer.style(f"    -> {ds_id}", fg=typer.colors.RED))
@@ -4159,7 +4196,9 @@ def diff_command(
             total_files = len(modified) + len(new) + len(deleted)
             total_ins = sum(r.insertions for r in modified)
             total_del = sum(r.deletions for r in modified)
-            typer.echo(f"  {total_files} file(s) changed, {total_ins} insertion(s), {total_del} deletion(s)")
+            typer.echo(
+                f"  {total_files} file(s) changed, {total_ins} insertion(s), {total_del} deletion(s)"
+            )
         else:
             # Summary mode
             typer.echo(typer.style("Changes since last apply:", bold=True))
@@ -4208,7 +4247,9 @@ def diff_command(
             py_files = list(py_dir.glob("*.py"))
             if py_files:
                 typer.echo("")
-                _echo_info(f"Note: {len(py_files)} Python pipeline file(s) found. Diff not yet supported for .py files.")
+                _echo_info(
+                    f"Note: {len(py_files)} Python pipeline file(s) found. Diff not yet supported for .py files."
+                )
 
 
 @app.command()
@@ -4230,28 +4271,30 @@ def promote(
 @app.command()
 def repl(
     profile: Optional[str] = typer.Option(
-        None, "--profile",
-        help="Path to profiles.yml for connections (default: ~/.seeknal/profiles.yml)"
+        None,
+        "--profile",
+        help="Path to profiles.yml for connections (default: ~/.seeknal/profiles.yml)",
     ),
     env: Optional[str] = typer.Option(
-        None, "--env",
-        help="Load data from a virtual environment (e.g., dev) instead of production"
+        None, "--env", help="Load data from a virtual environment (e.g., dev) instead of production"
     ),
     exec_sql: Optional[str] = typer.Option(
-        None, "--exec", "-e",
-        help="Execute SQL query and exit (non-interactive). Use '-' to read from stdin."
+        None,
+        "--exec",
+        "-e",
+        help="Execute SQL query and exit (non-interactive). Use '-' to read from stdin.",
     ),
     format: str = typer.Option(
-        "table", "--format", "-f",
-        help="Output format for --exec: table, json, csv"
+        "table", "--format", "-f", help="Output format for --exec: table, json, csv"
     ),
     output: Optional[str] = typer.Option(
-        None, "--output", "-o",
-        help="Export --exec results to file (format inferred from .csv, .json, .parquet)"
+        None,
+        "--output",
+        "-o",
+        help="Export --exec results to file (format inferred from .csv, .json, .parquet)",
     ),
     limit: Optional[int] = typer.Option(
-        None, "--limit",
-        help="Limit number of result rows for --exec"
+        None, "--limit", help="Limit number of result rows for --exec"
     ),
 ):
     """Start interactive SQL REPL or execute a one-shot query.
@@ -4302,8 +4345,7 @@ def repl(
         env_dir = project_path / "target" / "environments" / env
         if not env_dir.exists():
             _echo_error(
-                f"Environment '{env}' not found. "
-                f"Run 'seeknal env plan {env}' to create it."
+                f"Environment '{env}' not found. " f"Run 'seeknal env plan {env}' to create it."
             )
             raise typer.Exit(1)
 
@@ -4329,6 +4371,7 @@ def repl(
             raise typer.Exit(code=1)
         except Exception as e:
             from seeknal.db_utils import sanitize_error_message
+
             print(f"Error: {sanitize_error_message(str(e))}", file=sys.stderr)
             raise typer.Exit(code=1)
 
@@ -4414,12 +4457,19 @@ def _exec_export_to_file(columns: list, rows: list, output_path: str) -> None:
 
 @app.command()
 def draft(
-    node_type: str = typer.Argument(..., help="Node type (source, transform, feature-group, semantic-model, model, aggregation, rule, exposure)"),
+    node_type: str = typer.Argument(
+        ...,
+        help="Node type (source, transform, feature-group, semantic-model, model, aggregation, rule, exposure)",
+    ),
     name: str = typer.Argument(..., help="Node name"),
     description: Optional[str] = typer.Option(None, "--description", "-d", help="Node description"),
     force: bool = typer.Option(False, "--force", "-f", help="Overwrite existing draft file"),
-    python: bool = typer.Option(False, "--python", "-py", help="Generate Python file instead of YAML"),
-    deps: str = typer.Option("", "--deps", help="Comma-separated Python dependencies for PEP 723 header"),
+    python: bool = typer.Option(
+        False, "--python", "-py", help="Generate Python file instead of YAML"
+    ),
+    deps: str = typer.Option(
+        "", "--deps", help="Comma-separated Python dependencies for PEP 723 header"
+    ),
 ):
     """Generate template from Jinja2 template.
 
@@ -4457,8 +4507,12 @@ def draft(
 def dry_run(
     file_path: str = typer.Argument(..., help="Path to YAML or Python pipeline file"),
     limit: int = typer.Option(10, "--limit", "-l", help="Row limit for preview (default: 10)"),
-    timeout: int = typer.Option(30, "--timeout", "-t", help="Query timeout in seconds (default: 30)"),
-    schema_only: bool = typer.Option(False, "--schema-only", "-s", help="Validate schema only, skip execution"),
+    timeout: int = typer.Option(
+        30, "--timeout", "-t", help="Query timeout in seconds (default: 30)"
+    ),
+    schema_only: bool = typer.Option(
+        False, "--schema-only", "-s", help="Validate schema only, skip execution"
+    ),
 ):
     """Validate YAML/Python and preview execution.
 
@@ -4493,7 +4547,9 @@ def inspect(
         help="Node ID to inspect (e.g., 'source.products', 'transform.sales_enriched')",
     ),
     limit: int = typer.Option(10, "--limit", "-l", help="Row limit for preview"),
-    schema_only: bool = typer.Option(False, "--schema", "-s", help="Show schema (columns + types) only"),
+    schema_only: bool = typer.Option(
+        False, "--schema", "-s", help="Show schema (columns + types) only"
+    ),
     list_all: bool = typer.Option(False, "--list", help="List all available intermediate outputs"),
     project_path: Path = typer.Option(".", help="Project directory"),
 ):
@@ -4537,9 +4593,7 @@ def inspect(
         # Suggest available nodes
         intermediate_dir = target_path / "intermediate"
         if intermediate_dir.exists():
-            available = [
-                f.stem.replace("_", ".", 1) for f in intermediate_dir.glob("*.parquet")
-            ]
+            available = [f.stem.replace("_", ".", 1) for f in intermediate_dir.glob("*.parquet")]
             if available:
                 _echo_info(f"\n  Available nodes:")
                 for node in sorted(available):
@@ -4613,7 +4667,9 @@ def _inspect_list(target_path: Path):
 @app.command()
 def apply(
     file_path: str = typer.Argument(..., help="Path to YAML or Python pipeline file"),
-    force: bool = typer.Option(False, "--force", "-f", help="Overwrite existing file without prompt"),
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Overwrite existing file without prompt"
+    ),
     no_parse: bool = typer.Option(False, "--no-parse", help="Skip manifest regeneration"),
 ):
     """Apply file to production.
@@ -4686,6 +4742,7 @@ def apply(
         if target_path.resolve() != path.resolve():
             _echo_info(f"Moving file to {target_path}...")
             import shutil
+
             target_path.parent.mkdir(parents=True, exist_ok=True)
             shutil.move(str(path), str(target_path))
 
@@ -4695,6 +4752,7 @@ def apply(
 
         # Convert to list format for dry_run_command
         import sys
+
         sys.argv = ["seeknal", "dry-run", str(target_path)]
 
         # Run dry-run with schema-only mode
@@ -4818,7 +4876,7 @@ def audit(
         if node and view_name != node:
             continue
         try:
-            conn.execute(f'CREATE VIEW "{view_name}" AS SELECT * FROM read_parquet(\'{pf}\')')
+            conn.execute(f"CREATE VIEW \"{view_name}\" AS SELECT * FROM read_parquet('{pf}')")
         except Exception as e:
             _echo_warning(f"Could not load {view_name}: {e}")
 
@@ -4829,9 +4887,11 @@ def audit(
         raise typer.Exit(code=1)
 
     from seeknal.dag.manifest import Manifest
+
     manifest = Manifest.load(str(manifest_path))
 
     from seeknal.workflow.audits import parse_audits, AuditRunner
+
     runner = AuditRunner(conn)
     total_passed = 0
     total_failed = 0
@@ -4868,13 +4928,24 @@ def audit(
 @app.command()
 def query(
     metrics: str = typer.Option(..., help="Comma-separated metric names"),
-    dimensions: Optional[str] = typer.Option(None, help="Comma-separated dimensions (e.g. region,ordered_at__month)"),
+    dimensions: Optional[str] = typer.Option(
+        None, help="Comma-separated dimensions (e.g. region,ordered_at__month)"
+    ),
     filter: Optional[str] = typer.Option(None, "--filter", help="SQL filter expression"),
-    order_by: Optional[str] = typer.Option(None, "--order-by", help="Order by columns (prefix - for DESC)"),
+    order_by: Optional[str] = typer.Option(
+        None, "--order-by", help="Order by columns (prefix - for DESC)"
+    ),
     limit: int = typer.Option(100, help="Maximum rows to return"),
-    compile_only: bool = typer.Option(False, "--compile", help="Show generated SQL without executing"),
+    compile_only: bool = typer.Option(
+        False, "--compile", help="Show generated SQL without executing"
+    ),
     format: str = typer.Option("table", help="Output format: table, json, csv"),
-    output: Optional[str] = typer.Option(None, "--output", "-o", help="Export results to file (format inferred from extension: .csv, .json, .parquet)"),
+    output: Optional[str] = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Export results to file (format inferred from extension: .csv, .json, .parquet)",
+    ),
     project_path: str = typer.Option(".", help="Path to project directory"),
 ):
     """
@@ -4944,16 +5015,20 @@ def query(
     for sm in semantic_models:
         for measure in sm.measures:
             if measure.name not in seen_names:
-                metric_list.append(MetricModel(
-                    name=measure.name,
-                    type=MetricType.SIMPLE,
-                    description=measure.description,
-                    measure=measure.name,
-                ))
+                metric_list.append(
+                    MetricModel(
+                        name=measure.name,
+                        type=MetricType.SIMPLE,
+                        description=measure.description,
+                        measure=measure.name,
+                    )
+                )
                 seen_names.add(measure.name)
 
     if not metric_list:
-        _echo_error("No metrics or measures found. Define measures in seeknal/semantic_models/ or metrics in seeknal/metrics/")
+        _echo_error(
+            "No metrics or measures found. Define measures in seeknal/semantic_models/ or metrics in seeknal/metrics/"
+        )
         raise typer.Exit(code=1)
 
     # Build compiler
@@ -4985,6 +5060,7 @@ def query(
 
     # Execute on DuckDB
     import duckdb
+
     conn = duckdb.connect(":memory:")
 
     # Register tables from cached parquet files (target/cache/{kind}/{name}.parquet)
@@ -5006,7 +5082,9 @@ def query(
             parts = stem.split("_", 1)
             table_name = parts[1] if len(parts) > 1 else stem
             try:
-                conn.execute(f"CREATE OR REPLACE VIEW \"{table_name}\" AS SELECT * FROM read_parquet('{pf}')")
+                conn.execute(
+                    f"CREATE OR REPLACE VIEW \"{table_name}\" AS SELECT * FROM read_parquet('{pf}')"
+                )
             except Exception:
                 pass
 
@@ -5021,6 +5099,7 @@ def query(
     # Export to file if --output is specified
     if output:
         import pandas as pd
+
         df = pd.DataFrame(rows, columns=columns)
         out_path = P(output)
         ext = out_path.suffix.lower()
@@ -5043,6 +5122,7 @@ def query(
     elif format == "csv":
         import csv
         import io
+
         buf = io.StringIO()
         writer = csv.writer(buf)
         writer.writerow(columns)
@@ -5051,6 +5131,7 @@ def query(
     else:
         try:
             from tabulate import tabulate as tabfmt
+
             typer.echo(tabfmt(rows, headers=columns, tablefmt="simple"))
         except ImportError:
             # Fallback to simple formatting
@@ -5064,9 +5145,15 @@ def query(
 @app.command("deploy-metrics")
 def deploy_metrics(
     connection: str = typer.Option(..., help="StarRocks connection name or URL"),
-    dimensions: Optional[str] = typer.Option(None, help="Comma-separated dimensions to include in MVs"),
-    refresh_interval: str = typer.Option("1 DAY", help="MV refresh interval (e.g. '1 HOUR', '1 DAY')"),
-    drop_existing: bool = typer.Option(False, "--drop-existing", help="Drop and recreate existing MVs"),
+    dimensions: Optional[str] = typer.Option(
+        None, help="Comma-separated dimensions to include in MVs"
+    ),
+    refresh_interval: str = typer.Option(
+        "1 DAY", help="MV refresh interval (e.g. '1 HOUR', '1 DAY')"
+    ),
+    drop_existing: bool = typer.Option(
+        False, "--drop-existing", help="Drop and recreate existing MVs"
+    ),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show DDL without executing"),
     project_path: str = typer.Option(".", help="Path to project directory"),
 ):
@@ -5136,12 +5223,14 @@ def deploy_metrics(
     for sm in semantic_models:
         for measure in sm.measures:
             if measure.name not in seen_names:
-                metric_list.append(MetricModel(
-                    name=measure.name,
-                    type=MetricTypeModel.SIMPLE,
-                    description=measure.description,
-                    measure=measure.name,
-                ))
+                metric_list.append(
+                    MetricModel(
+                        name=measure.name,
+                        type=MetricTypeModel.SIMPLE,
+                        description=measure.description,
+                        measure=measure.name,
+                    )
+                )
                 seen_names.add(measure.name)
 
     if not metric_list:
@@ -5151,12 +5240,14 @@ def deploy_metrics(
     # Resolve connection config
     if connection.startswith("starrocks://"):
         from seeknal.connections.starrocks import parse_starrocks_url
+
         sr_config = parse_starrocks_url(connection)
         conn_config = sr_config.to_pymysql_kwargs()
     else:
         # Try loading from profiles
         try:
             from seeknal.workflow.materialization.profile_loader import ProfileLoader
+
             loader = ProfileLoader()
             conn_config = loader.load_starrocks_profile(connection)
         except Exception as e:
@@ -5178,7 +5269,9 @@ def deploy_metrics(
         for sm in semantic_models:
             if sm.default_time_dimension:
                 dim_list = [sm.default_time_dimension]
-                _echo_info(f"Auto-including dimension '{sm.default_time_dimension}' (required for StarRocks MV keys)")
+                _echo_info(
+                    f"Auto-including dimension '{sm.default_time_dimension}' (required for StarRocks MV keys)"
+                )
                 break
 
     deployer = MetricDeployer(compiler, conn_config)
@@ -5223,8 +5316,7 @@ def env_plan(
     env_name: str = typer.Argument(..., help="Environment name (e.g., dev, staging)"),
     project_path: Path = typer.Option(".", help="Project directory"),
     profile: Optional[str] = typer.Option(
-        None, "--profile",
-        help="Path to profiles.yml for source_defaults and connections"
+        None, "--profile", help="Path to profiles.yml for source_defaults and connections"
     ),
 ):
     """Preview changes in a virtual environment."""
@@ -5309,6 +5401,7 @@ def _resolve_env_profile(
 
     # Convention: ~/.seeknal/profiles-{env}.yml
     from seeknal.context import CONFIG_BASE_URL
+
     home_env_profile = Path(CONFIG_BASE_URL) / f"profiles-{env_name}.yml"
     if home_env_profile.exists():
         return home_env_profile
@@ -5392,6 +5485,7 @@ def _run_in_environment(
     copied_refs: set[str] = set()
     if refs_data:
         import shutil
+
         env_intermediate = env_dir / "intermediate"
         env_intermediate.mkdir(parents=True, exist_ok=True)
         for ref in refs_data.get("refs", []):
@@ -5417,7 +5511,11 @@ def _run_in_environment(
         while queue:
             nid = queue.pop()
             for up in manifest.get_upstream_nodes(nid):
-                if up not in nodes_to_execute and up not in copied_refs and up not in missing_upstream:
+                if (
+                    up not in nodes_to_execute
+                    and up not in copied_refs
+                    and up not in missing_upstream
+                ):
                     missing_upstream.add(up)
                     queue.append(up)
         nodes_to_execute = nodes_to_execute | missing_upstream
@@ -5454,6 +5552,7 @@ def _run_in_environment(
     else:
         # Sequential execution
         import time as _time
+
         successful = 0
         failed = 0
         order = runner._get_topological_order()
@@ -5488,17 +5587,14 @@ def _run_in_environment(
     env_state_path = env_dir / "run_state.json"
     if not env_state_path.exists():
         import json
+
         with open(env_state_path, "w") as f:
             json.dump({"applied": True, "env_name": env_name}, f)
 
     if failed > 0:
-        _echo_warning(
-            f"Environment '{env_name}' applied with {failed} failure(s)."
-        )
+        _echo_warning(f"Environment '{env_name}' applied with {failed} failure(s).")
     else:
-        _echo_success(
-            f"Environment '{env_name}' applied successfully."
-        )
+        _echo_success(f"Environment '{env_name}' applied successfully.")
 
 
 @env_app.command("apply")
@@ -5508,12 +5604,15 @@ def env_apply(
     force: bool = typer.Option(False, help="Apply even if plan is stale"),
     parallel: bool = typer.Option(False, "--parallel", help="Run nodes in parallel"),
     max_workers: int = typer.Option(4, "--max-workers", help="Max parallel workers"),
-    continue_on_error: bool = typer.Option(False, "--continue-on-error", help="Continue past failures"),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Show what would execute without running"),
+    continue_on_error: bool = typer.Option(
+        False, "--continue-on-error", help="Continue past failures"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Show what would execute without running"
+    ),
     project_path: Path = typer.Option(".", help="Project directory"),
     profile: Optional[str] = typer.Option(
-        None, "--profile",
-        help="Path to profiles.yml for source_defaults and connections"
+        None, "--profile", help="Path to profiles.yml for source_defaults and connections"
     ),
 ):
     """Execute a plan in a virtual environment.
@@ -5558,7 +5657,8 @@ def _promote_environment(
 
     # Run dry_run first to get diff analysis (warnings, changed files)
     preview = manager.promote(
-        from_env, to_env,
+        from_env,
+        to_env,
         rematerialize=rematerialize,
         profile_path=profile_path,
         dry_run=True,
@@ -5617,7 +5717,8 @@ def _promote_environment(
     )
 
     result = manager.promote(
-        from_env, to_env,
+        from_env,
+        to_env,
         rematerialize=rematerialize,
         profile_path=profile_path,
     )
@@ -5669,19 +5770,23 @@ def env_promote(
     from_env: str = typer.Argument(..., help="Source environment"),
     to_env: str = typer.Argument("prod", help="Target (default: prod)"),
     project_path: Path = typer.Option(".", help="Project directory"),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Show what would be promoted without executing"),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Show what would be promoted without executing"
+    ),
     profile: Optional[str] = typer.Option(
-        None, "--profile",
-        help="Path to profiles.yml for re-materialization connections"
+        None, "--profile", help="Path to profiles.yml for re-materialization connections"
     ),
     rematerialize: bool = typer.Option(
-        False, "--rematerialize",
-        help="Re-execute materialization targets with production credentials after promotion"
+        False,
+        "--rematerialize",
+        help="Re-execute materialization targets with production credentials after promotion",
     ),
 ):
     """Promote environment to production."""
     _promote_environment(
-        from_env, to_env, project_path,
+        from_env,
+        to_env,
+        project_path,
         dry_run=dry_run,
         profile=profile,
         rematerialize=rematerialize,
@@ -5716,7 +5821,8 @@ def env_list(
 
         status = "applied" if applied else ("planned" if plan_exists else "created")
         status_color = (
-            typer.colors.GREEN if applied
+            typer.colors.GREEN
+            if applied
             else (typer.colors.BLUE if plan_exists else typer.colors.YELLOW)
         )
 
@@ -5757,13 +5863,9 @@ def env_delete(
 @app.command("download-sample-data")
 def download_sample_data(
     output_dir: Path = typer.Option(
-        Path("data/sample"), "--output-dir", "-o",
-        help="Output directory for sample data files"
+        Path("data/sample"), "--output-dir", "-o", help="Output directory for sample data files"
     ),
-    force: bool = typer.Option(
-        False, "--force", "-f",
-        help="Overwrite existing sample data files"
-    ),
+    force: bool = typer.Option(False, "--force", "-f", help="Overwrite existing sample data files"),
 ):
     """Download sample e-commerce datasets for tutorials and testing.
 
@@ -5796,17 +5898,19 @@ def download_sample_data(
 
     # Get the package data directory
     from importlib.resources import files
+
     try:
         # Try Python 3.9+ style first
-        sample_data_dir = files('seeknal.docs.data.sample')
+        sample_data_dir = files("seeknal.docs.data.sample")
     except (TypeError, AttributeError):
         # Fallback for older Python versions
         import os
+
         package_dir = Path(__file__).parent.parent
-        sample_data_dir = package_dir / 'docs' / 'data' / 'sample'
+        sample_data_dir = package_dir / "docs" / "data" / "sample"
 
     # Check if source sample data exists
-    source_files = ['customers.csv', 'products.csv', 'orders.csv', 'sales.csv']
+    source_files = ["customers.csv", "products.csv", "orders.csv", "sales.csv"]
     missing_files = [f for f in source_files if not (sample_data_dir / f).exists()]
 
     if missing_files:
@@ -5865,16 +5969,14 @@ def download_sample_data(
 # Interval Management Commands
 # =============================================================================
 
+
 @intervals_app.command("list")
 def intervals_list(
     node_id: str = typer.Argument(
-        ...,
-        help="Node identifier (e.g., transform.clean_data, feature_group.user_features)"
+        ..., help="Node identifier (e.g., transform.clean_data, feature_group.user_features)"
     ),
     output_format: OutputFormat = typer.Option(
-        OutputFormat.TABLE,
-        "--output", "-o",
-        help="Output format"
+        OutputFormat.TABLE, "--output", "-o", help="Output format"
     ),
 ):
     """List completed intervals for a node.
@@ -5920,6 +6022,7 @@ def intervals_list(
 
     elif output_format == OutputFormat.JSON:
         import json
+
         data = {
             "node_id": node_id,
             "completed_intervals": node_state.completed_intervals,
@@ -5931,17 +6034,18 @@ def intervals_list(
 @intervals_app.command("pending")
 def intervals_pending(
     node_id: str = typer.Argument(
-        ...,
-        help="Node identifier (e.g., transform.clean_data, feature_group.user_features)"
+        ..., help="Node identifier (e.g., transform.clean_data, feature_group.user_features)"
     ),
     start: str = typer.Option(
         ...,
-        "--start", "-s",
+        "--start",
+        "-s",
         help="Start date (YYYY-MM-DD or ISO timestamp)",
     ),
     end: Optional[str] = typer.Option(
         None,
-        "--end", "-e",
+        "--end",
+        "-e",
         help="End date (YYYY-MM-DD or ISO timestamp). Defaults to next scheduled run.",
     ),
     schedule: str = typer.Option(
@@ -6004,18 +6108,17 @@ def intervals_pending(
 # Restatement subcommands - use add subcommand pattern
 @intervals_app.command("restatement-add")
 def restatement_add(
-    node_id: str = typer.Argument(
-        ...,
-        help="Node identifier"
-    ),
+    node_id: str = typer.Argument(..., help="Node identifier"),
     start: str = typer.Option(
         ...,
-        "--start", "-s",
+        "--start",
+        "-s",
         help="Start date (YYYY-MM-DD or ISO timestamp)",
     ),
     end: str = typer.Option(
         ...,
-        "--end", "-e",
+        "--end",
+        "-e",
         help="End date (YYYY-MM-DD or ISO timestamp)",
     ),
 ):
@@ -6058,10 +6161,7 @@ def restatement_add(
 
 @intervals_app.command("restatement-list")
 def restatement_list(
-    node_id: str = typer.Argument(
-        ...,
-        help="Node identifier"
-    ),
+    node_id: str = typer.Argument(..., help="Node identifier"),
 ):
     """List restatement intervals for a node.
 
@@ -6101,10 +6201,7 @@ def restatement_list(
 
 @intervals_app.command("restatement-clear")
 def restatement_clear(
-    node_id: str = typer.Argument(
-        ...,
-        help="Node identifier"
-    ),
+    node_id: str = typer.Argument(..., help="Node identifier"),
 ):
     """Clear all restatement intervals for a node.
 
@@ -6138,18 +6235,17 @@ def restatement_clear(
 
 @intervals_app.command("backfill")
 def intervals_backfill(
-    node_id: str = typer.Argument(
-        ...,
-        help="Node identifier to backfill"
-    ),
+    node_id: str = typer.Argument(..., help="Node identifier to backfill"),
     start: str = typer.Option(
         ...,
-        "--start", "-s",
+        "--start",
+        "-s",
         help="Start date (YYYY-MM-DD or ISO timestamp)",
     ),
     end: str = typer.Option(
         ...,
-        "--end", "-e",
+        "--end",
+        "-e",
         help="End date (YYYY-MM-DD or ISO timestamp)",
     ),
     schedule: str = typer.Option(
@@ -6221,7 +6317,9 @@ def intervals_backfill(
 
 @app.command()
 def migrate_state(
-    backend: str = typer.Option(..., "--backend", "-b", help="Target backend type (file, database)"),
+    backend: str = typer.Option(
+        ..., "--backend", "-b", help="Target backend type (file, database)"
+    ),
     project_path: Path = typer.Option(".", help="Project directory"),
     dry_run: bool = typer.Option(True, help="Preview changes without executing"),
 ):
@@ -6295,7 +6393,7 @@ def migrate_state(
                 status=run_info.status,
                 started_at=run_info.started_at,
                 finished_at=run_info.finished_at,
-                metadata=run_info.metadata or {}
+                metadata=run_info.metadata or {},
             )
 
         # Migrate all node states
@@ -6331,6 +6429,7 @@ def migrate_state(
         project_file = project_path / "seeknal_project.yml"
         if project_file.exists():
             import yaml
+
             with open(project_file) as f:
                 config = yaml.safe_load(f)
             config["state_backend"] = "database"
@@ -6356,32 +6455,22 @@ def lineage(
         None, help="Node to focus on (e.g., transform.clean_orders)"
     ),
     column: Optional[str] = typer.Option(
-        None, "--column", "-c",
-        help="Column to trace lineage for (requires node argument)"
+        None, "--column", "-c", help="Column to trace lineage for (requires node argument)"
     ),
-    project: str = typer.Option(
-        None, "--project", "-p", help="Project name"
-    ),
-    path: Path = typer.Option(
-        Path("."), "--path", help="Project path"
-    ),
+    project: str = typer.Option(None, "--project", "-p", help="Project name"),
+    path: Path = typer.Option(Path("."), "--path", help="Project path"),
     output: Path = typer.Option(
-        None, "--output", "-o",
-        help="Output HTML file path (default: target/lineage.html)"
+        None, "--output", "-o", help="Output HTML file path (default: target/lineage.html)"
     ),
-    no_open: bool = typer.Option(
-        False, "--no-open", help="Don't auto-open browser"
-    ),
+    no_open: bool = typer.Option(False, "--no-open", help="Don't auto-open browser"),
     ascii_output: bool = typer.Option(
         False, "--ascii", help="Print DAG as ASCII tree to stdout instead of HTML"
     ),
     tags: Optional[List[str]] = typer.Option(
-        None, "--tags",
-        help="Show only nodes with these tags (plus upstream deps). OR logic."
+        None, "--tags", help="Show only nodes with these tags (plus upstream deps). OR logic."
     ),
     exclude_tags: Optional[List[str]] = typer.Option(
-        None, "--exclude-tags",
-        help="Hide nodes with these tags from the lineage."
+        None, "--exclude-tags", help="Hide nodes with these tags from the lineage."
     ),
 ):
     """Generate interactive lineage visualization.
@@ -6428,7 +6517,8 @@ def lineage(
             if tags:
                 tag_set = set(tags)
                 tag_matched = {
-                    nid for nid, node in manifest.nodes.items()
+                    nid
+                    for nid, node in manifest.nodes.items()
                     if any(t in tag_set for t in node.tags)
                 }
                 if not tag_matched:
@@ -6438,6 +6528,7 @@ def lineage(
                 # Auto-include all transitive upstream deps via BFS
                 keep_ids = set(tag_matched)
                 from collections import deque
+
                 queue = deque(tag_matched)
                 while queue:
                     current = queue.popleft()
@@ -6450,12 +6541,14 @@ def lineage(
                 exclude_set = set(exclude_tags)
                 if keep_ids is not None:
                     keep_ids = {
-                        nid for nid in keep_ids
+                        nid
+                        for nid in keep_ids
                         if not any(t in exclude_set for t in manifest.nodes[nid].tags)
                     }
                 else:
                     keep_ids = {
-                        nid for nid, node in manifest.nodes.items()
+                        nid
+                        for nid, node in manifest.nodes.items()
                         if not any(t in exclude_set for t in node.tags)
                     }
 
@@ -6472,6 +6565,7 @@ def lineage(
 
         if ascii_output:
             from seeknal.dag.visualize import render_ascii_tree  # ty: ignore[unresolved-import]
+
             tree_text = render_ascii_tree(manifest, focus_node=node_id)
             typer.echo(tree_text)
             return
@@ -6492,26 +6586,15 @@ def lineage(
         raise typer.Exit(code=1)
 
 
-
-
 @app.command()
 def dq(
-    node_id: Optional[str] = typer.Argument(
-        None, help="Focus on a specific profile or rule node"
-    ),
-    project: str = typer.Option(
-        None, "--project", "-p", help="Project name"
-    ),
-    path: Path = typer.Option(
-        Path("."), "--path", help="Project path"
-    ),
+    node_id: Optional[str] = typer.Argument(None, help="Focus on a specific profile or rule node"),
+    project: str = typer.Option(None, "--project", "-p", help="Project name"),
+    path: Path = typer.Option(Path("."), "--path", help="Project path"),
     output: Path = typer.Option(
-        None, "--output", "-o",
-        help="Output HTML file path (default: target/dq_report.html)"
+        None, "--output", "-o", help="Output HTML file path (default: target/dq_report.html)"
     ),
-    no_open: bool = typer.Option(
-        False, "--no-open", help="Don't auto-open browser"
-    ),
+    no_open: bool = typer.Option(False, "--no-open", help="Don't auto-open browser"),
     ascii_output: bool = typer.Option(
         False, "--ascii", help="Print ASCII report to stdout instead of HTML"
     ),
@@ -6527,7 +6610,8 @@ def dq(
     """
     from seeknal.workflow.dag import DAGBuilder, CycleDetectedError, MissingDependencyError
     from seeknal.dag.dq import (
-        DQDataBuilder, DQVisualizationError,
+        DQDataBuilder,
+        DQVisualizationError,
         render_dq_ascii as _render_dq_ascii,
         generate_dq_html as _generate_dq_html,
     )
@@ -6555,6 +6639,7 @@ def dq(
         state = load_state(state_path)
         if state is None:
             from seeknal.workflow.state import RunState
+
             state = RunState()
             _echo_warning("No run state found. Run 'seeknal run' first for DQ data.")
 
@@ -6587,12 +6672,8 @@ def dq(
 
 @entity_app.command("list")
 def entity_list(
-    project: str = typer.Option(
-        None, "--project", "-p", help="Project name"
-    ),
-    path: Path = typer.Option(
-        Path("."), "--path", help="Project path"
-    ),
+    project: str = typer.Option(None, "--project", "-p", help="Project name"),
+    path: Path = typer.Option(Path("."), "--path", help="Project path"),
 ):
     """List all consolidated entities in the feature store.
 
@@ -6607,7 +6688,9 @@ def entity_list(
 
     feature_store_path = path / "target" / "feature_store"
     if not feature_store_path.exists():
-        _echo_info("No consolidated entities found. Run 'seeknal run' with feature group nodes first.")
+        _echo_info(
+            "No consolidated entities found. Run 'seeknal run' with feature group nodes first."
+        )
         return
 
     entities_found = False
@@ -6621,9 +6704,7 @@ def entity_list(
 
         entities_found = True
         fg_count = len(catalog.feature_groups)
-        total_features = sum(
-            len(fg.features) for fg in catalog.feature_groups.values()
-        )
+        total_features = sum(len(fg.features) for fg in catalog.feature_groups.values())
         parquet_exists = (entity_dir / "features.parquet").exists()
         status = "ready" if parquet_exists else "stale"
 
@@ -6635,18 +6716,16 @@ def entity_list(
         )
 
     if not entities_found:
-        _echo_info("No consolidated entities found. Run 'seeknal run' with feature group nodes first.")
+        _echo_info(
+            "No consolidated entities found. Run 'seeknal run' with feature group nodes first."
+        )
 
 
 @entity_app.command("show")
 def entity_show(
     name: str = typer.Argument(..., help="Entity name to inspect"),
-    project: str = typer.Option(
-        None, "--project", "-p", help="Project name"
-    ),
-    path: Path = typer.Option(
-        Path("."), "--path", help="Project path"
-    ),
+    project: str = typer.Option(None, "--project", "-p", help="Project name"),
+    path: Path = typer.Option(Path("."), "--path", help="Project path"),
 ):
     """Display detailed catalog for a consolidated entity.
 
@@ -6691,12 +6770,8 @@ def entity_show(
 
 @app.command()
 def consolidate(
-    project: str = typer.Option(
-        None, "--project", "-p", help="Project name"
-    ),
-    path: Path = typer.Option(
-        Path("."), "--path", help="Project path"
-    ),
+    project: str = typer.Option(None, "--project", "-p", help="Project name"),
+    path: Path = typer.Option(Path("."), "--path", help="Project path"),
     prune: bool = typer.Option(
         False, "--prune", help="Remove stale FG columns not in current manifest"
     ),

--- a/src/seeknal/integrations/atlas_governance.py
+++ b/src/seeknal/integrations/atlas_governance.py
@@ -22,10 +22,14 @@ single Atlas configuration drives both surfaces.
 
 from __future__ import annotations
 
+import base64
+import binascii
 import getpass
+import json
 import os
 import re
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
 
 import httpx
@@ -47,6 +51,10 @@ __all__ = [
     "referenced_tables",
     "mask_value",
     "MASK_TOKEN",
+    "credentials_path",
+    "user_token_from_credentials",
+    "user_sub_from_credentials",
+    "user_email_from_credentials",
 ]
 
 #: Replacement rendered for a fully masked value.
@@ -63,6 +71,125 @@ def _fail_open_default() -> bool:
     """
 
     return os.getenv("ATLAS_FAIL_OPEN", "").strip().lower() in _TRUTHY
+
+
+#: Default location of the seeknal credentials file written by the login flow.
+_DEFAULT_CREDENTIALS_PATH = "~/.config/seeknal/credentials.json"
+
+
+def credentials_path() -> Path:
+    """Return the resolved path to the seeknal credentials file.
+
+    Honours the ``SEEKNAL_CREDENTIALS_PATH`` environment override, falling back to
+    ``~/.config/seeknal/credentials.json``. The file holds the JSON written by the
+    login flow (``access_token``, ``refresh_token``, ...); this function does not
+    require the file to exist.
+    """
+
+    override = os.getenv("SEEKNAL_CREDENTIALS_PATH", "").strip()
+    raw = override or _DEFAULT_CREDENTIALS_PATH
+    return Path(raw).expanduser()
+
+
+def _read_credentials() -> dict[str, Any] | None:
+    """Load the credentials JSON, returning ``None`` if absent or invalid.
+
+    Never raises: a missing file, unreadable file, or malformed JSON all yield
+    ``None`` so callers can treat "logged out" and "broken creds" uniformly.
+    """
+
+    path = credentials_path()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return None
+    try:
+        data = json.loads(text)
+    except (ValueError, TypeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _user_token_from_credentials() -> str | None:
+    """Return the stored ``access_token`` from the credentials file, or ``None``.
+
+    Used by :func:`create_governance_gate_from_env` so per-user identity flows to
+    Atlas once the user has logged in. Returns ``None`` (never raises) when the
+    credentials file is missing, malformed, or carries no usable token.
+    """
+
+    creds = _read_credentials()
+    if not creds:
+        return None
+    token = creds.get("access_token")
+    if isinstance(token, str) and token.strip():
+        return token
+    return None
+
+
+#: Public alias for reuse by the CLI; mirrors the private gate-side reader.
+user_token_from_credentials = _user_token_from_credentials
+
+
+def _decode_jwt_payload(token: str) -> dict[str, Any] | None:
+    """Base64url-decode a JWT's payload segment into a dict.
+
+    No signature verification is performed — the Atlas backend validates the token;
+    this only needs to read claims locally. Returns ``None`` (never raises) when the
+    token is not a well-formed three-segment JWT or the payload is not a JSON object.
+    """
+
+    if not isinstance(token, str):
+        return None
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    segment = parts[1]
+    padding = "=" * (-len(segment) % 4)
+    try:
+        raw = base64.urlsafe_b64decode(segment + padding)
+        payload = json.loads(raw)
+    except (ValueError, TypeError, binascii.Error):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def user_sub_from_credentials() -> str | None:
+    """Return the ``sub`` claim of the stored access token, or ``None``.
+
+    Reads the credentials file, base64url-decodes the JWT payload (no signature
+    check), and extracts the ``sub`` claim. Returns ``None`` (never raises) when the
+    file is absent/invalid, the token is not a JWT, or no ``sub`` claim is present.
+    """
+
+    token = _user_token_from_credentials()
+    if not token:
+        return None
+    payload = _decode_jwt_payload(token)
+    if not payload:
+        return None
+    sub = payload.get("sub")
+    return sub if isinstance(sub, str) and sub else None
+
+
+def user_email_from_credentials() -> str | None:
+    """Return the caller's email from the stored access token, or ``None``.
+
+    Prefers the ``email`` claim, falling back to ``preferred_username``. Returns
+    ``None`` (never raises) when no usable identity claim is available.
+    """
+
+    token = _user_token_from_credentials()
+    if not token:
+        return None
+    payload = _decode_jwt_payload(token)
+    if not payload:
+        return None
+    for claim in ("email", "preferred_username"):
+        value = payload.get(claim)
+        if isinstance(value, str) and value:
+            return value
+    return None
 
 
 @dataclass(frozen=True)
@@ -93,7 +220,9 @@ def create_governance_gate_from_env() -> "GovernanceGate | None":
         return None
 
     timeout = float(os.getenv("ATLAS_API_TIMEOUT_SECONDS", "10"))
-    token = os.getenv("ATLAS_API_TOKEN")
+    # An explicit service token wins; otherwise fall back to the logged-in user's
+    # token so per-user identity flows to Atlas. Both absent → token stays ``None``.
+    token = os.getenv("ATLAS_API_TOKEN") or _user_token_from_credentials()
     config = AtlasContractConfig(
         base_url=base_url.rstrip("/"),
         token=token,

--- a/src/seeknal/integrations/atlas_governance.py
+++ b/src/seeknal/integrations/atlas_governance.py
@@ -1,0 +1,366 @@
+"""Runtime data-access governance gate, active only when Atlas is configured.
+
+This extends the apply-time contract gate in :mod:`seeknal.integrations.atlas_client`
+to *runtime* data access. When ``ATLAS_API_URL`` is set, Seeknal delegates every
+governed read to the Atlas policy backend (OpenFGA-backed): Atlas decides whether
+the caller may read a resource and which columns must be masked. The rules live in
+Atlas — not in editable local YAML — so a project author cannot loosen governance
+by editing a file.
+
+Two deliberate properties:
+
+* **Config-activated.** With no ``ATLAS_API_URL`` the gate is inactive and reads pass
+  through unchanged (full backward compatibility). Governance turns on exactly when
+  the operator configures the Atlas setup.
+* **Fail-closed.** When the gate *is* active, a denied decision or a transport error
+  results in *denied* access (unless ``ATLAS_FAIL_OPEN`` is explicitly set). Governance
+  cannot be bypassed by breaking the connection to Atlas.
+
+The gate reuses the connection settings and error types of the apply-time client so a
+single Atlas configuration drives both surfaces.
+"""
+
+from __future__ import annotations
+
+import getpass
+import os
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Sequence
+
+import httpx
+
+from seeknal.integrations.atlas_client import (
+    AtlasContractConfig,
+    AtlasContractError,
+    AtlasPolicyDenied,
+)
+
+__all__ = [
+    "AccessDecision",
+    "GovernanceGate",
+    "create_governance_gate_from_env",
+    "apply_column_masks",
+    "mask_rows",
+    "govern_read",
+    "mask_value",
+    "MASK_TOKEN",
+]
+
+#: Replacement rendered for a fully masked value.
+MASK_TOKEN = "******"
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _fail_open_default() -> bool:
+    """Return whether the gate should fail *open* on transport errors.
+
+    Defaults to ``False`` (fail-closed). Set ``ATLAS_FAIL_OPEN=true`` only in
+    environments where availability must win over enforcement.
+    """
+
+    return os.getenv("ATLAS_FAIL_OPEN", "").strip().lower() in _TRUTHY
+
+
+@dataclass(frozen=True)
+class AccessDecision:
+    """Outcome of an Atlas access check for a single resource."""
+
+    allowed: bool
+    reason: str = ""
+    masked_columns: tuple[str, ...] = ()
+    classification: str = "internal"
+
+    @property
+    def has_masking(self) -> bool:
+        """``True`` when Atlas requires one or more columns to be masked."""
+
+        return bool(self.masked_columns)
+
+
+def create_governance_gate_from_env() -> "GovernanceGate | None":
+    """Build a gate only when Atlas access enforcement is configured.
+
+    Returns ``None`` when ``ATLAS_API_URL`` is unset, signalling that governance is
+    inactive and callers should pass data through unchanged.
+    """
+
+    base_url = os.getenv("ATLAS_API_URL", "").strip()
+    if not base_url:
+        return None
+
+    timeout = float(os.getenv("ATLAS_API_TIMEOUT_SECONDS", "10"))
+    token = os.getenv("ATLAS_API_TOKEN")
+    config = AtlasContractConfig(
+        base_url=base_url.rstrip("/"),
+        token=token,
+        timeout_seconds=timeout,
+    )
+    return GovernanceGate(config)
+
+
+def mask_value(value: Any, *, keep: int = 0) -> Any:
+    """Mask a single cell value, optionally preserving a leading prefix.
+
+    ``None`` is preserved (a null stays null). With ``keep > 0`` the first ``keep``
+    characters of the stringified value are retained and the remainder replaced with
+    :data:`MASK_TOKEN` (e.g. ``keep=6`` turns ``"3201011234567"`` into ``"320101******"``).
+    """
+
+    if value is None:
+        return None
+    if keep <= 0:
+        return MASK_TOKEN
+    text = str(value)
+    if len(text) <= keep:
+        return text
+    return f"{text[:keep]}{MASK_TOKEN}"
+
+
+def apply_column_masks(
+    rows: Iterable[Mapping[str, Any]],
+    masked_columns: Sequence[str],
+    *,
+    keep: int = 0,
+) -> list[dict[str, Any]]:
+    """Return a masked copy of ``rows`` with ``masked_columns`` redacted.
+
+    Operates on a sequence of row mappings (the lowest-common-denominator shape across
+    DuckDB/Spark result rows). Columns not present in a row are ignored; non-masked
+    columns are copied verbatim. The input is never mutated.
+    """
+
+    masked_set = set(masked_columns)
+    if not masked_set:
+        return [dict(row) for row in rows]
+
+    result: list[dict[str, Any]] = []
+    for row in rows:
+        new_row = dict(row)
+        for column in masked_set:
+            if column in new_row:
+                new_row[column] = mask_value(new_row[column], keep=keep)
+        result.append(new_row)
+    return result
+
+
+def mask_rows(
+    columns: Sequence[str],
+    rows: Iterable[Sequence[Any]],
+    masked_columns: Sequence[str],
+    *,
+    keep: int = 0,
+) -> list[tuple[Any, ...]]:
+    """Mask positional (``columns``, ``rows``) results — the ``execute_oneshot`` shape.
+
+    ``columns`` are the column names aligned to each row tuple. Masked columns not
+    present in ``columns`` are ignored. Returns new row tuples; inputs are not mutated.
+    """
+
+    target_indices = [index for index, name in enumerate(columns) if name in set(masked_columns)]
+    if not target_indices:
+        return [tuple(row) for row in rows]
+
+    result: list[tuple[Any, ...]] = []
+    for row in rows:
+        new_row = list(row)
+        for index in target_indices:
+            if index < len(new_row):
+                new_row[index] = mask_value(new_row[index], keep=keep)
+        result.append(tuple(new_row))
+    return result
+
+
+def govern_read(
+    gate: "GovernanceGate | None",
+    *,
+    resource: str,
+    columns: Sequence[str],
+    rows: Iterable[Sequence[Any]],
+    action: str = "read",
+    actor: str | None = None,
+    keep: int = 0,
+) -> list[tuple[Any, ...]]:
+    """Apply runtime governance to a positional read result.
+
+    The single chokepoint a read call site needs:
+
+    * ``gate is None`` (Atlas not configured) → rows pass through unchanged.
+    * otherwise the read is access-checked via :meth:`GovernanceGate.enforce_access`
+      (raising :class:`~seeknal.integrations.atlas_client.AtlasPolicyDenied` on deny),
+      then any columns Atlas marks sensitive are masked.
+
+    Returns the (possibly masked) rows as tuples.
+    """
+
+    if gate is None:
+        return [tuple(row) for row in rows]
+    decision = gate.enforce_access(resource=resource, action=action, actor=actor)
+    return mask_rows(columns, rows, decision.masked_columns, keep=keep)
+
+
+class GovernanceGate:
+    """Delegates runtime access decisions and masking to the Atlas backend.
+
+    Construct via :func:`create_governance_gate_from_env`. Pass an explicit
+    ``client`` (e.g. backed by :class:`httpx.MockTransport`) in tests.
+    """
+
+    def __init__(
+        self,
+        config: AtlasContractConfig,
+        *,
+        fail_open: bool | None = None,
+        client: httpx.Client | None = None,
+    ) -> None:
+        self.config = config
+        self._fail_open = _fail_open_default() if fail_open is None else fail_open
+        self._client = client
+
+    @property
+    def fail_open(self) -> bool:
+        """Whether the gate allows access when Atlas is unreachable (default: False)."""
+
+        return self._fail_open
+
+    # -- HTTP plumbing -------------------------------------------------------
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.config.token:
+            headers["Authorization"] = f"Bearer {self.config.token}"
+        return headers
+
+    def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        url = f"{self.config.base_url}{path}"
+        try:
+            if self._client is not None:
+                response = self._client.post(url, json=payload, headers=self._headers())
+            else:
+                response = httpx.post(
+                    url,
+                    json=payload,
+                    headers=self._headers(),
+                    timeout=self.config.timeout_seconds,
+                )
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as exc:
+            message = exc.response.text.strip() or str(exc)
+            raise AtlasContractError(
+                f"Atlas governance request failed for {path}: {message}"
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise AtlasContractError(f"Atlas governance request failed for {path}: {exc}") from exc
+
+    # -- Public API ----------------------------------------------------------
+
+    def check_access(
+        self,
+        *,
+        resource: str,
+        action: str = "read",
+        actor: str | None = None,
+        classification: str | None = None,
+    ) -> AccessDecision:
+        """Ask Atlas whether ``actor`` may ``action`` ``resource``.
+
+        On a transport error the result honours the fail-open/closed policy: a
+        fail-closed gate (the default) returns a *denied* decision rather than
+        propagating the error, so callers uniformly act on :class:`AccessDecision`.
+        """
+
+        resolved_actor = actor or os.getenv("ATLAS_ACTOR") or getpass.getuser()
+        payload: dict[str, Any] = {
+            "operation": "access-check",
+            "resource": resource,
+            "action": action,
+            "actor": resolved_actor,
+        }
+        if classification:
+            payload["classification"] = classification
+
+        try:
+            decision = self._post("/api/contracts/access-check", payload)
+        except AtlasContractError as exc:
+            if self._fail_open:
+                return AccessDecision(
+                    allowed=True,
+                    reason=f"fail-open: Atlas unreachable ({exc})",
+                )
+            return AccessDecision(
+                allowed=False,
+                reason=f"fail-closed: Atlas unreachable ({exc})",
+            )
+
+        masked = decision.get("masked_columns") or []
+        masked_columns = tuple(str(column) for column in masked if column)
+        return AccessDecision(
+            allowed=bool(decision.get("allowed", False)),
+            reason=str(decision.get("reason", "")),
+            masked_columns=masked_columns,
+            classification=str(decision.get("classification", classification or "internal")),
+        )
+
+    def enforce_access(
+        self,
+        *,
+        resource: str,
+        action: str = "read",
+        actor: str | None = None,
+        classification: str | None = None,
+    ) -> AccessDecision:
+        """Like :meth:`check_access` but raise :class:`AtlasPolicyDenied` on deny.
+
+        Returns the :class:`AccessDecision` (carrying any required masking) when
+        access is allowed. Emits a best-effort audit event for the denial.
+        """
+
+        decision = self.check_access(
+            resource=resource,
+            action=action,
+            actor=actor,
+            classification=classification,
+        )
+        if not decision.allowed:
+            self.audit(
+                action=action,
+                resource=resource,
+                actor=actor,
+                status="denied",
+                details={"reason": decision.reason},
+            )
+            raise AtlasPolicyDenied(decision.reason or f"Atlas denied {action} on {resource}")
+        return decision
+
+    def audit(
+        self,
+        *,
+        action: str,
+        resource: str,
+        actor: str | None = None,
+        status: str = "success",
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        """Record a best-effort audit event. Never raises.
+
+        Audit is advisory from the engine's perspective — the authoritative, immutable
+        record lives in Atlas. A failure to log must not break a governed read.
+        """
+
+        resolved_actor = actor or os.getenv("ATLAS_ACTOR") or getpass.getuser()
+        payload: dict[str, Any] = {
+            "operation": "access",
+            "action": action,
+            "resource": resource,
+            "actor": resolved_actor,
+            "status": status,
+            "project_name": os.getenv("SEEKNAL_PROJECT_NAME", ""),
+            "environment": os.getenv("ATLAS_ENVIRONMENT", os.getenv("SEEKNAL_ENV", "dev")),
+        }
+        if details:
+            payload["details"] = details
+        try:
+            self._post("/api/contracts/runs/report", payload)
+        except AtlasContractError:
+            pass

--- a/src/seeknal/integrations/atlas_governance.py
+++ b/src/seeknal/integrations/atlas_governance.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import getpass
 import os
+import re
 from dataclasses import dataclass
 from typing import Any, Iterable, Mapping, Sequence
 
@@ -42,6 +43,8 @@ __all__ = [
     "apply_column_masks",
     "mask_rows",
     "govern_read",
+    "govern_query",
+    "referenced_tables",
     "mask_value",
     "MASK_TOKEN",
 ]
@@ -197,6 +200,63 @@ def govern_read(
         return [tuple(row) for row in rows]
     decision = gate.enforce_access(resource=resource, action=action, actor=actor)
     return mask_rows(columns, rows, decision.masked_columns, keep=keep)
+
+
+_FROM_JOIN_RE = re.compile(r"\b(?:FROM|JOIN)\s+([\"`\w.]+)", re.IGNORECASE)
+_WITH_CTE_RE = re.compile(r"\b(\w+)\s+AS\s*\(", re.IGNORECASE)
+
+
+def referenced_tables(sql: str) -> list[str]:
+    """Best-effort extraction of base table identifiers referenced by a query.
+
+    Returns ``FROM``/``JOIN`` targets (surrounding quotes stripped), excluding
+    names defined as CTEs in a ``WITH`` clause. This is a heuristic used to scope
+    governance checks — Atlas remains the authority, so over- or under-identifying
+    a table only changes which resources are checked, not whether Atlas enforces.
+    """
+
+    ctes = {name.lower() for name in _WITH_CTE_RE.findall(sql)}
+    tables: list[str] = []
+    seen: set[str] = set()
+    for raw in _FROM_JOIN_RE.findall(sql):
+        name = raw.strip('"`')
+        key = name.lower()
+        if not name or key in ctes or key in seen:
+            continue
+        seen.add(key)
+        tables.append(name)
+    return tables
+
+
+def govern_query(
+    gate: "GovernanceGate | None",
+    *,
+    sql: str,
+    columns: Sequence[str],
+    rows: Iterable[Sequence[Any]],
+    actor: str | None = None,
+    keep: int = 0,
+) -> list[tuple[Any, ...]]:
+    """Govern an ad-hoc SQL read: access-check referenced tables, then mask columns.
+
+    * ``gate is None`` → rows pass through unchanged.
+    * otherwise each base table referenced by ``sql`` is access-checked via
+      :meth:`GovernanceGate.enforce_access` (raising
+      :class:`~seeknal.integrations.atlas_client.AtlasPolicyDenied` on the first
+      deny), and the union of columns Atlas marks sensitive across those tables is
+      masked in the result.
+
+    A tableless query (no ``FROM``/``JOIN``) reads no governed resource and passes
+    through unchanged.
+    """
+
+    if gate is None:
+        return [tuple(row) for row in rows]
+    masked: set[str] = set()
+    for table in referenced_tables(sql):
+        decision = gate.enforce_access(resource=table, action="read", actor=actor)
+        masked.update(decision.masked_columns)
+    return mask_rows(columns, rows, tuple(masked), keep=keep)
 
 
 class GovernanceGate:

--- a/src/seeknal/sources/config.py
+++ b/src/seeknal/sources/config.py
@@ -801,6 +801,22 @@ def _preview_table(
 ) -> str:
     try:
         columns, rows = repl.execute_oneshot(f"SELECT * FROM {qualified}", limit=limit)
+        # Runtime governance: when Atlas is configured (ATLAS_API_URL), enforce read
+        # access on the table and mask sensitive columns before sample rows are
+        # persisted into the Ask context. Inactive when Atlas is not configured. A
+        # denial raises AtlasPolicyDenied, which degrades below to "Preview
+        # unavailable" so no governed rows leak into context.
+        from seeknal.integrations.atlas_governance import (
+            create_governance_gate_from_env,
+            govern_read,
+        )
+
+        rows = govern_read(
+            create_governance_gate_from_env(),
+            resource=qualified,
+            columns=columns,
+            rows=rows,
+        )
     except Exception as exc:  # noqa: BLE001 - sync should continue
         return f"# Preview for {qualified}\n\nPreview unavailable: {exc}\n"
 

--- a/tests/ask/test_memory.py
+++ b/tests/ask/test_memory.py
@@ -83,7 +83,14 @@ class TestMemoryAgentConfiguration:
 
             call_kwargs = mock_create.call_args[1]
             processors = call_kwargs["history_processors"]
-            assert len(processors) == 2
+            # auto_summarization defaults OFF (since 2.9.7), so the default agent
+            # ships exactly the always-on ensure_trailing_model_request safety-net
+            # processor. The summarization processors are added only when
+            # auto_summarization is enabled.
+            from seeknal.ask.processors import ensure_trailing_model_request
+
+            assert len(processors) == 1
+            assert processors[-1] is ensure_trailing_model_request
 
     def test_seeknal_directory_created(self, tmp_path):
         """Verify .seeknal/ directory is created."""

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -1,0 +1,253 @@
+"""
+Tests for the ``seeknal auth`` command group.
+
+These cover the pure, testable PKCE/OIDC helpers (no network, no browser, no live
+loopback) plus the ``status`` and ``logout`` commands via ``CliRunner`` against a
+temporary credentials file. ``webbrowser.open`` and the local loopback server are
+mocked; the live redirect round-trip is intentionally not exercised here.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from typing import Any
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from seeknal.cli import auth as auth_module
+from seeknal.cli.main import app
+
+runner = CliRunner()
+
+
+# -- PKCE / URL / token-exchange helpers ------------------------------------
+
+
+def test_pkce_pair_s256_relationship() -> None:
+    verifier, challenge = auth_module._pkce_pair()
+
+    # Verifier is non-trivial and URL-safe (no '=' padding, no '+'/'/').
+    assert len(verifier) >= 43
+    assert "=" not in verifier and "+" not in verifier and "/" not in verifier
+
+    # Challenge is base64url(SHA256(verifier)) with padding stripped.
+    expected = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest())
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    assert challenge == expected
+    assert "=" not in challenge
+
+    # Distinct invocations produce distinct verifiers.
+    other_verifier, _ = auth_module._pkce_pair()
+    assert other_verifier != verifier
+
+
+def test_build_authorize_url_carries_pkce_and_flow_params() -> None:
+    endpoints = {
+        "authorization_endpoint": "http://localhost:8080/realms/atlas/protocol/openid-connect/auth",
+        "token_endpoint": "http://localhost:8080/realms/atlas/protocol/openid-connect/token",
+    }
+    url = auth_module._build_authorize_url(
+        endpoints,
+        client_id="seeknal-cli",
+        redirect_uri="http://127.0.0.1:8765/callback",
+        code_challenge="abc123",
+        state="state-xyz",
+    )
+
+    assert url.startswith(endpoints["authorization_endpoint"] + "?")
+    from urllib.parse import parse_qs, urlparse
+
+    query = parse_qs(urlparse(url).query)
+    assert query["response_type"] == ["code"]
+    assert query["client_id"] == ["seeknal-cli"]
+    assert query["code_challenge"] == ["abc123"]
+    assert query["code_challenge_method"] == ["S256"]
+    assert query["redirect_uri"] == ["http://127.0.0.1:8765/callback"]
+    assert query["state"] == ["state-xyz"]
+
+
+def test_exchange_code_posts_pkce_and_returns_tokens() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["body"] = request.content.decode("utf-8")
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "at-1",
+                "refresh_token": "rt-1",
+                "expires_in": 300,
+                "refresh_expires_in": 1800,
+            },
+        )
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    tokens = auth_module._exchange_code(
+        "http://localhost:8080/realms/atlas/protocol/openid-connect/token",
+        code="the-code",
+        code_verifier="the-verifier",
+        client_id="seeknal-cli",
+        redirect_uri="http://127.0.0.1:8765/callback",
+        client=client,
+    )
+
+    assert tokens["access_token"] == "at-1"
+    assert tokens["refresh_token"] == "rt-1"
+
+    # PKCE verifier + authorization_code grant are sent; public client (no secret).
+    from urllib.parse import parse_qs
+
+    sent = parse_qs(captured["body"])
+    assert sent["grant_type"] == ["authorization_code"]
+    assert sent["code"] == ["the-code"]
+    assert sent["code_verifier"] == ["the-verifier"]
+    assert sent["client_id"] == ["seeknal-cli"]
+    assert "client_secret" not in sent
+
+
+def test_write_credentials_to_tmp_path(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    creds = tmp_path / "nested" / "credentials.json"
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(creds))
+
+    path = auth_module._write_credentials(
+        {
+            "access_token": "at-1",
+            "refresh_token": "rt-1",
+            "expires_in": 300,
+            "refresh_expires_in": 1800,
+            "extra_ignored": "x",
+        }
+    )
+
+    assert path == creds
+    data = json.loads(creds.read_text(encoding="utf-8"))
+    assert data == {
+        "access_token": "at-1",
+        "refresh_token": "rt-1",
+        "expires_in": 300,
+        "refresh_expires_in": 1800,
+    }
+    # File written 0600 (owner read/write only).
+    assert (creds.stat().st_mode & 0o777) == 0o600
+
+
+# -- status / logout via CliRunner ------------------------------------------
+
+
+def _unsigned_jwt(payload: dict[str, Any]) -> str:
+    """Build an unsigned-but-decodable JWT for ``user_*_from_credentials`` to read."""
+
+    def seg(obj: dict[str, Any]) -> str:
+        raw = json.dumps(obj).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+    return f"{seg({'alg': 'none'})}.{seg(payload)}.sig"
+
+
+def _write_creds_file(tmp_path, monkeypatch: pytest.MonkeyPatch, *, sub: str, email: str) -> None:
+    token = _unsigned_jwt({"sub": sub, "email": email})
+    creds = tmp_path / "credentials.json"
+    creds.write_text(json.dumps({"access_token": token}), encoding="utf-8")
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(creds))
+
+
+def test_status_authenticated(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_creds_file(tmp_path, monkeypatch, sub="user-123", email="alice@example.com")
+
+    result = runner.invoke(app, ["auth", "status"])
+
+    assert result.exit_code == 0, result.output
+    assert "user-123" in result.output
+    assert "alice@example.com" in result.output
+
+
+def test_status_not_authenticated_exits_1(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(tmp_path / "missing.json"))
+
+    result = runner.invoke(app, ["auth", "status"])
+
+    assert result.exit_code == 1
+    assert "no" in result.output.lower()
+
+
+def test_logout_removes_credentials(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    creds = tmp_path / "credentials.json"
+    creds.write_text(json.dumps({"access_token": "at"}), encoding="utf-8")
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(creds))
+
+    result = runner.invoke(app, ["auth", "logout"])
+
+    assert result.exit_code == 0, result.output
+    assert not creds.exists()
+
+
+def test_logout_when_missing_is_noop(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(tmp_path / "missing.json"))
+
+    result = runner.invoke(app, ["auth", "logout"])
+
+    assert result.exit_code == 0, result.output
+
+
+def test_login_no_browser_prints_url_and_writes_credentials(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    creds = tmp_path / "credentials.json"
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(creds))
+
+    # A real token so the success line can echo the decoded email.
+    access_token = _unsigned_jwt({"sub": "user-9", "email": "bob@example.com"})
+
+    monkeypatch.setattr(
+        auth_module,
+        "_discover_endpoints",
+        lambda issuer, client=None: {
+            "authorization_endpoint": "http://kc/auth",
+            "token_endpoint": "http://kc/token",
+        },
+    )
+    captured_state: dict[str, Any] = {}
+
+    def fake_capture(port: int, **kwargs: Any) -> dict[str, Any]:
+        # Echo back the state generated inside login() by reading the authorize URL.
+        return {"code": "auth-code", "state": captured_state["state"], "error": None}
+
+    def fake_build_url(endpoints, *, state: str, **kwargs: Any) -> str:
+        captured_state["state"] = state
+        return "http://kc/auth?state=" + state
+
+    monkeypatch.setattr(auth_module, "_build_authorize_url", fake_build_url)
+    monkeypatch.setattr(auth_module, "_capture_authorization_code", fake_capture)
+    monkeypatch.setattr(
+        auth_module,
+        "_exchange_code",
+        lambda token_endpoint, **kwargs: {
+            "access_token": access_token,
+            "refresh_token": "rt",
+            "expires_in": 300,
+            "refresh_expires_in": 1800,
+        },
+    )
+
+    opened: list[str] = []
+    monkeypatch.setattr(auth_module.webbrowser, "open", lambda url: opened.append(url))
+
+    result = runner.invoke(app, ["auth", "login", "--no-browser"])
+
+    assert result.exit_code == 0, result.output
+    # --no-browser: URL printed, browser not opened.
+    assert opened == []
+    assert "http://kc/auth" in result.output
+    assert "bob@example.com" in result.output
+
+    data = json.loads(creds.read_text(encoding="utf-8"))
+    assert data["access_token"] == access_token
+    assert data["refresh_token"] == "rt"

--- a/tests/cli/test_gov.py
+++ b/tests/cli/test_gov.py
@@ -1,0 +1,164 @@
+"""
+Tests for ``seeknal gov request-access``.
+
+These exercise the CLI command in isolation by monkeypatching ``httpx.post`` so no
+network call is made. The behaviours under test: the POST body carries the expected
+keys, the created request id is printed on a 201, and a non-2xx response exits 1.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from seeknal.cli import gov as gov_module
+from seeknal.cli.main import app
+
+runner = CliRunner()
+
+
+def _captured_post(
+    captured: dict[str, Any],
+    *,
+    status_code: int,
+    json_body: dict[str, Any] | None = None,
+    text: str = "",
+):
+    """Build a fake ``httpx.post`` that records its call and returns a canned response."""
+
+    def fake_post(url: str, *, json: dict[str, Any], headers: dict[str, str], timeout: float):
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        request = httpx.Request("POST", url)
+        if json_body is not None:
+            return httpx.Response(status_code, json=json_body, request=request)
+        return httpx.Response(status_code, text=text, request=request)
+
+    return fake_post
+
+
+def test_request_access_posts_expected_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SEEKNAL_API_URL", "https://atlas.example.com")
+    monkeypatch.delenv("ATLAS_API_URL", raising=False)
+    monkeypatch.setattr(gov_module, "user_email_from_credentials", lambda: "alice@example.com")
+    monkeypatch.setattr(gov_module, "user_token_from_credentials", lambda: "tok-123")
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        _captured_post(
+            captured,
+            status_code=201,
+            json_body={"id": "AR-7", "status": "pending"},
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "gov",
+            "request-access",
+            "warehouse.namespace.table",
+            "--reason",
+            "need it for the Q3 model",
+            "--access",
+            "read",
+            "--duration",
+            "90d",
+            "--priority",
+            "medium",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["url"] == "https://atlas.example.com/governance/access-requests"
+    body = captured["json"]
+    assert body == {
+        "requester": "alice@example.com",
+        "entityName": "warehouse.namespace.table",
+        "entityUrn": "",
+        "requestedAccess": "read",
+        "reason": "need it for the Q3 model",
+        "duration": "90d",
+        "priority": "medium",
+        "type": "dataset",
+    }
+    assert captured["headers"]["Authorization"] == "Bearer tok-123"
+    assert "AR-7" in result.output
+
+
+def test_request_access_includes_urn_when_given(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SEEKNAL_API_URL", "https://atlas.example.com")
+    monkeypatch.setattr(gov_module, "user_email_from_credentials", lambda: "bob@example.com")
+    monkeypatch.setattr(gov_module, "user_token_from_credentials", lambda: None)
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        _captured_post(captured, status_code=201, json_body={"id": "AR-9", "status": "pending"}),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "gov",
+            "request-access",
+            "prod.gold.customer",
+            "--reason",
+            "audit",
+            "--urn",
+            "urn:li:dataset:(x,prod.gold.customer,PROD)",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["json"]["entityUrn"] == "urn:li:dataset:(x,prod.gold.customer,PROD)"
+    # No credentials token → no Authorization header.
+    assert "Authorization" not in captured["headers"]
+
+
+def test_request_access_non_2xx_exits_1(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SEEKNAL_API_URL", "https://atlas.example.com")
+    monkeypatch.setattr(gov_module, "user_email_from_credentials", lambda: "alice@example.com")
+    monkeypatch.setattr(gov_module, "user_token_from_credentials", lambda: None)
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        _captured_post(captured, status_code=403, text="forbidden"),
+    )
+
+    result = runner.invoke(
+        app,
+        ["gov", "request-access", "prod.gold.finance", "--reason", "nope"],
+    )
+
+    assert result.exit_code == 1
+    assert "403" in result.output
+
+
+def test_request_access_transport_error_exits_1(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SEEKNAL_API_URL", "https://atlas.example.com")
+    monkeypatch.setattr(gov_module, "user_email_from_credentials", lambda: "alice@example.com")
+    monkeypatch.setattr(gov_module, "user_token_from_credentials", lambda: None)
+
+    def boom(url: str, *, json: dict[str, Any], headers: dict[str, str], timeout: float):
+        raise httpx.ConnectError("atlas down", request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx, "post", boom)
+
+    result = runner.invoke(
+        app,
+        ["gov", "request-access", "prod.gold.finance", "--reason", "x"],
+    )
+
+    assert result.exit_code == 1

--- a/tests/cli/test_run_governance.py
+++ b/tests/cli/test_run_governance.py
@@ -1,0 +1,157 @@
+"""
+Tests for the Atlas pre-run access enforcement hooked into ``seeknal run``.
+
+These exercise the enforcement at the hook level (``_enforce_pre_run``) and the pure
+``_source_fqtn`` resolver -- no data is materialized and no DAG is built. A fake gate
+stands in for the live Atlas backend, and ``create_governance_gate_from_env`` is
+monkeypatched on ``seeknal.cli.main`` so the gate-None / deny / allow paths are
+covered without ATLAS_API_URL or a network.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from seeknal.cli import main as main_module
+from seeknal.dag.manifest import NodeType
+from seeknal.integrations.atlas_client import AtlasPolicyDenied
+
+
+class _FakeNode:
+    """Minimal stand-in for a DAG node exposing ``config`` and ``node_type``."""
+
+    def __init__(self, node_type: NodeType, config: dict[str, Any]) -> None:
+        self.node_type = node_type
+        self.kind = node_type
+        self.config = config
+
+
+class _FakeDAG:
+    """Minimal stand-in for the DAG builder exposing ``nodes`` by id."""
+
+    def __init__(self, nodes: dict[str, _FakeNode]) -> None:
+        self.nodes = nodes
+
+
+class _FakeGate:
+    """Records ``enforce_access`` calls; optionally denies a named resource."""
+
+    def __init__(self, deny: str | None = None) -> None:
+        self.deny = deny
+        self.calls: list[dict[str, Any]] = []
+
+    def enforce_access(self, *, resource: str, action: str, actor: str | None) -> Any:
+        self.calls.append({"resource": resource, "action": action, "actor": actor})
+        if self.deny is not None and resource == self.deny:
+            raise AtlasPolicyDenied(f"denied {action} on {resource}")
+        return object()
+
+
+# -- _source_fqtn ------------------------------------------------------------
+
+
+def test_source_fqtn_iceberg_three_part_table_used_verbatim() -> None:
+    node = _FakeNode(
+        NodeType.SOURCE,
+        {"source": "iceberg", "table": "atlas.qa_iceberg.signal_events"},
+    )
+    assert main_module._source_fqtn(node) == "atlas.qa_iceberg.signal_events"
+
+
+def test_source_fqtn_prepends_warehouse_from_params() -> None:
+    node = _FakeNode(
+        NodeType.SOURCE,
+        {"source": "iceberg", "table": "qa.events", "params": {"warehouse": "seeknal-warehouse"}},
+    )
+    assert main_module._source_fqtn(node) == "seeknal-warehouse.qa.events"
+
+
+def test_source_fqtn_postgresql_schema_table_fallback() -> None:
+    # No warehouse/catalog context -> most-qualified string available is returned.
+    node = _FakeNode(
+        NodeType.SOURCE,
+        {"source": "postgresql", "table": "public.events", "params": {"connection": "pg"}},
+    )
+    assert main_module._source_fqtn(node) == "public.events"
+
+
+def test_source_fqtn_none_when_no_table() -> None:
+    node = _FakeNode(NodeType.SOURCE, {"source": "csv"})
+    assert main_module._source_fqtn(node) is None
+    node_empty = _FakeNode(NodeType.SOURCE, {"source": "csv", "table": "  "})
+    assert main_module._source_fqtn(node_empty) is None
+
+
+# -- _enforce_pre_run --------------------------------------------------------
+
+
+def test_gate_none_skips_enforcement(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A gate that would explode if used -- proves None short-circuits.
+    sentinel = _FakeGate()
+    dag = _FakeDAG(
+        {"source.a": _FakeNode(NodeType.SOURCE, {"source": "iceberg", "table": "w.n.a"})}
+    )
+    # gate is None => no calls.
+    main_module._enforce_pre_run({"source.a"}, dag, None)
+    assert sentinel.calls == []
+
+
+def test_gate_allows_checks_only_sources(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(main_module, "user_sub_from_credentials", lambda: "user-1", raising=False)
+    dag = _FakeDAG(
+        {
+            "source.a": _FakeNode(NodeType.SOURCE, {"source": "iceberg", "table": "w.n.a"}),
+            "transform.b": _FakeNode(NodeType.TRANSFORM, {"transform": "SELECT 1"}),
+        }
+    )
+    gate = _FakeGate()
+
+    main_module._enforce_pre_run({"source.a", "transform.b"}, dag, gate)
+
+    # Only the source node was access-checked, with action=read.
+    assert len(gate.calls) == 1
+    assert gate.calls[0]["resource"] == "w.n.a"
+    assert gate.calls[0]["action"] == "read"
+
+
+def test_gate_denies_aborts_with_request_access_hint(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import typer
+
+    monkeypatch.setattr(main_module, "user_sub_from_credentials", lambda: "user-1", raising=False)
+    dag = _FakeDAG(
+        {"source.secret": _FakeNode(NodeType.SOURCE, {"source": "iceberg", "table": "w.n.secret"})}
+    )
+    gate = _FakeGate(deny="w.n.secret")
+
+    with pytest.raises(typer.Exit) as excinfo:
+        main_module._enforce_pre_run({"source.secret"}, dag, gate)
+
+    assert excinfo.value.exit_code == 1
+    out = capsys.readouterr().out
+    assert "request-access" in out
+    assert "w.n.secret" in out
+
+
+# -- run() integration at the enforcement boundary ---------------------------
+
+
+def test_run_proceeds_when_gate_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """gate None => the factory returns None and enforcement is a no-op."""
+
+    called = {"enforced": False}
+
+    def fake_enforce(nodes_to_run, dag_builder, gate):
+        called["enforced"] = True
+        assert gate is None
+
+    monkeypatch.setattr(main_module, "create_governance_gate_from_env", lambda: None)
+    monkeypatch.setattr(main_module, "_enforce_pre_run", fake_enforce)
+
+    # Call the hook the way run() does.
+    gate = main_module.create_governance_gate_from_env()
+    main_module._enforce_pre_run({"source.a"}, _FakeDAG({}), gate)
+    assert called["enforced"] is True

--- a/tests/integrations/test_atlas_governance.py
+++ b/tests/integrations/test_atlas_governance.py
@@ -1,0 +1,288 @@
+"""Tests for the runtime Atlas governance gate.
+
+These exercise the gate in isolation using an injected ``httpx.MockTransport`` so no
+real Atlas backend is required. The behaviours under test are the ones that make the
+gate trustworthy: it is inactive unless configured, it delegates decisions to Atlas,
+it is fail-closed by default, and audit logging can never break a read.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import httpx
+import pytest
+
+from seeknal.integrations.atlas_client import AtlasContractConfig, AtlasPolicyDenied
+from seeknal.integrations.atlas_governance import (
+    MASK_TOKEN,
+    AccessDecision,
+    GovernanceGate,
+    apply_column_masks,
+    create_governance_gate_from_env,
+    govern_read,
+    mask_rows,
+    mask_value,
+)
+
+BASE_URL = "http://atlas.test"
+
+
+def _gate(
+    handler: Callable[[httpx.Request], httpx.Response],
+    *,
+    fail_open: bool = False,
+) -> GovernanceGate:
+    """Build a gate whose HTTP calls are served by ``handler`` via MockTransport."""
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    config = AtlasContractConfig(base_url=BASE_URL, token="t0ken", timeout_seconds=5.0)
+    return GovernanceGate(config, fail_open=fail_open, client=client)
+
+
+# ---------------------------------------------------------------------------
+# Activation
+# ---------------------------------------------------------------------------
+
+
+def test_gate_inactive_without_atlas_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ATLAS_API_URL", raising=False)
+    assert create_governance_gate_from_env() is None
+
+
+def test_gate_active_when_atlas_url_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAS_API_URL", "https://atlas.example.com/")
+    monkeypatch.setenv("ATLAS_API_TOKEN", "abc")
+    gate = create_governance_gate_from_env()
+    assert isinstance(gate, GovernanceGate)
+    # trailing slash trimmed
+    assert gate.config.base_url == "https://atlas.example.com"
+    assert gate.config.token == "abc"
+
+
+# ---------------------------------------------------------------------------
+# check_access / enforce_access
+# ---------------------------------------------------------------------------
+
+
+def test_check_access_allowed() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/contracts/access-check"
+        assert request.headers["Authorization"] == "Bearer t0ken"
+        return httpx.Response(200, json={"allowed": True, "classification": "internal"})
+
+    decision = _gate(handler).check_access(resource="prod.gold.sales", actor="alice")
+    assert decision == AccessDecision(
+        allowed=True, reason="", masked_columns=(), classification="internal"
+    )
+    assert decision.has_masking is False
+
+
+def test_check_access_denied_with_reason() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"allowed": False, "reason": "no grant"})
+
+    decision = _gate(handler).check_access(resource="prod.gold.finance", actor="bob")
+    assert decision.allowed is False
+    assert decision.reason == "no grant"
+
+
+def test_check_access_returns_masked_columns() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "allowed": True,
+                "masked_columns": ["nik", "npwp"],
+                "classification": "restricted",
+            },
+        )
+
+    decision = _gate(handler).check_access(resource="prod.gold.customer", actor="carol")
+    assert decision.allowed is True
+    assert decision.masked_columns == ("nik", "npwp")
+    assert decision.classification == "restricted"
+    assert decision.has_masking is True
+
+
+def test_enforce_access_returns_decision_when_allowed() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"allowed": True, "masked_columns": ["nik"]})
+
+    decision = _gate(handler).enforce_access(resource="prod.gold.customer", actor="carol")
+    assert decision.allowed is True
+    assert decision.masked_columns == ("nik",)
+
+
+def test_enforce_access_raises_when_denied() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/contracts/access-check":
+            return httpx.Response(200, json={"allowed": False, "reason": "denied by policy"})
+        return httpx.Response(200, json={})  # audit endpoint
+
+    with pytest.raises(AtlasPolicyDenied, match="denied by policy"):
+        _gate(handler).enforce_access(resource="prod.gold.finance", actor="bob")
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed / fail-open on transport errors
+# ---------------------------------------------------------------------------
+
+
+def test_fail_closed_on_transport_error_by_default() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("atlas down", request=request)
+
+    decision = _gate(handler).check_access(resource="prod.gold.sales")
+    assert decision.allowed is False
+    assert "fail-closed" in decision.reason
+
+
+def test_enforce_access_raises_when_atlas_unreachable() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("atlas down", request=request)
+
+    with pytest.raises(AtlasPolicyDenied):
+        _gate(handler).enforce_access(resource="prod.gold.sales")
+
+
+def test_fail_open_when_explicitly_enabled() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("atlas down", request=request)
+
+    decision = _gate(handler, fail_open=True).check_access(resource="prod.gold.sales")
+    assert decision.allowed is True
+    assert "fail-open" in decision.reason
+
+
+def test_server_5xx_is_fail_closed() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="unavailable")
+
+    decision = _gate(handler).check_access(resource="prod.gold.sales")
+    assert decision.allowed is False
+
+
+# ---------------------------------------------------------------------------
+# Audit never raises
+# ---------------------------------------------------------------------------
+
+
+def test_audit_never_raises_on_server_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    # Must not raise.
+    assert _gate(handler).audit(action="read", resource="prod.gold.sales", status="success") is None
+
+
+def test_audit_never_raises_on_connect_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("atlas down", request=request)
+
+    assert _gate(handler).audit(action="read", resource="prod.gold.sales") is None
+
+
+# ---------------------------------------------------------------------------
+# Pure masking helpers
+# ---------------------------------------------------------------------------
+
+
+def test_mask_value_variants() -> None:
+    assert mask_value(None) is None
+    assert mask_value("3201011234567") == MASK_TOKEN
+    assert mask_value("3201011234567", keep=6) == f"320101{MASK_TOKEN}"
+    # value shorter than keep is returned unchanged
+    assert mask_value("ab", keep=6) == "ab"
+    assert mask_value(12345, keep=0) == MASK_TOKEN
+
+
+def test_apply_column_masks_redacts_only_listed_columns() -> None:
+    rows = [
+        {"customer_id": "C-001", "nik": "3201011234567", "arpu": 152000},
+        {"customer_id": "C-002", "nik": "3273010000000", "arpu": 98000},
+    ]
+    masked = apply_column_masks(rows, ["nik"], keep=6)
+    assert masked == [
+        {"customer_id": "C-001", "nik": f"320101{MASK_TOKEN}", "arpu": 152000},
+        {"customer_id": "C-002", "nik": f"327301{MASK_TOKEN}", "arpu": 98000},
+    ]
+    # original rows untouched
+    assert rows[0]["nik"] == "3201011234567"
+
+
+def test_apply_column_masks_no_columns_is_passthrough_copy() -> None:
+    rows = [{"a": 1, "b": 2}]
+    out = apply_column_masks(rows, [])
+    assert out == rows
+    assert out is not rows
+    assert out[0] is not rows[0]
+
+
+def test_apply_column_masks_ignores_absent_columns() -> None:
+    rows = [{"a": 1}]
+    out = apply_column_masks(rows, ["nik"], keep=4)
+    assert out == [{"a": 1}]
+
+
+# ---------------------------------------------------------------------------
+# Positional masking (execute_oneshot shape) + govern_read
+# ---------------------------------------------------------------------------
+
+
+def test_mask_rows_masks_named_columns() -> None:
+    columns = ["customer_id", "nik", "arpu"]
+    rows = [("C-001", "3201011234567", 152000), ("C-002", "3273010000000", 98000)]
+    out = mask_rows(columns, rows, ["nik"], keep=6)
+    assert out == [
+        ("C-001", f"320101{MASK_TOKEN}", 152000),
+        ("C-002", f"327301{MASK_TOKEN}", 98000),
+    ]
+    # input not mutated
+    assert rows[0] == ("C-001", "3201011234567", 152000)
+
+
+def test_mask_rows_ignores_absent_and_empty() -> None:
+    columns = ["a", "b"]
+    rows = [(1, 2)]
+    assert mask_rows(columns, rows, []) == [(1, 2)]
+    assert mask_rows(columns, rows, ["nik"]) == [(1, 2)]
+
+
+def test_mask_rows_preserves_none() -> None:
+    assert mask_rows(["nik"], [(None,)], ["nik"], keep=4) == [(None,)]
+
+
+def test_govern_read_passthrough_when_gate_none() -> None:
+    rows = [("3201011234567",)]
+    out = govern_read(None, resource="prod.t", columns=["nik"], rows=rows)
+    assert out == [("3201011234567",)]
+
+
+def test_govern_read_masks_when_allowed() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"allowed": True, "masked_columns": ["nik"]})
+
+    out = govern_read(
+        _gate(handler),
+        resource="prod.gold.customer",
+        columns=["customer_id", "nik"],
+        rows=[("C-001", "3201011234567")],
+        keep=6,
+    )
+    assert out == [("C-001", f"320101{MASK_TOKEN}")]
+
+
+def test_govern_read_raises_when_denied() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/contracts/access-check":
+            return httpx.Response(200, json={"allowed": False, "reason": "no grant"})
+        return httpx.Response(200, json={})
+
+    with pytest.raises(AtlasPolicyDenied):
+        govern_read(
+            _gate(handler),
+            resource="prod.gold.finance",
+            columns=["x"],
+            rows=[("v",)],
+        )

--- a/tests/integrations/test_atlas_governance.py
+++ b/tests/integrations/test_atlas_governance.py
@@ -20,9 +20,11 @@ from seeknal.integrations.atlas_governance import (
     GovernanceGate,
     apply_column_masks,
     create_governance_gate_from_env,
+    govern_query,
     govern_read,
     mask_rows,
     mask_value,
+    referenced_tables,
 )
 
 BASE_URL = "http://atlas.test"
@@ -286,3 +288,75 @@ def test_govern_read_raises_when_denied() -> None:
             columns=["x"],
             rows=[("v",)],
         )
+
+
+# ---------------------------------------------------------------------------
+# referenced_tables + govern_query (ad-hoc SQL reads)
+# ---------------------------------------------------------------------------
+
+
+def test_referenced_tables_from_and_join() -> None:
+    sql = "SELECT a.id FROM prod.gold.customer a JOIN prod.gold.orders b ON a.id = b.cid"
+    assert referenced_tables(sql) == ["prod.gold.customer", "prod.gold.orders"]
+
+
+def test_referenced_tables_excludes_ctes() -> None:
+    sql = "WITH recent AS (SELECT * FROM prod.gold.orders) SELECT * FROM recent"
+    assert referenced_tables(sql) == ["prod.gold.orders"]
+
+
+def test_referenced_tables_tableless_is_empty() -> None:
+    assert referenced_tables("SELECT 1 AS one") == []
+
+
+def test_govern_query_passthrough_when_gate_none() -> None:
+    rows = [("C-001", "3201011234567")]
+    out = govern_query(
+        None,
+        sql="SELECT * FROM prod.gold.customer",
+        columns=["customer_id", "nik"],
+        rows=rows,
+    )
+    assert out == [("C-001", "3201011234567")]
+
+
+def test_govern_query_masks_referenced_table_columns() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"allowed": True, "masked_columns": ["nik"]})
+
+    out = govern_query(
+        _gate(handler),
+        sql="SELECT customer_id, nik FROM prod.gold.customer",
+        columns=["customer_id", "nik"],
+        rows=[("C-001", "3201011234567")],
+        keep=6,
+    )
+    assert out == [("C-001", f"320101{MASK_TOKEN}")]
+
+
+def test_govern_query_raises_when_a_table_denied() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/contracts/access-check":
+            return httpx.Response(200, json={"allowed": False, "reason": "no grant"})
+        return httpx.Response(200, json={})
+
+    with pytest.raises(AtlasPolicyDenied):
+        govern_query(
+            _gate(handler),
+            sql="SELECT * FROM prod.gold.finance",
+            columns=["x"],
+            rows=[("v",)],
+        )
+
+
+def test_govern_query_tableless_does_not_call_atlas() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("Atlas must not be called for a tableless query")
+
+    out = govern_query(
+        _gate(handler),
+        sql="SELECT 1 AS one",
+        columns=["one"],
+        rows=[(1,)],
+    )
+    assert out == [(1,)]

--- a/tests/integrations/test_atlas_governance.py
+++ b/tests/integrations/test_atlas_governance.py
@@ -13,6 +13,10 @@ from typing import Callable
 import httpx
 import pytest
 
+import base64
+import json
+from pathlib import Path
+
 from seeknal.integrations.atlas_client import AtlasContractConfig, AtlasPolicyDenied
 from seeknal.integrations.atlas_governance import (
     MASK_TOKEN,
@@ -25,6 +29,8 @@ from seeknal.integrations.atlas_governance import (
     mask_rows,
     mask_value,
     referenced_tables,
+    user_sub_from_credentials,
+    user_token_from_credentials,
 )
 
 BASE_URL = "http://atlas.test"
@@ -360,3 +366,106 @@ def test_govern_query_tableless_does_not_call_atlas() -> None:
         rows=[(1,)],
     )
     assert out == [(1,)]
+
+
+# ---------------------------------------------------------------------------
+# Credentials-backed user token + JWT claim extraction
+# ---------------------------------------------------------------------------
+
+
+def _b64url(data: dict[str, object]) -> str:
+    """Base64url-encode a dict as a JWT segment (no padding)."""
+
+    raw = json.dumps(data).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _unsigned_jwt(payload: dict[str, object]) -> str:
+    """Build an unsigned JWT (header.payload.sig) carrying ``payload``."""
+
+    header = _b64url({"alg": "none", "typ": "JWT"})
+    return f"{header}.{_b64url(payload)}.sig"
+
+
+def _write_creds(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, access_token: str) -> Path:
+    """Write a credentials file and point SEEKNAL_CREDENTIALS_PATH at it."""
+
+    creds = tmp_path / "credentials.json"
+    creds.write_text(
+        json.dumps(
+            {
+                "access_token": access_token,
+                "refresh_token": "r",
+                "expires_in": 3600,
+                "refresh_expires_in": 7200,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(creds))
+    return creds
+
+
+def test_gate_token_from_credentials_when_api_token_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ATLAS_API_URL", "https://atlas.example.com")
+    monkeypatch.delenv("ATLAS_API_TOKEN", raising=False)
+    _write_creds(tmp_path, monkeypatch, "user-access-token")
+
+    gate = create_governance_gate_from_env()
+    assert isinstance(gate, GovernanceGate)
+    assert gate.config.token == "user-access-token"
+
+
+def test_gate_api_token_takes_precedence_over_credentials(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ATLAS_API_URL", "https://atlas.example.com")
+    monkeypatch.setenv("ATLAS_API_TOKEN", "service-token")
+    _write_creds(tmp_path, monkeypatch, "user-access-token")
+
+    gate = create_governance_gate_from_env()
+    assert isinstance(gate, GovernanceGate)
+    assert gate.config.token == "service-token"
+
+
+def test_gate_token_none_when_credentials_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ATLAS_API_URL", "https://atlas.example.com")
+    monkeypatch.delenv("ATLAS_API_TOKEN", raising=False)
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(tmp_path / "missing.json"))
+
+    gate = create_governance_gate_from_env()
+    assert isinstance(gate, GovernanceGate)
+    assert gate.config.token is None
+
+
+def test_user_token_from_credentials_reads_access_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_creds(tmp_path, monkeypatch, "abc.def.ghi")
+    assert user_token_from_credentials() == "abc.def.ghi"
+
+
+def test_user_token_from_credentials_none_when_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(tmp_path / "missing.json"))
+    assert user_token_from_credentials() is None
+
+
+def test_user_sub_from_credentials_decodes_jwt_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    token = _unsigned_jwt({"sub": "abc-123"})
+    _write_creds(tmp_path, monkeypatch, token)
+    assert user_sub_from_credentials() == "abc-123"
+
+
+def test_user_sub_from_credentials_none_when_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(tmp_path / "missing.json"))
+    assert user_sub_from_credentials() is None


### PR DESCRIPTION
## Summary

Brings the **Atlas data-access governance** integration into mainline as **v2.10.0** — previously it lived only on the `feat/atlas-access-request-flow` branch and had to be run sideways via `PYTHONPATH`. Now it's first-class: a clean `seeknal` install has the gate and the `gov`/`auth` commands natively.

Activation is **opt-in and backward-compatible** — everything is a no-op unless `ATLAS_API_URL` is set.

## What's included

- **Config-activated runtime governance gate** — when `ATLAS_API_URL` is set, a pre-run access check enforces `can_select` (via the Atlas backend / OpenFGA) for every **source** node a run reads. Denial aborts the run with exit 1 and a `seeknal gov request-access` hint, **before any data is read**. Unset → gate is a no-op.
- **`seeknal gov request-access <table>`** — request access to a governed dataset (`--reason`, `--access read|write`, `--duration`).
- **`seeknal auth login` / `status` / `logout`** — authenticate against the Atlas Keycloak realm (PKCE loopback); credentials cached at `~/.config/seeknal/credentials.json` and used as the per-user identity for access checks.
- **Governed Ask SQL execution** — `execute_sql` / REPL reads run through the same access-check and apply column masking when the backend reports masked columns.
- **`seeknal atlas …`** optional command group (governance/lineage/api helpers); imports lazily, degrades gracefully without the `atlas` extra.

## Notes / config

- Opt-in via `ATLAS_API_URL` (+ `KEYCLOAK_ISSUER` for login). Gate fails **closed** on denial; `ATLAS_FAIL_OPEN=true` allows on transport error.

## Included fix: import-safe optional command groups

`cli/main.py` imported `seeknal.cli.heartbeat` and `seeknal.cli.admin` unconditionally, but those optional modules aren't present in every build — which broke `import seeknal.cli.main` (and the whole CLI) on a clean checkout. This PR guards both with `try/except ImportError` so a missing optional group is skipped instead of crashing CLI startup. (Surfaced while validating this branch on a clean tree.)

## Testing

- **58/58** governance tests pass (`tests/cli/test_auth.py`, `test_gov.py`, `test_run_governance.py`, `tests/integrations/test_atlas_governance.py`).
- Full suite collects cleanly (5023 tests, no import breakage).
- CLI imports cleanly on a simulated clean checkout with `gov`/`auth`/`atlas` present.
- **Live e2e** against a deployed Atlas stack: `seeknal run` denied at the gate → `gov request-access` (AR-076) → owner grant flips the OpenFGA tuple → `seeknal run` passes the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
