### PR TITLE
feat(atlas): `seeknal dataset` catalog CLI + REPL Atlas catalog (governed browse/preview)

### DIFF
--- a/src/seeknal/cli/dataset.py
+++ b/src/seeknal/cli/dataset.py
@@ -32,11 +32,17 @@ from seeknal.integrations.atlas_catalog import (
     Dataset,
     create_catalog_client_from_env,
 )
-from seeknal.integrations.atlas_client import AtlasContractError, AtlasPolicyDenied
+from seeknal.integrations.atlas_client import (
+    AtlasAuthError,
+    AtlasContractError,
+    AtlasPolicyDenied,
+    SESSION_EXPIRED_HINT,
+)
 from seeknal.integrations.atlas_governance import (
     AccessDecision,
     apply_column_masks,
     create_governance_gate_from_env,
+    refresh_access_token,
     user_email_from_credentials,
     user_token_from_credentials,
 )
@@ -77,10 +83,20 @@ def _resolve_dataset(client: AtlasCatalogClient, ref: str) -> Dataset:
     if _UUID_RE.match(ref):
         try:
             return client.get_dataset(ref)
+        except AtlasAuthError as exc:
+            echo_error(str(exc))
+            raise typer.Exit(1) from exc
         except AtlasContractError:
             pass  # fall through to a name search
 
-    matches = client.list_datasets(query=ref, limit=10)
+    try:
+        matches = client.list_datasets(query=ref, limit=10)
+    except AtlasAuthError as exc:
+        echo_error(str(exc))
+        raise typer.Exit(1) from exc
+    except AtlasContractError as exc:
+        echo_error(f"Catalog lookup failed: {exc}")
+        raise typer.Exit(1) from exc
     for dataset in matches:
         if ref in (dataset.name, dataset.fqn, dataset.id):
             return dataset
@@ -115,8 +131,17 @@ def _extract_sample(data: Any) -> tuple[list[str], list[list[Any]]]:
     """Normalise a ``/api/sample`` response into ``(columns, rows)``.
 
     Tolerant of the common shapes: ``{columns, rows}``, ``{schema, data}``, a list of
-    row dicts, or a list of row sequences.
+    row dicts, or a list of row sequences. The Atlas backend wraps each row as
+    ``{"values": {col: val}}``, so unwrap that envelope before projecting columns.
     """
+
+    def _row_dict(row: Any) -> dict[str, Any]:
+        if isinstance(row, dict):
+            inner = row.get("values")
+            if isinstance(inner, dict):
+                return inner
+            return row
+        return {}
 
     if isinstance(data, dict):
         raw_cols = data.get("columns") or data.get("schema") or []
@@ -124,15 +149,15 @@ def _extract_sample(data: Any) -> tuple[list[str], list[list[Any]]]:
         raw_rows = data.get("rows") or data.get("data") or []
         if raw_rows and isinstance(raw_rows[0], dict):
             if not columns:
-                columns = list(raw_rows[0].keys())
-            rows = [[r.get(c) for c in columns] for r in raw_rows]
+                columns = list(_row_dict(raw_rows[0]).keys())
+            rows = [[_row_dict(r).get(c) for c in columns] for r in raw_rows]
         else:
             rows = [list(r) for r in raw_rows]
         return [str(c) for c in columns], rows
     if isinstance(data, list):
         if data and isinstance(data[0], dict):
-            columns = list(data[0].keys())
-            return columns, [[r.get(c) for c in columns] for r in data]
+            columns = list(_row_dict(data[0]).keys())
+            return columns, [[_row_dict(r).get(c) for c in columns] for r in data]
         return [], [list(r) for r in data]
     return [], []
 
@@ -147,6 +172,9 @@ def _print_sample(
 
     try:
         data = client.sample(dataset.fqn, limit=limit)
+    except AtlasAuthError as exc:
+        echo_error(str(exc))
+        return
     except AtlasContractError as exc:
         echo_error(f"Sample failed: {exc}")
         return
@@ -300,20 +328,29 @@ def request_access(
         "priority": priority,
         "type": "dataset",
     }
-    headers = {"Content-Type": "application/json"}
-    token = user_token_from_credentials()
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-
-    try:
-        response = httpx.post(
+    def _post_access_request(bearer: str | None) -> httpx.Response:
+        headers = {"Content-Type": "application/json"}
+        if bearer:
+            headers["Authorization"] = f"Bearer {bearer}"
+        return httpx.post(
             f"{base}/governance/access-requests",
             json=body,
             headers=headers,
             timeout=_REQUEST_TIMEOUT_SECONDS,
         )
+
+    try:
+        response = _post_access_request(user_token_from_credentials())
+        # On an expired session, refresh the access token once and retry.
+        if response.status_code == 401:
+            new_token = refresh_access_token()
+            if new_token:
+                response = _post_access_request(new_token)
     except httpx.HTTPError as exc:
         echo_error(f"Access request failed: {exc}")
+        raise typer.Exit(1)
+    if response.status_code == 401:
+        echo_error(SESSION_EXPIRED_HINT)
         raise typer.Exit(1)
     if not (200 <= response.status_code < 300):
         detail = response.text.strip() or f"HTTP {response.status_code}"

--- a/src/seeknal/cli/dataset.py
+++ b/src/seeknal/cli/dataset.py
@@ -1,0 +1,363 @@
+"""Seeknal CLI - Atlas data catalog.
+
+A first-class command group for browsing and querying the Atlas data catalog from
+the engine side. Active only when Atlas is configured (``ATLAS_API_URL`` set); every
+command exits with code 2 and a hint when it is not.
+
+Usage:
+    seeknal dataset list [-q TEXT] [--type T] [--namespace NS]
+    seeknal dataset show <dataset> [--sample]
+    seeknal dataset annotate <dataset> --tag pii --description "..."
+    seeknal dataset request-access <dataset> --reason "need it for X"
+    seeknal dataset query <dataset> [--limit N]
+
+Reads (``list``/``show``/``query``) flow the logged-in user's token to Atlas; the
+access decision and any column masking come from the governance gate, so the CLI
+shows exactly what the user is permitted to see.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import os
+import re
+from typing import Any, List, Optional
+
+import httpx
+import typer
+from tabulate import tabulate
+
+from seeknal.integrations.atlas_catalog import (
+    AtlasCatalogClient,
+    Dataset,
+    create_catalog_client_from_env,
+)
+from seeknal.integrations.atlas_client import AtlasContractError, AtlasPolicyDenied
+from seeknal.integrations.atlas_governance import (
+    AccessDecision,
+    apply_column_masks,
+    create_governance_gate_from_env,
+    user_email_from_credentials,
+    user_token_from_credentials,
+)
+from seeknal.ui.output import echo_error, echo_info, echo_success
+
+dataset_app = typer.Typer(
+    name="dataset",
+    help="Browse and query the Atlas data catalog (requires ATLAS_API_URL).",
+)
+
+#: Seconds to wait for the Atlas governance API before giving up.
+_REQUEST_TIMEOUT_SECONDS = 30.0
+_UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{12}$")
+#: A dotted ``namespace.table`` identifier (a governed Lakekeeper table that may not
+#: be a registered catalog asset). No slashes/spaces — distinguishes it from an
+#: asset's path-style namespace.
+_TABLE_ID_RE = re.compile(r"^[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)+$")
+
+
+def _require_catalog() -> AtlasCatalogClient:
+    """Return a catalog client or exit(2) when Atlas is not configured."""
+
+    client = create_catalog_client_from_env()
+    if client is None:
+        echo_error("Atlas is not configured (set ATLAS_API_URL).")
+        raise typer.Exit(2)
+    return client
+
+
+def _resolve_dataset(client: AtlasCatalogClient, ref: str) -> Dataset:
+    """Resolve a dataset reference (id or name) to a :class:`Dataset`.
+
+    A UUID-looking ``ref`` is fetched directly; otherwise the catalog is searched and
+    the best name/fqn match (else the first hit) is returned. Exits 1 when nothing
+    matches.
+    """
+
+    if _UUID_RE.match(ref):
+        try:
+            return client.get_dataset(ref)
+        except AtlasContractError:
+            pass  # fall through to a name search
+
+    matches = client.list_datasets(query=ref, limit=10)
+    for dataset in matches:
+        if ref in (dataset.name, dataset.fqn, dataset.id):
+            return dataset
+    if matches:
+        return matches[0]
+
+    # Not a registered catalog asset. If it looks like a governed table identifier
+    # (``namespace.table``), treat it as a direct dataset so show/query/access-check
+    # work against governed Lakekeeper tables that aren't in the unified catalog.
+    if _TABLE_ID_RE.match(ref):
+        namespace, _, name = ref.rpartition(".")
+        return Dataset(id=ref, name=name or ref, namespace=namespace, asset_type="table")
+
+    echo_error(f"No dataset found matching '{ref}'.")
+    raise typer.Exit(1)
+
+
+def _dataset_dict(dataset: Dataset) -> dict[str, Any]:
+    return {
+        "id": dataset.id,
+        "name": dataset.name,
+        "namespace": dataset.namespace,
+        "asset_type": dataset.asset_type,
+        "source_system": dataset.source_system,
+        "description": dataset.description,
+        "tags": list(dataset.tags),
+        "fqn": dataset.fqn,
+    }
+
+
+def _extract_sample(data: Any) -> tuple[list[str], list[list[Any]]]:
+    """Normalise a ``/api/sample`` response into ``(columns, rows)``.
+
+    Tolerant of the common shapes: ``{columns, rows}``, ``{schema, data}``, a list of
+    row dicts, or a list of row sequences.
+    """
+
+    if isinstance(data, dict):
+        raw_cols = data.get("columns") or data.get("schema") or []
+        columns = [c.get("name") if isinstance(c, dict) else c for c in raw_cols]
+        raw_rows = data.get("rows") or data.get("data") or []
+        if raw_rows and isinstance(raw_rows[0], dict):
+            if not columns:
+                columns = list(raw_rows[0].keys())
+            rows = [[r.get(c) for c in columns] for r in raw_rows]
+        else:
+            rows = [list(r) for r in raw_rows]
+        return [str(c) for c in columns], rows
+    if isinstance(data, list):
+        if data and isinstance(data[0], dict):
+            columns = list(data[0].keys())
+            return columns, [[r.get(c) for c in columns] for r in data]
+        return [], [list(r) for r in data]
+    return [], []
+
+
+def _print_sample(
+    client: AtlasCatalogClient,
+    dataset: Dataset,
+    limit: int,
+    decision: Optional[AccessDecision],
+) -> None:
+    """Fetch + render a row sample, applying any masking the gate requires."""
+
+    try:
+        data = client.sample(dataset.fqn, limit=limit)
+    except AtlasContractError as exc:
+        echo_error(f"Sample failed: {exc}")
+        return
+    columns, rows = _extract_sample(data)
+    if decision is not None and decision.masked_columns and rows and columns:
+        masked = apply_column_masks(
+            [dict(zip(columns, row)) for row in rows], decision.masked_columns
+        )
+        rows = [[m.get(c) for c in columns] for m in masked]
+    if not rows:
+        echo_info("(no rows)")
+        return
+    typer.echo(tabulate(rows, headers=columns, tablefmt="simple"))
+    echo_info(f"{len(rows)} row(s).")
+
+
+@dataset_app.command("list")
+def list_datasets(
+    query: Optional[str] = typer.Option(None, "-q", "--query", help="Search text."),
+    asset_type: Optional[str] = typer.Option(None, "--type", help="Filter by asset type."),
+    namespace: Optional[str] = typer.Option(None, "--namespace", help="Filter by namespace."),
+    limit: int = typer.Option(50, "--limit", help="Maximum number of datasets."),
+    as_json: bool = typer.Option(False, "--json", help="Output JSON instead of a table."),
+) -> None:
+    """List datasets in the Atlas catalog."""
+
+    client = _require_catalog()
+    try:
+        datasets = client.list_datasets(
+            query=query, asset_type=asset_type, namespace=namespace, limit=limit
+        )
+    except AtlasContractError as exc:
+        echo_error(f"Failed to list datasets: {exc}")
+        raise typer.Exit(1)
+
+    if as_json:
+        typer.echo(_json.dumps([_dataset_dict(d) for d in datasets], indent=2))
+        return
+    if not datasets:
+        echo_info("No datasets found.")
+        return
+    rows = [[d.name, d.namespace, d.asset_type, ", ".join(d.tags)] for d in datasets]
+    typer.echo(tabulate(rows, headers=["Name", "Namespace", "Type", "Tags"], tablefmt="simple"))
+    echo_info(f"{len(datasets)} dataset(s).")
+
+
+@dataset_app.command("show")
+def show_dataset(
+    dataset: str = typer.Argument(..., help="Dataset id or name."),
+    sample: bool = typer.Option(False, "-s", "--sample", help="Include a row sample."),
+    limit: int = typer.Option(20, "--limit", help="Sample row limit."),
+    as_json: bool = typer.Option(False, "--json", help="Output JSON instead of text."),
+) -> None:
+    """Show a dataset's metadata, your live access decision, and (optionally) a sample."""
+
+    client = _require_catalog()
+    resolved = _resolve_dataset(client, dataset)
+
+    gate = create_governance_gate_from_env()
+    decision: Optional[AccessDecision] = None
+    if gate is not None:
+        try:
+            decision = gate.check_access(resource=resolved.fqn, action="read")
+        except AtlasContractError:
+            decision = None
+
+    if as_json:
+        out = _dataset_dict(resolved)
+        if decision is not None:
+            out["access"] = {
+                "allowed": decision.allowed,
+                "masked_columns": list(decision.masked_columns),
+                "reason": decision.reason,
+            }
+        typer.echo(_json.dumps(out, indent=2))
+        return
+
+    echo_success(resolved.name)
+    typer.echo(f"  namespace : {resolved.namespace}")
+    typer.echo(f"  type      : {resolved.asset_type}")
+    typer.echo(f"  source    : {resolved.source_system}")
+    if resolved.description:
+        typer.echo(f"  description: {resolved.description}")
+    if resolved.tags:
+        typer.echo(f"  tags      : {', '.join(resolved.tags)}")
+    typer.echo(f"  id        : {resolved.id}")
+    if decision is not None:
+        mark = "ALLOW" if decision.allowed else "DENY"
+        masked = (
+            f" (masked: {', '.join(decision.masked_columns)})"
+            if decision.masked_columns
+            else ""
+        )
+        typer.echo(f"  access    : {mark}{masked}")
+        if not decision.allowed and decision.reason:
+            typer.echo(f"  reason    : {decision.reason}")
+    if sample:
+        _print_sample(client, resolved, limit, decision)
+
+
+@dataset_app.command("annotate")
+def annotate_dataset(
+    dataset: str = typer.Argument(..., help="Dataset id or name."),
+    tags: Optional[List[str]] = typer.Option(None, "--tag", help="Tag to add (repeatable)."),
+    description: Optional[str] = typer.Option(None, "--description", help="Set the description."),
+    owners: Optional[List[str]] = typer.Option(None, "--owner", help="Owner to add (repeatable)."),
+) -> None:
+    """Annotate a dataset (tags / description / owners) in the Atlas catalog."""
+
+    if not tags and description is None and not owners:
+        echo_error("Provide at least one of --tag, --description, --owner.")
+        raise typer.Exit(1)
+    client = _require_catalog()
+    resolved = _resolve_dataset(client, dataset)
+    try:
+        client.annotate(
+            resolved.id,
+            tags=tags or None,
+            description=description,
+            owners=owners or None,
+        )
+    except AtlasContractError as exc:
+        echo_error(f"Annotation failed: {exc}")
+        raise typer.Exit(1)
+    echo_success(f"Annotated {resolved.name}.")
+
+
+@dataset_app.command("request-access")
+def request_access(
+    dataset: str = typer.Argument(..., help="Dataset id or name."),
+    reason: str = typer.Option(..., "--reason", help="Justification for the request."),
+    access: str = typer.Option("read", "--access", help="Access type (read, write)."),
+    duration: str = typer.Option("90d", "--duration", help="Requested grant duration."),
+    priority: str = typer.Option("medium", "--priority", help="Request priority."),
+) -> None:
+    """Request access to a dataset via the Atlas governance backend."""
+
+    client = _require_catalog()
+    resolved = _resolve_dataset(client, dataset)
+
+    base = (
+        os.getenv("SEEKNAL_API_URL") or os.getenv("ATLAS_API_URL") or "http://localhost:8000"
+    ).rstrip("/")
+    body: dict[str, Any] = {
+        "requester": user_email_from_credentials() or os.getenv("USER", ""),
+        "entityName": resolved.fqn,
+        "entityUrn": "",
+        "requestedAccess": access,
+        "reason": reason,
+        "duration": duration,
+        "priority": priority,
+        "type": "dataset",
+    }
+    headers = {"Content-Type": "application/json"}
+    token = user_token_from_credentials()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    try:
+        response = httpx.post(
+            f"{base}/governance/access-requests",
+            json=body,
+            headers=headers,
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        )
+    except httpx.HTTPError as exc:
+        echo_error(f"Access request failed: {exc}")
+        raise typer.Exit(1)
+    if not (200 <= response.status_code < 300):
+        detail = response.text.strip() or f"HTTP {response.status_code}"
+        echo_error(f"Access request rejected ({response.status_code}): {detail[:200]}")
+        raise typer.Exit(1)
+    try:
+        record = response.json()
+    except ValueError:
+        record = {}
+    echo_success(
+        f"Access request {record.get('id', '(unknown)')} created for {resolved.fqn}"
+    )
+    echo_info(f"Status: {record.get('status', 'pending')} | access: {access} | duration: {duration}")
+
+
+@dataset_app.command("query")
+def query_dataset(
+    dataset: str = typer.Argument(..., help="Dataset id or name."),
+    limit: int = typer.Option(20, "--limit", help="Row limit."),
+) -> None:
+    """Preview a governed dataset (access-checked + masked).
+
+    This is a quick, governed ``SELECT *`` preview. For ad-hoc SQL across Atlas
+    datasets, use the REPL (``seeknal repl``) — when Atlas is connected it lists and
+    queries the governed catalog directly.
+    """
+
+    client = _require_catalog()
+    resolved = _resolve_dataset(client, dataset)
+
+    gate = create_governance_gate_from_env()
+    decision: Optional[AccessDecision] = None
+    if gate is not None:
+        try:
+            decision = gate.enforce_access(resource=resolved.fqn, action="read")
+        except AtlasPolicyDenied as exc:
+            echo_error(str(exc))
+            echo_info(f'Run: seeknal dataset request-access {resolved.name} --reason "<why>"')
+            raise typer.Exit(1)
+        except AtlasContractError as exc:
+            echo_error(f"Access check failed: {exc}")
+            raise typer.Exit(1)
+
+    _print_sample(client, resolved, limit, decision)
+
+
+__all__ = ["dataset_app"]

--- a/src/seeknal/cli/main.py
+++ b/src/seeknal/cli/main.py
@@ -241,6 +241,12 @@ from seeknal.cli.auth import auth_app  # ty: ignore[unresolved-import]
 
 app.add_typer(auth_app, name="auth")
 
+# Atlas data catalog (list/show/annotate/request-access/query). Same stdlib + httpx
+# + tabulate footprint as gov/auth, registered unconditionally alongside them.
+from seeknal.cli.dataset import dataset_app  # ty: ignore[unresolved-import]
+
+app.add_typer(dataset_app, name="dataset")
+
 # Virtual environment management
 env_app = typer.Typer(
     help="Virtual environments for safe pipeline development (plan/apply/promote)"

--- a/src/seeknal/cli/repl.py
+++ b/src/seeknal/cli/repl.py
@@ -101,6 +101,7 @@ class REPL:
         self._registered_parquets: int = 0
         self._registered_pg: int = 0
         self._registered_iceberg: int = 0
+        self._registered_atlas: int = 0
         self._node_count: int = 0
         self._last_run: Optional[str] = None
         self._load_extensions()
@@ -195,6 +196,12 @@ class REPL:
             self._register_iceberg_catalogs()
         except Exception as e:
             warnings.warn(f"REPL: Failed to attach Iceberg catalogs: {e}")
+
+        # Phase 3b: Attach the Atlas governed catalog (config-gated, best-effort)
+        try:
+            self._register_atlas_catalog()
+        except Exception as e:
+            warnings.warn(f"REPL: Failed to attach Atlas catalog: {e}")
 
         # Phase 1c: Register ask-ingested parquets
         try:
@@ -508,6 +515,61 @@ class REPL:
         )
         self.attached.add("iceberg")
         self._registered_iceberg += 1
+
+    def _register_atlas_catalog(self) -> None:
+        """Phase 3b: Surface the Atlas governed catalog when Atlas is connected.
+
+        When ``ATLAS_API_URL`` is set, count the governed datasets Atlas exposes and —
+        if the Lakekeeper catalog env (``LAKEKEEPER_URL``) is configured — ATTACH the
+        warehouse so the datasets are queryable in the REPL as
+        ``atlas.<namespace>.<table>`` (mirrors the iceberg-source read path). The
+        governance gate still enforces access on every read. Best-effort: any failure
+        leaves the rest of the REPL catalog intact.
+        """
+        import os
+        import warnings
+
+        from seeknal.integrations.atlas_catalog import create_catalog_client_from_env
+
+        client = create_catalog_client_from_env()
+        if client is None:
+            return  # Atlas not configured → nothing to surface
+
+        uri = os.getenv("LAKEKEEPER_URL", "").strip()
+        warehouse = os.getenv("LAKEKEEPER_WAREHOUSE", "").strip()
+        if uri and "atlas" not in self.attached:
+            try:
+                from seeknal.workflow.materialization.operations import (
+                    DuckDBIcebergExtension,
+                )
+
+                DuckDBIcebergExtension.load_extension(self.conn)
+                DuckDBIcebergExtension.configure_s3(self.conn)
+                bearer_token = None
+                try:
+                    bearer_token = DuckDBIcebergExtension.get_oauth2_token()
+                except Exception:
+                    pass  # no OAuth2 configured → try without
+                catalog_uri = uri.rstrip("/")
+                if "/catalog" not in catalog_uri:
+                    catalog_uri = f"{catalog_uri}/catalog"
+                DuckDBIcebergExtension.attach_rest_catalog(
+                    con=self.conn,
+                    catalog_name="atlas",
+                    uri=catalog_uri,
+                    warehouse_path=warehouse,
+                    bearer_token=bearer_token,
+                )
+                self.attached.add("atlas")
+            except Exception as e:
+                warnings.warn(f"REPL: Atlas catalog attach skipped: {e}")
+
+        # Record how many governed datasets Atlas exposes (visibility), regardless of
+        # whether the warehouse could be attached.
+        try:
+            self._registered_atlas = len(client.list_datasets(limit=200))
+        except Exception as e:
+            warnings.warn(f"REPL: Atlas dataset listing failed: {e}")
 
     def execute_oneshot(
         self, sql: str, limit: Optional[int] = None

--- a/src/seeknal/integrations/atlas_catalog.py
+++ b/src/seeknal/integrations/atlas_catalog.py
@@ -24,12 +24,20 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
-from typing import Any, Sequence
+from typing import Any, Callable, Sequence
 
 import httpx
 
-from seeknal.integrations.atlas_client import AtlasContractConfig, AtlasContractError
-from seeknal.integrations.atlas_governance import user_token_from_credentials
+from seeknal.integrations.atlas_client import (
+    AtlasAuthError,
+    AtlasContractConfig,
+    AtlasContractError,
+    SESSION_EXPIRED_HINT,
+)
+from seeknal.integrations.atlas_governance import (
+    refresh_access_token,
+    user_token_from_credentials,
+)
 
 __all__ = ["Dataset", "AtlasCatalogClient", "create_catalog_client_from_env"]
 
@@ -105,68 +113,101 @@ class AtlasCatalogClient:
         config: AtlasContractConfig,
         *,
         client: httpx.Client | None = None,
+        token_refresher: Callable[[], str | None] | None = None,
     ) -> None:
         self.config = config
         self._client = client
+        # ``config.token`` is the initial bearer; keep a mutable copy so a 401-driven
+        # refresh can swap in a new access token without rebuilding the frozen config.
+        self._token = config.token
+        self._token_refresher = token_refresher or refresh_access_token
 
     # -- HTTP plumbing -------------------------------------------------------
 
     def _headers(self) -> dict[str, str]:
         headers = {"Content-Type": "application/json"}
-        if self.config.token:
-            headers["Authorization"] = f"Bearer {self.config.token}"
+        if self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
         return headers
 
-    def _get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+    def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        """Issue a single HTTP request via the injected client or a one-shot call."""
+
+        if self._client is not None:
+            if method == "GET":
+                return self._client.get(url, params=params, headers=self._headers())
+            return self._client.post(url, json=json_body, headers=self._headers())
+        if method == "GET":
+            return httpx.get(
+                url,
+                params=params,
+                headers=self._headers(),
+                timeout=self.config.timeout_seconds,
+            )
+        return httpx.post(
+            url,
+            json=json_body,
+            headers=self._headers(),
+            timeout=self.config.timeout_seconds,
+        )
+
+    def _send(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+    ) -> Any:
+        """Send a request, transparently refreshing the token once on HTTP 401.
+
+        On a 401 the stored refresh token is used to mint a new access token and the
+        request is retried exactly once. When no refresh is possible (or the retry is
+        still 401), an :class:`AtlasAuthError` carrying a re-authentication hint is
+        raised — never a raw traceback. Other HTTP/transport failures map to
+        :class:`AtlasContractError` as before.
+        """
+
         url = f"{self.config.base_url}{path}"
+        refreshed = False
+        while True:
+            try:
+                response = self._request(method, url, params=params, json_body=json_body)
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code == 401:
+                    if not refreshed:
+                        refreshed = True
+                        new_token = self._token_refresher()
+                        if new_token:
+                            self._token = new_token
+                            continue
+                    raise AtlasAuthError(SESSION_EXPIRED_HINT) from exc
+                message = exc.response.text.strip() or str(exc)
+                raise AtlasContractError(
+                    f"Atlas catalog request failed for {path}: {message}"
+                ) from exc
+            except httpx.HTTPError as exc:
+                raise AtlasContractError(
+                    f"Atlas catalog request failed for {path}: {exc}"
+                ) from exc
+
+    def _get(self, path: str, params: dict[str, Any] | None = None) -> Any:
         clean = {
             key: value for key, value in (params or {}).items() if value is not None
         }
-        try:
-            if self._client is not None:
-                response = self._client.get(url, params=clean, headers=self._headers())
-            else:
-                response = httpx.get(
-                    url,
-                    params=clean,
-                    headers=self._headers(),
-                    timeout=self.config.timeout_seconds,
-                )
-            response.raise_for_status()
-            return response.json()
-        except httpx.HTTPStatusError as exc:
-            message = exc.response.text.strip() or str(exc)
-            raise AtlasContractError(
-                f"Atlas catalog request failed for {path}: {message}"
-            ) from exc
-        except httpx.HTTPError as exc:
-            raise AtlasContractError(
-                f"Atlas catalog request failed for {path}: {exc}"
-            ) from exc
+        return self._send("GET", path, params=clean)
 
     def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
-        url = f"{self.config.base_url}{path}"
-        try:
-            if self._client is not None:
-                response = self._client.post(url, json=payload, headers=self._headers())
-            else:
-                response = httpx.post(
-                    url,
-                    json=payload,
-                    headers=self._headers(),
-                    timeout=self.config.timeout_seconds,
-                )
-            response.raise_for_status()
-            return response.json()
-        except httpx.HTTPStatusError as exc:
-            message = exc.response.text.strip() or str(exc)
-            raise AtlasContractError(
-                f"Atlas catalog request failed for {path}: {message}"
-            ) from exc
-        except httpx.HTTPError as exc:
-            raise AtlasContractError(
-                f"Atlas catalog request failed for {path}: {exc}"
-            ) from exc
+        return self._send("POST", path, json_body=payload)
 
     # -- Public API ----------------------------------------------------------
 

--- a/src/seeknal/integrations/atlas_catalog.py
+++ b/src/seeknal/integrations/atlas_catalog.py
@@ -1,0 +1,330 @@
+"""Read-only Atlas data-catalog client, active only when Atlas is configured.
+
+This is the *catalog* surface of the Atlas integration: a GET-only client over the
+unified-catalog read API. Where :mod:`seeknal.integrations.atlas_client` handles
+apply-time dual writes and :mod:`seeknal.integrations.atlas_governance` enforces
+runtime access, this module lets a caller *browse* the catalog — list, fetch,
+search, and sample assets — plus a single write (:meth:`AtlasCatalogClient.annotate`)
+that upserts annotations onto an existing asset.
+
+Like the governance gate it is **config-activated**: with no ``ATLAS_API_URL`` the
+factory returns ``None`` and callers can skip catalog features entirely. It reuses
+the same :class:`~seeknal.integrations.atlas_client.AtlasContractConfig` and the
+per-user token resolution so a single Atlas configuration drives every surface.
+
+The backend asset shape is a JSON dict::
+
+    {id, asset_type, name, namespace, source_system, source_id, canonical_source,
+     metadata: {description, tags, canonical_asset_id}, created_at, updated_at}
+
+:class:`Dataset` is the typed projection of that dict the rest of Seeknal consumes.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Sequence
+
+import httpx
+
+from seeknal.integrations.atlas_client import AtlasContractConfig, AtlasContractError
+from seeknal.integrations.atlas_governance import user_token_from_credentials
+
+__all__ = ["Dataset", "AtlasCatalogClient", "create_catalog_client_from_env"]
+
+
+@dataclass(frozen=True)
+class Dataset:
+    """Typed projection of a unified-catalog asset.
+
+    Construct from a raw backend asset dict via :meth:`from_api`. ``description``,
+    ``tags``, and ``canonical_id`` are flattened out of the nested ``metadata`` block
+    the backend returns, while the full ``metadata`` dict is retained verbatim.
+    """
+
+    id: str
+    name: str
+    namespace: str = ""
+    asset_type: str = ""
+    source_system: str = ""
+    description: str = ""
+    tags: tuple[str, ...] = ()
+    canonical_id: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_api(cls, d: dict[str, Any]) -> "Dataset":
+        """Map a raw backend asset dict to a :class:`Dataset`.
+
+        Tolerant of missing fields: any absent key falls back to its dataclass
+        default. ``description``, ``tags``, and ``canonical_asset_id`` are read from
+        the nested ``metadata`` block; the whole ``metadata`` dict is preserved.
+        """
+
+        metadata = d.get("metadata") or {}
+        raw_tags = metadata.get("tags") or []
+        tags = tuple(str(tag) for tag in raw_tags if tag)
+        return cls(
+            id=str(d.get("id", "")),
+            name=str(d.get("name", "")),
+            namespace=str(d.get("namespace", "")),
+            asset_type=str(d.get("asset_type", "")),
+            source_system=str(d.get("source_system", "")),
+            description=str(metadata.get("description", "")),
+            tags=tags,
+            canonical_id=str(metadata.get("canonical_asset_id", "")),
+            metadata=dict(metadata),
+        )
+
+    @property
+    def fqn(self) -> str:
+        """Fully-qualified name for the dataset.
+
+        Prefers the canonical asset id when present; otherwise composes
+        ``"{namespace}.{name}"`` (dropping the leading dot when no namespace is set).
+        """
+
+        if self.canonical_id:
+            return self.canonical_id
+        if self.namespace:
+            return f"{self.namespace}.{self.name}"
+        return self.name
+
+
+class AtlasCatalogClient:
+    """GET-only HTTP client for the Atlas unified-catalog read API.
+
+    Construct via :func:`create_catalog_client_from_env`. Pass an explicit ``client``
+    (e.g. backed by :class:`httpx.MockTransport`) in tests. Mirrors the headers and
+    HTTP/error handling of :class:`~seeknal.integrations.atlas_governance.GovernanceGate`.
+    """
+
+    def __init__(
+        self,
+        config: AtlasContractConfig,
+        *,
+        client: httpx.Client | None = None,
+    ) -> None:
+        self.config = config
+        self._client = client
+
+    # -- HTTP plumbing -------------------------------------------------------
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.config.token:
+            headers["Authorization"] = f"Bearer {self.config.token}"
+        return headers
+
+    def _get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        url = f"{self.config.base_url}{path}"
+        clean = {
+            key: value for key, value in (params or {}).items() if value is not None
+        }
+        try:
+            if self._client is not None:
+                response = self._client.get(url, params=clean, headers=self._headers())
+            else:
+                response = httpx.get(
+                    url,
+                    params=clean,
+                    headers=self._headers(),
+                    timeout=self.config.timeout_seconds,
+                )
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as exc:
+            message = exc.response.text.strip() or str(exc)
+            raise AtlasContractError(
+                f"Atlas catalog request failed for {path}: {message}"
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise AtlasContractError(
+                f"Atlas catalog request failed for {path}: {exc}"
+            ) from exc
+
+    def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        url = f"{self.config.base_url}{path}"
+        try:
+            if self._client is not None:
+                response = self._client.post(url, json=payload, headers=self._headers())
+            else:
+                response = httpx.post(
+                    url,
+                    json=payload,
+                    headers=self._headers(),
+                    timeout=self.config.timeout_seconds,
+                )
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as exc:
+            message = exc.response.text.strip() or str(exc)
+            raise AtlasContractError(
+                f"Atlas catalog request failed for {path}: {message}"
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise AtlasContractError(
+                f"Atlas catalog request failed for {path}: {exc}"
+            ) from exc
+
+    # -- Public API ----------------------------------------------------------
+
+    def list_datasets(
+        self,
+        *,
+        query: str | None = None,
+        asset_type: str | None = None,
+        namespace: str | None = None,
+        source_system: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[Dataset]:
+        """List catalog assets, optionally filtered. Returns a list of :class:`Dataset`.
+
+        GET ``/api/assets``. ``query`` maps to the ``q`` parameter and ``asset_type``
+        to ``type``. The backend returns a JSON array of asset dicts.
+        """
+
+        params = {
+            "q": query,
+            "type": asset_type,
+            "namespace": namespace,
+            "source_system": source_system,
+            "limit": limit,
+            "offset": offset,
+        }
+        resp = self._get("/api/assets", params)
+        return [Dataset.from_api(asset) for asset in (resp or [])]
+
+    def get_dataset(self, dataset_id: str) -> Dataset:
+        """Fetch a single catalog asset by id.
+
+        GET ``/api/assets/{dataset_id}`` and project the result into a :class:`Dataset`.
+        """
+
+        resp = self._get(f"/api/assets/{dataset_id}")
+        return Dataset.from_api(resp)
+
+    def search(
+        self,
+        query: str,
+        *,
+        asset_types: Sequence[str] | None = None,
+        tags: Sequence[str] | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[Dataset]:
+        """Full-text search across the catalog. Returns a list of :class:`Dataset`.
+
+        GET ``/api/search`` with ``q=query``. The response may be a bare JSON array or
+        a dict wrapping the hits under ``results``/``items``/``assets``; both shapes are
+        handled, and each hit is mapped tolerantly via :meth:`Dataset.from_api`.
+        """
+
+        params = {
+            "q": query,
+            "asset_types": list(asset_types) if asset_types else None,
+            "tags": list(tags) if tags else None,
+            "limit": limit,
+            "offset": offset,
+        }
+        resp = self._get("/api/search", params)
+        if isinstance(resp, dict):
+            hits = resp.get("results") or resp.get("items") or resp.get("assets") or []
+        else:
+            hits = resp or []
+        return [Dataset.from_api(hit) for hit in hits if isinstance(hit, dict)]
+
+    def sample(
+        self, identifier: str, *, limit: int = 20, offset: int = 0
+    ) -> dict[str, Any]:
+        """Fetch a row sample for an asset, returning the backend JSON verbatim.
+
+        GET ``/api/sample`` with the required ``identifier`` plus ``limit``/``offset``.
+        The response is returned unmodified for the caller to render.
+        """
+
+        return self._get(
+            "/api/sample",
+            {"identifier": identifier, "limit": limit, "offset": offset},
+        )
+
+    def annotate(
+        self,
+        dataset_id: str,
+        *,
+        tags: Sequence[str] | None = None,
+        description: str | None = None,
+        owners: Sequence[str] | None = None,
+    ) -> dict[str, Any]:
+        """Upsert the unified-catalog asset annotations.
+
+        Fetches the current asset, unions any new ``tags`` with the existing ones,
+        overrides ``description`` when supplied, records ``owners`` in metadata when
+        given, then POSTs the merged asset to ``/api/contracts/assets/register``.
+        Returns the backend response.
+        """
+
+        current = self.get_dataset(dataset_id)
+
+        merged_tags = list(current.tags)
+        if tags:
+            for tag in tags:
+                if tag and tag not in merged_tags:
+                    merged_tags.append(tag)
+
+        description_value = (
+            description if description is not None else current.description
+        )
+
+        metadata = dict(current.metadata)
+        metadata["description"] = description_value
+        metadata["tags"] = merged_tags
+        if owners:
+            metadata["owners"] = list(owners)
+
+        source_id = str(
+            current.metadata.get("source_id", "")
+            or f"{current.asset_type}:{current.name}"
+        )
+        asset = {
+            "asset_type": current.asset_type,
+            "name": current.name,
+            "namespace": current.namespace,
+            "source_system": current.source_system,
+            "source_id": source_id,
+            "description": description_value,
+            "tags": merged_tags,
+            "metadata": metadata,
+        }
+        payload = {
+            "project_name": os.getenv("SEEKNAL_PROJECT_NAME") or current.namespace,
+            "environment": os.getenv("ATLAS_ENVIRONMENT", "dev"),
+            "asset": asset,
+        }
+        return self._post("/api/contracts/assets/register", payload)
+
+
+def create_catalog_client_from_env() -> "AtlasCatalogClient | None":
+    """Build a catalog client only when Atlas is configured.
+
+    Returns ``None`` when ``ATLAS_API_URL`` is unset, signalling catalog features are
+    inactive. Otherwise mirrors
+    :func:`~seeknal.integrations.atlas_governance.create_governance_gate_from_env`:
+    an explicit ``ATLAS_API_TOKEN`` wins, else the logged-in user's token is used so
+    per-user identity flows to Atlas.
+    """
+
+    base_url = os.getenv("ATLAS_API_URL", "").strip()
+    if not base_url:
+        return None
+
+    timeout = float(os.getenv("ATLAS_API_TIMEOUT_SECONDS", "10"))
+    token = os.getenv("ATLAS_API_TOKEN") or user_token_from_credentials()
+    config = AtlasContractConfig(
+        base_url=base_url.rstrip("/"),
+        token=token,
+        timeout_seconds=timeout,
+    )
+    return AtlasCatalogClient(config)

--- a/src/seeknal/integrations/atlas_client.py
+++ b/src/seeknal/integrations/atlas_client.py
@@ -20,6 +20,24 @@ class AtlasPolicyDenied(AtlasContractError):
     """Raised when Atlas explicitly denies a Seeknal operation."""
 
 
+class AtlasAuthError(AtlasContractError):
+    """Raised when the caller's Atlas session is missing or expired (HTTP 401).
+
+    Carries a user-facing, re-authentication hint. It is only raised after an
+    automatic token refresh has been attempted and failed (or no refresh token was
+    available), so the right remedy is always to log in again. Subclasses
+    :class:`AtlasContractError` so existing ``except AtlasContractError`` handlers
+    keep working while callers may special-case the auth message.
+    """
+
+
+#: One-line, user-facing hint shown when the Atlas session is missing/expired and
+#: could not be refreshed automatically. Surfaced verbatim by the CLI (no traceback).
+SESSION_EXPIRED_HINT = (
+    "Your Atlas session has expired. Run `seeknal auth login` to sign in again."
+)
+
+
 @dataclass(frozen=True)
 class AtlasContractConfig:
     """Environment-backed Atlas client configuration."""

--- a/src/seeknal/integrations/atlas_governance.py
+++ b/src/seeknal/integrations/atlas_governance.py
@@ -28,16 +28,19 @@ import getpass
 import json
 import os
 import re
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any, Callable, Iterable, Mapping, Sequence
 
 import httpx
 
 from seeknal.integrations.atlas_client import (
+    AtlasAuthError,
     AtlasContractConfig,
     AtlasContractError,
     AtlasPolicyDenied,
+    SESSION_EXPIRED_HINT,
 )
 
 __all__ = [
@@ -55,6 +58,7 @@ __all__ = [
     "user_token_from_credentials",
     "user_sub_from_credentials",
     "user_email_from_credentials",
+    "refresh_access_token",
 ]
 
 #: Replacement rendered for a fully masked value.
@@ -129,6 +133,114 @@ def _user_token_from_credentials() -> str | None:
 
 #: Public alias for reuse by the CLI; mirrors the private gate-side reader.
 user_token_from_credentials = _user_token_from_credentials
+
+
+#: OIDC config for refreshing the stored access token. Mirrors ``cli/auth.py`` so a
+#: single ``KEYCLOAK_ISSUER`` / ``SEEKNAL_OIDC_CLIENT_ID`` drives login *and* refresh.
+_DEFAULT_OIDC_ISSUER = "http://localhost:8080/realms/atlas"
+_DEFAULT_OIDC_CLIENT_ID = "seeknal-cli"
+#: Seconds to wait on the token endpoint before giving up on a refresh.
+_REFRESH_TIMEOUT_SECONDS = 30.0
+
+
+def _oidc_issuer() -> str:
+    """Return the Keycloak realm issuer used for token refresh (no trailing slash)."""
+
+    return (os.getenv("KEYCLOAK_ISSUER", "").strip() or _DEFAULT_OIDC_ISSUER).rstrip("/")
+
+
+def _oidc_client_id() -> str:
+    """Return the public OIDC client id used for token refresh."""
+
+    return os.getenv("SEEKNAL_OIDC_CLIENT_ID", "").strip() or _DEFAULT_OIDC_CLIENT_ID
+
+
+def _persist_refreshed_tokens(existing: dict[str, Any], tokens: dict[str, Any]) -> None:
+    """Best-effort write of refreshed tokens to the credentials file (mode 0600).
+
+    Preserves the previous ``refresh_token``/``refresh_expires_in`` when the refresh
+    response omits them (Keycloak usually rotates the refresh token, but not always).
+    Never raises: a refresh whose token we already hold in memory must still succeed
+    even if the on-disk write fails.
+    """
+
+    payload = {
+        "access_token": tokens.get("access_token"),
+        "refresh_token": tokens.get("refresh_token") or existing.get("refresh_token"),
+        "expires_in": tokens.get("expires_in"),
+        "refresh_expires_in": (
+            tokens.get("refresh_expires_in") or existing.get("refresh_expires_in")
+        ),
+    }
+    try:
+        path = credentials_path()
+        path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        # Write to a temp file that is owner-only (0600) from creation, then atomically
+        # rename into place. This avoids the brief world/group-readable window of
+        # ``write_text`` + ``chmod`` and prevents a torn file if the process dies mid-write.
+        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".credentials-", suffix=".tmp")
+        try:
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(json.dumps(payload, indent=2))
+            os.replace(tmp, path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+    except OSError:
+        pass
+
+
+def refresh_access_token(*, client: httpx.Client | None = None) -> str | None:
+    """Mint a fresh access token from the stored refresh token, or return ``None``.
+
+    Uses the OAuth2 ``refresh_token`` grant against the Keycloak realm (the public
+    ``seeknal-cli`` client). On success the rotated tokens are persisted to the
+    credentials file (mode 0600) and the new access token is returned. Returns
+    ``None`` (never raises) when there is no usable refresh token, the grant is
+    rejected (e.g. the refresh token itself has expired), or the identity provider is
+    unreachable — callers then surface a "log in again" hint instead of a traceback.
+
+    ``client`` lets tests inject an :class:`httpx.Client` (e.g. ``MockTransport``).
+    """
+
+    creds = _read_credentials()
+    if not creds:
+        return None
+    refresh_token = creds.get("refresh_token")
+    if not isinstance(refresh_token, str) or not refresh_token.strip():
+        return None
+
+    data = {
+        "grant_type": "refresh_token",
+        "client_id": _oidc_client_id(),
+        "refresh_token": refresh_token,
+    }
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    endpoint = f"{_oidc_issuer()}/protocol/openid-connect/token"
+    try:
+        if client is not None:
+            response = client.post(
+                endpoint, data=data, headers=headers, timeout=_REFRESH_TIMEOUT_SECONDS
+            )
+        else:
+            response = httpx.post(
+                endpoint, data=data, headers=headers, timeout=_REFRESH_TIMEOUT_SECONDS
+            )
+        response.raise_for_status()
+        tokens = response.json()
+    except (httpx.HTTPError, ValueError):
+        return None
+    if not isinstance(tokens, dict):
+        return None
+    new_token = tokens.get("access_token")
+    if not isinstance(new_token, str) or not new_token.strip():
+        return None
+    _persist_refreshed_tokens(creds, tokens)
+    return new_token
 
 
 def _decode_jwt_payload(token: str) -> dict[str, Any] | None:
@@ -401,10 +513,15 @@ class GovernanceGate:
         *,
         fail_open: bool | None = None,
         client: httpx.Client | None = None,
+        token_refresher: Callable[[], str | None] | None = None,
     ) -> None:
         self.config = config
         self._fail_open = _fail_open_default() if fail_open is None else fail_open
         self._client = client
+        # Mutable bearer copy so a 401 can be recovered by refreshing the access token
+        # (the frozen config stays the source of the *initial* token).
+        self._token = config.token
+        self._token_refresher = token_refresher or refresh_access_token
 
     @property
     def fail_open(self) -> bool:
@@ -416,31 +533,47 @@ class GovernanceGate:
 
     def _headers(self) -> dict[str, str]:
         headers = {"Content-Type": "application/json"}
-        if self.config.token:
-            headers["Authorization"] = f"Bearer {self.config.token}"
+        if self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
         return headers
 
     def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
         url = f"{self.config.base_url}{path}"
-        try:
-            if self._client is not None:
-                response = self._client.post(url, json=payload, headers=self._headers())
-            else:
-                response = httpx.post(
-                    url,
-                    json=payload,
-                    headers=self._headers(),
-                    timeout=self.config.timeout_seconds,
-                )
-            response.raise_for_status()
-            return response.json()
-        except httpx.HTTPStatusError as exc:
-            message = exc.response.text.strip() or str(exc)
-            raise AtlasContractError(
-                f"Atlas governance request failed for {path}: {message}"
-            ) from exc
-        except httpx.HTTPError as exc:
-            raise AtlasContractError(f"Atlas governance request failed for {path}: {exc}") from exc
+        refreshed = False
+        while True:
+            try:
+                if self._client is not None:
+                    response = self._client.post(url, json=payload, headers=self._headers())
+                else:
+                    response = httpx.post(
+                        url,
+                        json=payload,
+                        headers=self._headers(),
+                        timeout=self.config.timeout_seconds,
+                    )
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPStatusError as exc:
+                # Transparently refresh the access token once on a 401, then retry.
+                if exc.response.status_code == 401:
+                    if not refreshed:
+                        refreshed = True
+                        new_token = self._token_refresher()
+                        if new_token:
+                            self._token = new_token
+                            continue
+                    # Unrecoverable auth failure. Raise AtlasAuthError (a subclass of
+                    # AtlasContractError) to mirror AtlasCatalogClient._send: check_access
+                    # still catches it and fails closed, so the run/ask/repl callers that
+                    # only expect AtlasPolicyDenied are unaffected, but the decision now
+                    # carries a clear "session expired" reason instead of "unreachable".
+                    raise AtlasAuthError(SESSION_EXPIRED_HINT) from exc
+                message = exc.response.text.strip() or str(exc)
+                raise AtlasContractError(
+                    f"Atlas governance request failed for {path}: {message}"
+                ) from exc
+            except httpx.HTTPError as exc:
+                raise AtlasContractError(f"Atlas governance request failed for {path}: {exc}") from exc
 
     # -- Public API ----------------------------------------------------------
 
@@ -471,6 +604,12 @@ class GovernanceGate:
 
         try:
             decision = self._post("/api/contracts/access-check", payload)
+        except AtlasAuthError as exc:
+            # An expired/missing session is an authentication problem, not an
+            # availability one: always fail closed (even when fail-open is enabled —
+            # an unauthenticated caller must never be waved through) and surface the
+            # re-authentication hint so the reason is actionable.
+            return AccessDecision(allowed=False, reason=str(exc))
         except AtlasContractError as exc:
             if self._fail_open:
                 return AccessDecision(

--- a/tests/cli/test_dataset.py
+++ b/tests/cli/test_dataset.py
@@ -7,9 +7,13 @@ from unittest.mock import MagicMock
 from typer.testing import CliRunner
 
 import seeknal.cli.dataset as dataset_mod
-from seeknal.cli.dataset import dataset_app
+from seeknal.cli.dataset import _extract_sample, dataset_app
 from seeknal.integrations.atlas_catalog import Dataset
-from seeknal.integrations.atlas_client import AtlasPolicyDenied
+from seeknal.integrations.atlas_client import (
+    AtlasAuthError,
+    AtlasPolicyDenied,
+    SESSION_EXPIRED_HINT,
+)
 from seeknal.integrations.atlas_governance import AccessDecision
 
 runner = CliRunner()
@@ -135,3 +139,89 @@ def test_request_access_prints_ar_id(monkeypatch):
     result = runner.invoke(dataset_app, ["request-access", "sales", "--reason", "need it"])
     assert result.exit_code == 0
     assert "AR-9" in result.output
+
+
+def test_extract_sample_unwraps_backend_values_envelope():
+    # The Atlas /api/sample backend returns columns as schema dicts and rows
+    # wrapped as {"values": {col: val}} -- the shape that previously rendered blank.
+    data = {
+        "columns": [{"name": "sale_id"}, {"name": "customer_name"}, {"name": "region"}],
+        "rows": [
+            {"values": {"sale_id": 1, "customer_name": "Alice", "region": "us-east"}},
+            {"values": {"sale_id": 2, "customer_name": "Bob", "region": "us-west"}},
+        ],
+    }
+    columns, rows = _extract_sample(data)
+    assert columns == ["sale_id", "customer_name", "region"]
+    assert rows == [[1, "Alice", "us-east"], [2, "Bob", "us-west"]]
+
+
+def test_query_renders_backend_values_envelope(monkeypatch):
+    client = _fake_client()
+    client.sample.return_value = {
+        "columns": [{"name": "sale_id"}, {"name": "region"}],
+        "rows": [{"values": {"sale_id": 1, "region": "us-east"}}],
+    }
+    _patch(monkeypatch, client=client)
+    result = runner.invoke(dataset_app, ["query", "retail_demo.sales"])
+    assert result.exit_code == 0
+    assert "us-east" in result.output
+    assert "1 row(s)." in result.output
+
+
+def test_show_presents_expired_session_without_traceback(monkeypatch):
+    client = _fake_client()
+    client.list_datasets.side_effect = AtlasAuthError(SESSION_EXPIRED_HINT)
+    _patch(monkeypatch, client=client)
+    result = runner.invoke(dataset_app, ["show", "sales"])
+    assert result.exit_code == 1
+    assert "seeknal auth login" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_query_presents_expired_session_without_traceback(monkeypatch):
+    client = _fake_client()
+    client.list_datasets.side_effect = AtlasAuthError(SESSION_EXPIRED_HINT)
+    _patch(monkeypatch, client=client)
+    result = runner.invoke(dataset_app, ["query", "retail_demo.sales"])
+    assert result.exit_code == 1
+    assert "seeknal auth login" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_request_access_refreshes_token_on_401(monkeypatch):
+    client = _fake_client()
+    _patch(monkeypatch, client=client)
+
+    calls = {"n": 0}
+    ok = MagicMock(status_code=200)
+    ok.json.return_value = {"id": "AR-12", "status": "pending"}
+    ok.content = b"{}"
+    expired = MagicMock(status_code=401)
+    expired.text = "Token has expired"
+
+    def fake_post(*a, **k):
+        calls["n"] += 1
+        return expired if calls["n"] == 1 else ok
+
+    monkeypatch.setattr(dataset_mod.httpx, "post", fake_post)
+    monkeypatch.setattr(dataset_mod, "refresh_access_token", lambda: "fresh-token")
+
+    result = runner.invoke(dataset_app, ["request-access", "sales", "--reason", "x"])
+    assert result.exit_code == 0
+    assert calls["n"] == 2  # 401 -> refresh -> retry succeeds
+    assert "AR-12" in result.output
+
+
+def test_request_access_friendly_when_refresh_fails(monkeypatch):
+    client = _fake_client()
+    _patch(monkeypatch, client=client)
+    expired = MagicMock(status_code=401)
+    expired.text = "Token has expired"
+    monkeypatch.setattr(dataset_mod.httpx, "post", lambda *a, **k: expired)
+    monkeypatch.setattr(dataset_mod, "refresh_access_token", lambda: None)
+
+    result = runner.invoke(dataset_app, ["request-access", "sales", "--reason", "x"])
+    assert result.exit_code == 1
+    assert "seeknal auth login" in result.output
+    assert "Traceback" not in result.output

--- a/tests/cli/test_dataset.py
+++ b/tests/cli/test_dataset.py
@@ -1,0 +1,137 @@
+"""Tests for the `seeknal dataset` CLI command group."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from typer.testing import CliRunner
+
+import seeknal.cli.dataset as dataset_mod
+from seeknal.cli.dataset import dataset_app
+from seeknal.integrations.atlas_catalog import Dataset
+from seeknal.integrations.atlas_client import AtlasPolicyDenied
+from seeknal.integrations.atlas_governance import AccessDecision
+
+runner = CliRunner()
+
+DS = Dataset(
+    id="abc-123",
+    name="sales",
+    namespace="retail_demo",
+    asset_type="source",
+    source_system="lakekeeper",
+    description="Retail sales",
+    tags=("gold",),
+    canonical_id="atlas.retail_demo.sales",
+)
+
+
+def _fake_client() -> MagicMock:
+    client = MagicMock()
+    client.list_datasets.return_value = [DS]
+    client.get_dataset.return_value = DS
+    client.sample.return_value = {"columns": ["sale_id", "region"], "rows": [[1, "us-east"]]}
+    client.annotate.return_value = {"ok": True}
+    return client
+
+
+def _patch(monkeypatch, *, client, gate="allow"):
+    monkeypatch.setattr(dataset_mod, "create_catalog_client_from_env", lambda: client)
+    if gate == "allow":
+        gate = MagicMock()
+        gate.check_access.return_value = AccessDecision(allowed=True)
+        gate.enforce_access.return_value = AccessDecision(allowed=True)
+    monkeypatch.setattr(dataset_mod, "create_governance_gate_from_env", lambda: gate)
+    return gate
+
+
+def test_not_configured_exits_2(monkeypatch):
+    _patch(monkeypatch, client=None)
+    result = runner.invoke(dataset_app, ["list"])
+    assert result.exit_code == 2
+    assert "not configured" in result.output.lower()
+
+
+def test_list_renders_datasets(monkeypatch):
+    _patch(monkeypatch, client=_fake_client())
+    result = runner.invoke(dataset_app, ["list"])
+    assert result.exit_code == 0
+    assert "sales" in result.output and "retail_demo" in result.output
+
+
+def test_list_json(monkeypatch):
+    _patch(monkeypatch, client=_fake_client())
+    result = runner.invoke(dataset_app, ["list", "--json"])
+    assert result.exit_code == 0
+    assert '"name": "sales"' in result.output
+
+
+def test_show_prints_metadata_and_access(monkeypatch):
+    _patch(monkeypatch, client=_fake_client())
+    result = runner.invoke(dataset_app, ["show", "sales"])
+    assert result.exit_code == 0
+    assert "retail_demo" in result.output and "ALLOW" in result.output
+
+
+def test_show_with_sample(monkeypatch):
+    client = _fake_client()
+    _patch(monkeypatch, client=client)
+    result = runner.invoke(dataset_app, ["show", "sales", "--sample"])
+    assert result.exit_code == 0
+    assert "us-east" in result.output
+    client.sample.assert_called_once()
+
+
+def test_annotate_calls_client(monkeypatch):
+    client = _fake_client()
+    _patch(monkeypatch, client=client)
+    result = runner.invoke(dataset_app, ["annotate", "sales", "--tag", "pii", "--description", "d"])
+    assert result.exit_code == 0
+    client.annotate.assert_called_once()
+
+
+def test_annotate_requires_a_flag(monkeypatch):
+    _patch(monkeypatch, client=_fake_client())
+    result = runner.invoke(dataset_app, ["annotate", "sales"])
+    assert result.exit_code == 1
+    assert "at least one" in result.output.lower()
+
+
+def test_query_denied_exits_1_with_hint(monkeypatch):
+    gate = MagicMock()
+    gate.enforce_access.side_effect = AtlasPolicyDenied("OpenFGA denies can_select")
+    _patch(monkeypatch, client=_fake_client(), gate=gate)
+    result = runner.invoke(dataset_app, ["query", "sales"])
+    assert result.exit_code == 1
+    assert "request-access" in result.output
+
+
+def test_query_allowed_prints_rows(monkeypatch):
+    client = _fake_client()
+    _patch(monkeypatch, client=client)
+    result = runner.invoke(dataset_app, ["query", "sales"])
+    assert result.exit_code == 0
+    assert "us-east" in result.output
+
+
+def test_query_accepts_direct_table_identifier(monkeypatch):
+    client = _fake_client()
+    client.list_datasets.return_value = []  # not a registered asset
+    gate = _patch(monkeypatch, client=client)
+    result = runner.invoke(dataset_app, ["query", "retail_demo.sales"])
+    assert result.exit_code == 0
+    gate.enforce_access.assert_called_with(resource="retail_demo.sales", action="read")
+    client.sample.assert_called_with("retail_demo.sales", limit=20)
+
+
+def test_request_access_prints_ar_id(monkeypatch):
+    client = _fake_client()
+    _patch(monkeypatch, client=client)
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {"id": "AR-9", "status": "pending"}
+    response.content = b"{}"
+    monkeypatch.setattr(dataset_mod.httpx, "post", lambda *a, **k: response)
+    result = runner.invoke(dataset_app, ["request-access", "sales", "--reason", "need it"])
+    assert result.exit_code == 0
+    assert "AR-9" in result.output

--- a/tests/integrations/test_atlas_catalog.py
+++ b/tests/integrations/test_atlas_catalog.py
@@ -1,0 +1,118 @@
+"""Tests for the Atlas data-catalog client (AtlasCatalogClient)."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+from seeknal.integrations.atlas_catalog import (
+    AtlasCatalogClient,
+    Dataset,
+    create_catalog_client_from_env,
+)
+from seeknal.integrations.atlas_client import AtlasContractConfig
+
+ASSET = {
+    "id": "abc-123",
+    "asset_type": "source",
+    "name": "sales",
+    "namespace": "retail_demo",
+    "source_system": "lakekeeper",
+    "source_id": "source:sales",
+    "metadata": {
+        "description": "Retail sales",
+        "tags": ["gold"],
+        "canonical_asset_id": "atlas.retail_demo.sales",
+    },
+}
+
+
+def _client(handler) -> AtlasCatalogClient:
+    transport = httpx.MockTransport(handler)
+    return AtlasCatalogClient(
+        AtlasContractConfig(base_url="http://atlas", token="tok"),
+        client=httpx.Client(transport=transport),
+    )
+
+
+def test_list_datasets_maps_assets_and_params():
+    seen: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["url"] = str(request.url)
+        assert request.headers["Authorization"] == "Bearer tok"
+        return httpx.Response(200, json=[ASSET])
+
+    datasets = _client(handler).list_datasets(query="sales", asset_type="source", limit=5)
+    assert seen["path"] == "/api/assets"
+    assert "q=sales" in seen["url"] and "type=source" in seen["url"] and "limit=5" in seen["url"]
+    assert len(datasets) == 1
+    d = datasets[0]
+    assert d.name == "sales" and d.namespace == "retail_demo"
+    assert d.tags == ("gold",) and d.description == "Retail sales"
+    assert d.fqn == "atlas.retail_demo.sales"
+
+
+def test_get_dataset_hits_id_path():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/assets/abc-123"
+        return httpx.Response(200, json=ASSET)
+
+    assert _client(handler).get_dataset("abc-123").name == "sales"
+
+
+def test_search_handles_dict_and_list_shapes():
+    assert len(_client(lambda r: httpx.Response(200, json={"results": [ASSET]})).search("x")) == 1
+    assert len(_client(lambda r: httpx.Response(200, json={"items": [ASSET]})).search("x")) == 1
+    assert len(_client(lambda r: httpx.Response(200, json=[ASSET])).search("x")) == 1
+
+
+def test_sample_requires_identifier_param():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/sample"
+        assert request.url.params.get("identifier") == "retail_demo.sales"
+        assert request.url.params.get("limit") == "3"
+        return httpx.Response(200, json={"columns": ["a"], "rows": [[1]]})
+
+    out = _client(handler).sample("retail_demo.sales", limit=3)
+    assert out["rows"] == [[1]]
+
+
+def test_annotate_merges_tags_then_registers():
+    calls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.url.path)
+        if request.url.path == "/api/assets/abc-123":
+            return httpx.Response(200, json=ASSET)
+        if request.url.path == "/api/contracts/assets/register":
+            body = json.loads(request.content)
+            asset = body["asset"]
+            assert "pii" in asset["tags"] and "gold" in asset["tags"]  # union with existing
+            assert asset["description"] == "new desc"
+            return httpx.Response(200, json={"asset": asset})
+        return httpx.Response(404)
+
+    _client(handler).annotate("abc-123", tags=["pii"], description="new desc")
+    assert calls == ["/api/assets/abc-123", "/api/contracts/assets/register"]
+
+
+def test_dataset_from_api_is_tolerant_of_missing_fields():
+    d = Dataset.from_api({"id": "1", "name": "n"})
+    assert d.namespace == "" and d.tags == () and d.description == ""
+    assert d.fqn == "n"
+
+
+def test_factory_returns_none_without_atlas_api_url(monkeypatch):
+    monkeypatch.delenv("ATLAS_API_URL", raising=False)
+    assert create_catalog_client_from_env() is None
+
+
+def test_factory_builds_client_with_env(monkeypatch):
+    monkeypatch.setenv("ATLAS_API_URL", "http://atlas:8000/")
+    monkeypatch.setenv("ATLAS_API_TOKEN", "svc")
+    client = create_catalog_client_from_env()
+    assert client is not None
+    assert client.config.base_url == "http://atlas:8000" and client.config.token == "svc"

--- a/tests/integrations/test_atlas_catalog.py
+++ b/tests/integrations/test_atlas_catalog.py
@@ -11,7 +11,7 @@ from seeknal.integrations.atlas_catalog import (
     Dataset,
     create_catalog_client_from_env,
 )
-from seeknal.integrations.atlas_client import AtlasContractConfig
+from seeknal.integrations.atlas_client import AtlasAuthError, AtlasContractConfig
 
 ASSET = {
     "id": "abc-123",
@@ -116,3 +116,68 @@ def test_factory_builds_client_with_env(monkeypatch):
     client = create_catalog_client_from_env()
     assert client is not None
     assert client.config.base_url == "http://atlas:8000" and client.config.token == "svc"
+
+
+def test_refreshes_token_on_401_and_retries():
+    """A 401 triggers a single refresh + retry with the new bearer, transparently."""
+
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            assert request.headers["Authorization"] == "Bearer tok"
+            return httpx.Response(401, json={"detail": "Token has expired"})
+        assert request.headers["Authorization"] == "Bearer refreshed"
+        return httpx.Response(200, json=[ASSET])
+
+    client = AtlasCatalogClient(
+        AtlasContractConfig(base_url="http://atlas", token="tok"),
+        client=httpx.Client(transport=httpx.MockTransport(handler)),
+        token_refresher=lambda: "refreshed",
+    )
+    datasets = client.list_datasets(query="sales")
+    assert calls["n"] == 2
+    assert len(datasets) == 1 and datasets[0].name == "sales"
+
+
+def test_raises_auth_error_when_refresh_unavailable():
+    """When the session cannot be refreshed, raise AtlasAuthError with a login hint."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"detail": "Token has expired"})
+
+    client = AtlasCatalogClient(
+        AtlasContractConfig(base_url="http://atlas", token="tok"),
+        client=httpx.Client(transport=httpx.MockTransport(handler)),
+        token_refresher=lambda: None,
+    )
+    try:
+        client.list_datasets(query="sales")
+    except AtlasAuthError as exc:
+        assert "seeknal auth login" in str(exc)
+    else:  # pragma: no cover - explicit failure if no error raised
+        raise AssertionError("expected AtlasAuthError")
+
+
+def test_post_path_also_refreshes_on_401():
+    """The shared sender covers POST (annotate) too, not just GET."""
+
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if request.url.path == "/api/assets/abc-123":
+            return httpx.Response(200, json=ASSET)  # get_dataset inside annotate()
+        # /api/contracts/assets/register (the POST)
+        if calls["n"] <= 2:
+            return httpx.Response(401, json={"detail": "expired"})
+        return httpx.Response(200, json={"ok": True})
+
+    client = AtlasCatalogClient(
+        AtlasContractConfig(base_url="http://atlas", token="tok"),
+        client=httpx.Client(transport=httpx.MockTransport(handler)),
+        token_refresher=lambda: "refreshed",
+    )
+    result = client.annotate("abc-123", tags=["pii"])
+    assert result == {"ok": True}

--- a/tests/integrations/test_atlas_governance.py
+++ b/tests/integrations/test_atlas_governance.py
@@ -8,7 +8,7 @@ it is fail-closed by default, and audit logging can never break a read.
 
 from __future__ import annotations
 
-from typing import Callable
+from typing import Any, Callable
 
 import httpx
 import pytest
@@ -17,7 +17,12 @@ import base64
 import json
 from pathlib import Path
 
-from seeknal.integrations.atlas_client import AtlasContractConfig, AtlasPolicyDenied
+from seeknal.integrations.atlas_client import (
+    AtlasAuthError,
+    AtlasContractConfig,
+    AtlasPolicyDenied,
+    SESSION_EXPIRED_HINT,
+)
 from seeknal.integrations.atlas_governance import (
     MASK_TOKEN,
     AccessDecision,
@@ -29,6 +34,7 @@ from seeknal.integrations.atlas_governance import (
     mask_rows,
     mask_value,
     referenced_tables,
+    refresh_access_token,
     user_sub_from_credentials,
     user_token_from_credentials,
 )
@@ -469,3 +475,181 @@ def test_user_sub_from_credentials_none_when_absent(
 ) -> None:
     monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(tmp_path / "missing.json"))
     assert user_sub_from_credentials() is None
+
+
+# ---------------------------------------------------------------------------
+# refresh_access_token
+# ---------------------------------------------------------------------------
+
+
+def _write_creds_with_refresh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    access_token: str = "old-access",
+    refresh_token: str | None = "rt-1",
+) -> Path:
+    """Write a credentials file (optionally without a refresh token) and point env at it."""
+
+    payload: dict[str, Any] = {"access_token": access_token, "expires_in": 300}
+    if refresh_token is not None:
+        payload["refresh_token"] = refresh_token
+        payload["refresh_expires_in"] = 1800
+    creds = tmp_path / "credentials.json"
+    creds.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(creds))
+    return creds
+
+
+def test_refresh_access_token_success_persists_rotation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("KEYCLOAK_ISSUER", "http://kc.test/realms/atlas")
+    monkeypatch.delenv("SEEKNAL_OIDC_CLIENT_ID", raising=False)
+    creds = _write_creds_with_refresh(tmp_path, monkeypatch)
+
+    seen: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["body"] = request.content.decode()
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "new-access",
+                "refresh_token": "rt-2",
+                "expires_in": 300,
+                "refresh_expires_in": 1800,
+            },
+        )
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    token = refresh_access_token(client=client)
+
+    assert token == "new-access"
+    assert seen["path"] == "/realms/atlas/protocol/openid-connect/token"
+    assert "grant_type=refresh_token" in seen["body"]
+    assert "refresh_token=rt-1" in seen["body"]
+    assert "client_id=seeknal-cli" in seen["body"]
+    # Rotated tokens are persisted (mode 0600) for the next call.
+    saved = json.loads(creds.read_text(encoding="utf-8"))
+    assert saved["access_token"] == "new-access"
+    assert saved["refresh_token"] == "rt-2"
+    # The refreshed credentials file must be owner-only (no world/group read window).
+    assert (creds.stat().st_mode & 0o777) == 0o600
+
+
+def test_refresh_access_token_none_without_refresh_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_creds_with_refresh(tmp_path, monkeypatch, refresh_token=None)
+    client = httpx.Client(transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})))
+    assert refresh_access_token(client=client) is None
+
+
+def test_refresh_access_token_none_on_rejected_grant(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("KEYCLOAK_ISSUER", "http://kc.test/realms/atlas")
+    _write_creds_with_refresh(tmp_path, monkeypatch)
+    client = httpx.Client(
+        transport=httpx.MockTransport(lambda r: httpx.Response(401, json={"error": "invalid_grant"}))
+    )
+    # An expired/invalid refresh token yields None (never raises).
+    assert refresh_access_token(client=client) is None
+
+
+def test_refresh_access_token_none_when_no_credentials(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(tmp_path / "missing.json"))
+    assert refresh_access_token() is None
+
+
+# ---------------------------------------------------------------------------
+# Gate token-refresh on 401
+# ---------------------------------------------------------------------------
+
+
+def test_gate_refreshes_token_on_401_and_retries() -> None:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            assert request.headers["Authorization"] == "Bearer t0ken"
+            return httpx.Response(401, json={"detail": "Token has expired"})
+        assert request.headers["Authorization"] == "Bearer fresh"
+        return httpx.Response(200, json={"allowed": True, "reason": "ok"})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    config = AtlasContractConfig(base_url=BASE_URL, token="t0ken", timeout_seconds=5.0)
+    gate = GovernanceGate(config, client=client, token_refresher=lambda: "fresh")
+
+    decision = gate.check_access(resource="retail_demo.sales", action="read")
+    assert decision.allowed is True
+    assert calls["n"] == 2
+
+
+def test_gate_fail_closed_when_refresh_unavailable() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"detail": "expired"})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    config = AtlasContractConfig(base_url=BASE_URL, token="t0ken", timeout_seconds=5.0)
+    gate = GovernanceGate(config, client=client, token_refresher=lambda: None)
+
+    # Unrecoverable 401 keeps the fail-closed contract (a denied decision, no raise),
+    # and the reason is the actionable re-auth hint, not "Atlas unreachable".
+    decision = gate.check_access(resource="retail_demo.sales", action="read")
+    assert decision.allowed is False
+    assert decision.reason == SESSION_EXPIRED_HINT
+
+
+def test_gate_post_raises_auth_error_on_unrecoverable_401() -> None:
+    """The low-level sender raises AtlasAuthError (not a generic error) on a dead 401,
+    mirroring AtlasCatalogClient._send so the exception type is consistent."""
+
+    client = httpx.Client(
+        transport=httpx.MockTransport(lambda r: httpx.Response(401, json={"detail": "expired"}))
+    )
+    config = AtlasContractConfig(base_url=BASE_URL, token="t0ken", timeout_seconds=5.0)
+    gate = GovernanceGate(config, client=client, token_refresher=lambda: None)
+
+    with pytest.raises(AtlasAuthError) as excinfo:
+        gate._post("/api/contracts/access-check", {"operation": "access-check"})
+    assert "seeknal auth login" in str(excinfo.value)
+
+
+def test_gate_fail_open_still_denies_on_expired_session() -> None:
+    """Security: fail-open trades availability for enforcement on *transport* errors,
+    but an expired session is an auth failure and must never be waved through."""
+
+    client = httpx.Client(
+        transport=httpx.MockTransport(lambda r: httpx.Response(401, json={"detail": "expired"}))
+    )
+    config = AtlasContractConfig(base_url=BASE_URL, token="t0ken", timeout_seconds=5.0)
+    gate = GovernanceGate(config, fail_open=True, client=client, token_refresher=lambda: None)
+
+    decision = gate.check_access(resource="retail_demo.sales", action="read")
+    assert decision.allowed is False  # NOT allowed, despite fail_open=True
+    assert decision.reason == SESSION_EXPIRED_HINT
+
+
+def test_enforce_access_on_expired_session_raises_policy_denied_not_auth_error() -> None:
+    """Run-safety contract: even though _post raises AtlasAuthError internally, the
+    public enforce_access() must still surface AtlasPolicyDenied (carrying the re-auth
+    hint as the reason). `seeknal run` catches only AtlasPolicyDenied, so raising
+    AtlasAuthError here would regress it into an uncaught traceback."""
+
+    client = httpx.Client(
+        transport=httpx.MockTransport(lambda r: httpx.Response(401, json={"detail": "expired"}))
+    )
+    config = AtlasContractConfig(base_url=BASE_URL, token="t0ken", timeout_seconds=5.0)
+    gate = GovernanceGate(config, client=client, token_refresher=lambda: None)
+
+    with pytest.raises(AtlasPolicyDenied) as excinfo:
+        gate.enforce_access(resource="retail_demo.sales", action="read")
+    # Not an AtlasAuthError (sibling type that `seeknal run` would not catch).
+    assert not isinstance(excinfo.value, AtlasAuthError)
+    assert str(excinfo.value) == SESSION_EXPIRED_HINT


### PR DESCRIPTION
Stacked on #74 (`feat/atlas-governance-mainline`). Makes Atlas a **first-class data catalog inside the seeknal CLI** when `ATLAS_API_URL` is set: browse, annotate, request access to, and preview governed datasets — every read flows the logged-in user's token and is access-checked + masked by the governance gate.

### What's in it
**`seeknal dataset` command group** (`list` / `show` / `annotate` / `request-access` / `query`) + REPL Atlas-catalog registration. New `AtlasCatalogClient` (GET-only over the unified-catalog read API) reusing `AtlasContractConfig`, the per-user token, and `GovernanceGate`.

Plus two robustness fixes found while exercising it end-to-end against a live backend:

1. **Row preview rendered blank** — the backend `/api/sample` wraps each row as `{"values": {col: val}}`; the renderer read the outer dict so every cell was empty. Now unwraps the `values` envelope (tolerant of the flat shape too).
2. **Expired session UX** — a 401 ("Token has expired") used to dump a raw traceback and the ~5-min token never refreshed. A 401 now transparently refreshes the access token from the stored `refresh_token` (Keycloak `refresh_token` grant, public `seeknal-cli` client) and retries once; when refresh is impossible it prints a one-line `Run \`seeknal auth login\`` hint and exits 1 — never a traceback. New `AtlasAuthError` + `SESSION_EXPIRED_HINT`; `refresh_access_token()` persists rotated tokens via an atomic mode-0600 write; `GovernanceGate` + `AtlasCatalogClient` both refresh-on-401.

### Safety
`GovernanceGate` keeps its **fail-closed contract**: `check_access` still returns a denied `AccessDecision` and `enforce_access` still raises `AtlasPolicyDenied` (with the re-auth hint as the reason), so `seeknal run` — which catches only `AtlasPolicyDenied` — is not regressed. Auth-expiry fails closed even under `ATLAS_FAIL_OPEN=true` (an unauthenticated caller is never waved through). Config-gated: with no `ATLAS_API_URL` the catalog factory returns `None` and the commands exit 2 with a hint.

### Tests / verification
- **549 integration + cli tests pass**; ruff clean; all modules import.
- New coverage: catalog client mapping/search/sample, the `dataset` commands, the `values`-envelope unwrap, refresh success/rotation/0600-perms/no-token/rejected-grant, catalog & gate 401-retry, gate fail-closed + fail-open-still-denies, the `seeknal run` safety contract, friendly CLI presentation (exit 1, no traceback), and `request-access` refresh.
- Live-verified against a real Atlas backend (analyst): expired-access+valid-refresh → transparent auto-refresh + token rotated to disk; both-invalid → friendly hint + exit 1; valid token → governed rows.
- An adversarial multi-lens (correctness/security/simplicity) review drove a critical fix (gate exception-type consistency) and a security fix (atomic 0600 credentials write).

🤖 Generated with [Claude Code](https://claude.com/claude-code)