### PR TITLE
release(2.10.0): Atlas governance + catalog CLI, gateway media /ask, heartbeat daemon, Ask access policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,15 @@ SEEKNAL_USER_CONFIG_PATH="${HOME}/.seeknal/config.toml"
 # Optional: Turso database for production
 # TURSO_DATABASE_URL="libsql://your-database.turso.io"
 # TURSO_AUTH_TOKEN="your-turso-auth-token"
+
+# Optional: Atlas data governance.
+# Setting ATLAS_API_URL activates governance — apply-time policy checks and
+# runtime data-access enforcement (source sample reads are access-checked and
+# sensitive columns masked via the Atlas backend). Unset = inactive; reads pass
+# through unchanged.
+# ATLAS_API_URL="http://atlas-dev-server:8000"
+# ATLAS_API_TOKEN="<optional bearer token>"
+# ATLAS_FAIL_OPEN="false"            # default fail-closed: deny when Atlas is unreachable
+# ATLAS_ACTOR="you@example.com"      # defaults to the OS user
+# SEEKNAL_PROJECT_NAME="my_project"
+# ATLAS_ENVIRONMENT="dev"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.10.0] - 2026-06-05
+## [2.10.0] - 2026-06-10
 
 Atlas data-access governance — first-class, config-activated access enforcement for
 `seeknal run` and the Ask SQL path, plus the requester/owner access-request CLI loop.
 Previously available only on the `feat/atlas-access-request-flow` branch; now mainline.
+Also ships the heartbeat daemon, deeper Atlas/DataHub catalog integration, Ask access
+policy with an admin approval loop, and two auth/packaging fixes for the failures hit
+in real projects (apply rejecting logged-in users; wheels crashing on import).
 
 ### Added
 
@@ -25,6 +28,45 @@ Previously available only on the `feat/atlas-access-request-flow` branch; now ma
   and supply the per-user identity (token + `sub`) used for access checks.
 - **Governed Ask SQL execution** — `execute_sql` / REPL reads run through the same
   access-check and apply column masking when the backend reports masked columns.
+- **`seeknal heartbeat` daemon** — HEARTBEAT.md-driven polling daemon (`start` /
+  `tick` / `status` / `review`): scans inbox folders, ingests new files (smart
+  classification, quarantine review), runs the DAG + exposures, and records each tick
+  to `target/heartbeat/runs.jsonl`. Scaffolded by `seeknal init`; now actually
+  included in published wheels (see Fixed).
+- **DataHub-backed `seeknal atlas lineage show`** — real upstream/downstream lineage
+  read through the Atlas catalog (shares the `seeknal dataset lineage` resolvers);
+  `atlas lineage publish` routes through the always-available contract client, so
+  neither needs the optional `atlas-data-platform` package.
+- **`seeknal dataset annotate --term / --domain`** — upsert glossary terms (unioned
+  with existing) and the business domain (`--domain ''` clears it) alongside tags,
+  description, and owners.
+- **Richer apply-time asset metadata** — node `owner`/`owners` and column
+  descriptions/types from YAML are forwarded to Atlas/DataHub so applied datasets get
+  ownership and schema metadata instead of arriving unassigned.
+- **Ask access policy + `seeknal admin`** — role-based access rules for Ask
+  (roles/registry/middleware) with a pending-approval queue managed via the new
+  `seeknal admin` command group; new `extract_finance_document` and
+  `write_seeknal_project_asset` agent tools and a `prepare-seeknal-project` builtin
+  skill.
+- **Gateway media + file ingestion** — `/ask` accepts image attachments for vision
+  OCR and generic file uploads with tabular staging.
+
+### Fixed
+
+- **`seeknal apply` rejected logged-in users** — the Atlas contract client only read
+  `ATLAS_API_TOKEN` and never the credentials written by `seeknal auth login`, so
+  apply failed with `{"detail":"Missing authentication token"}` even after a
+  successful login. It now resolves the token like the governance gate and catalog
+  client (explicit service token wins, else the stored user token), transparently
+  refreshes once on HTTP 401 and retries, persists rotated tokens, and surfaces an
+  actionable hint (`Run \`seeknal auth login\``) for logged-out/expired sessions
+  instead of the raw backend error.
+- **Published wheels crashed on startup (`ModuleNotFoundError:
+  seeknal.cli.heartbeat`)** — the heartbeat module (and the lazily-imported
+  `workflow.manifest_builder` / `iceberg.ingest_writer`) existed only locally and
+  were missing from release builds; v2.9.7's unguarded import killed `seeknal
+  --version` on a clean install. The modules are now tracked and optional command
+  groups are import-guarded so the CLI degrades gracefully.
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.0] - 2026-06-05
+
+Atlas data-access governance — first-class, config-activated access enforcement for
+`seeknal run` and the Ask SQL path, plus the requester/owner access-request CLI loop.
+Previously available only on the `feat/atlas-access-request-flow` branch; now mainline.
+
+### Added
+
+- **Config-activated runtime governance gate** — when `ATLAS_API_URL` is set, a pre-run
+  access check enforces `can_select` (via the Atlas backend / OpenFGA) for every source
+  node a run reads. Denial aborts the run with exit code 1 and a `seeknal gov
+  request-access` hint, **before any data is read**. With `ATLAS_API_URL` unset the gate
+  is a no-op — fully backward compatible.
+- **`seeknal gov request-access <table>`** — request access to a governed dataset through
+  the Atlas governance API (`--reason`, `--access read|write`, `--duration`).
+- **`seeknal auth login` / `status` / `logout`** — authenticate against the Atlas Keycloak
+  realm via PKCE loopback; credentials are cached at `~/.config/seeknal/credentials.json`
+  and supply the per-user identity (token + `sub`) used for access checks.
+- **Governed Ask SQL execution** — `execute_sql` / REPL reads run through the same
+  access-check and apply column masking when the backend reports masked columns.
+
+### Notes
+
+- Activation is opt-in via `ATLAS_API_URL` (+ `KEYCLOAK_ISSUER` for login). The gate fails
+  **closed** on denial; set `ATLAS_FAIL_OPEN=true` to allow on transport error.
+
 ## [2.9.7] - 2026-06-01
 
 Ask agent harness robustness + table-name discoverability — fixes that make

--- a/docs/atlas-dataset-cli.md
+++ b/docs/atlas-dataset-cli.md
@@ -6,17 +6,32 @@ schema and lineage, preview governed rows, request access, and wire a governed
 dataset straight into a pipeline. Every read flows the logged-in user's identity
 to Atlas, so you see exactly what you are permitted to see.
 
-## Configure
+## Configure (one command)
+
+Point the CLI at your Atlas host once — it derives the seeknal-api, portal, and
+Keycloak URLs and persists them to `~/.config/seeknal/atlas.json`, so no per-shell
+env vars are needed:
 
 ```bash
-export ATLAS_API_URL=http://atlas-dev-server:8000        # seeknal-api (gate + sample)
-export ATLAS_PORTAL_URL=http://atlas-dev-server:4200     # portal catalog (list/lineage parity with the web)
-export KEYCLOAK_ISSUER=http://atlas-dev-server:8080/realms/atlas
-seeknal auth login                                       # or a non-interactive token mint
+seeknal auth config set --host atlas-dev-server   # api :8000 · portal :4200 · keycloak :8080/realms/atlas
+seeknal auth login                                # sign in (Keycloak PKCE)
+seeknal dataset list                              # ready — no env vars
 ```
 
-With `ATLAS_API_URL` unset the whole group is inactive (commands exit with a hint),
-and `seeknal run` is ungoverned — full backward compatibility.
+Or do both in one step, and inspect/override later:
+
+```bash
+seeknal auth login --host atlas-dev-server   # configure + sign in together
+seeknal auth config show                     # effective values + where each comes from (env/config/default)
+```
+
+Non-standard deployment? Override any piece: `--api-url`, `--portal-url`,
+`--keycloak-issuer`, `--realm`, `--client-id`. **Environment variables still win**
+over the config file (`ATLAS_API_URL`, `ATLAS_PORTAL_URL`, `KEYCLOAK_ISSUER`,
+`SEEKNAL_OIDC_CLIENT_ID`), so CI/automation can override without editing the file.
+
+With none of these set the whole group is inactive (commands exit with a hint) and
+`seeknal run` is ungoverned — full backward compatibility.
 
 ## Discover → inspect
 

--- a/docs/atlas-dataset-cli.md
+++ b/docs/atlas-dataset-cli.md
@@ -1,0 +1,69 @@
+# Atlas data catalog from the CLI (`seeknal dataset`)
+
+When Atlas is configured, the `seeknal dataset` command group gives the CLI the
+same capabilities as the Atlas web portal — discover datasets, inspect their
+schema and lineage, preview governed rows, request access, and wire a governed
+dataset straight into a pipeline. Every read flows the logged-in user's identity
+to Atlas, so you see exactly what you are permitted to see.
+
+## Configure
+
+```bash
+export ATLAS_API_URL=http://atlas-dev-server:8000        # seeknal-api (gate + sample)
+export ATLAS_PORTAL_URL=http://atlas-dev-server:4200     # portal catalog (list/lineage parity with the web)
+export KEYCLOAK_ISSUER=http://atlas-dev-server:8080/realms/atlas
+seeknal auth login                                       # or a non-interactive token mint
+```
+
+With `ATLAS_API_URL` unset the whole group is inactive (commands exit with a hint),
+and `seeknal run` is ungoverned — full backward compatibility.
+
+## Discover → inspect
+
+```bash
+seeknal dataset list                       # the same catalog the web shows (Lakekeeper tables + cubes)
+seeknal dataset list -q sales --type table
+seeknal dataset show retail_demo.sales     # metadata + columns/schema + your live ALLOW/DENY
+seeknal dataset lineage retail_demo.sales  # upstream/downstream (DataHub-backed)
+seeknal dataset query retail_demo.sales --limit 5   # governed, access-checked + masked preview
+```
+
+`show` and `query` print your live access decision; a denied `query` points you at
+`request-access`.
+
+## Use a governed dataset in a pipeline
+
+```bash
+seeknal dataset use retail_demo.sales --write    # scaffolds seeknal/sources/sales.yml
+```
+
+This writes a governed iceberg source:
+
+```yaml
+kind: source
+name: sales
+source: iceberg
+table: atlas.retail_demo.sales
+# catalog_uri + warehouse resolve from profiles.yml (materialization.catalog) or source_defaults.iceberg.
+# `seeknal run` access-checks + masks this table via the Atlas gate.
+```
+
+Reference it in a transform with `ref('source.sales')` and run:
+
+```bash
+seeknal run
+```
+
+`seeknal run` enforces access on every source node before it runs (`_enforce_pre_run`):
+a dataset you have no grant for aborts the run with the Atlas reason — governance is
+not optional and the rules live in Atlas, not in editable local files.
+
+## Request access · annotate
+
+```bash
+seeknal dataset request-access retail_demo.sales --reason "need it for the churn model"
+seeknal dataset annotate retail_demo.sales --tag pii --owner data-team
+```
+
+`request-access` files an Atlas access request (auto-refreshing an expired session
+once before giving up); annotations are written back to the unified catalog.

--- a/docs/cli/apply.md
+++ b/docs/cli/apply.md
@@ -64,6 +64,37 @@ If Atlas denies the policy check, the local file is not moved. If Atlas fails
 after the local write, the local artifact remains in place and `seeknal apply`
 exits with an error so the sync issue is visible.
 
+## Runtime data-access governance
+
+The same Atlas configuration also activates **runtime** governance for data reads.
+When `ATLAS_API_URL` is set, Seeknal delegates read decisions to the Atlas backend
+(OpenFGA-backed) instead of trusting local configuration:
+
+- Source **sample reads** (`seeknal source sync`, the `preview` context template) are
+  access-checked per table, and any columns Atlas classifies as sensitive are masked
+  before sample rows are written into the Ask context.
+- The gate is **fail-closed**: a denied decision *or* an unreachable Atlas yields no
+  rows (the preview degrades to "Preview unavailable"). Set `ATLAS_FAIL_OPEN=true`
+  only where availability must outweigh enforcement.
+- When `ATLAS_API_URL` is unset, governance is inactive and reads pass through
+  unchanged.
+
+Relevant environment variables:
+
+```bash
+export ATLAS_API_URL="http://atlas-dev-server:8000"   # activates governance
+export ATLAS_API_TOKEN="<optional bearer token>"
+export ATLAS_FAIL_OPEN="false"                        # default: fail-closed
+export ATLAS_ACTOR="alice@example.com"                # defaults to the OS user
+```
+
+Inspect or test decisions from the CLI:
+
+```bash
+seeknal atlas governance status                       # is enforcement active?
+seeknal atlas governance check prod.gold.customer --action read
+```
+
 ## Examples
 
 ### Apply a draft file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "seeknal"
-version = "2.9.7"
+version = "2.10.0"
 description = "All-in-one platform for data and AI/ML engineering"
 authors = [
     {name = "Fitra Kacamarga"}

--- a/src/seeknal/__init__.py
+++ b/src/seeknal/__init__.py
@@ -29,7 +29,7 @@ Example:
 For more information, see the documentation at https://seeknal.readthedocs.io/
 """
 
-__version__ = "2.9.7"
+__version__ = "2.10.0"
 
 # Export validation functions
 from .validation import (

--- a/src/seeknal/ask/access/__init__.py
+++ b/src/seeknal/ask/access/__init__.py
@@ -1,0 +1,39 @@
+"""Role-gated access control for the Ask agent (v0.5).
+
+Pieces:
+- ``roles``     — ``Role`` IntEnum + rank comparison
+- ``registry``  — ``tool_min_role`` dict (every Ask tool → its required role)
+- ``messages``  — canonical user-facing reply strings (localizable)
+- ``middleware``— exception types + ``make_role_gated_tool`` decorator
+- ``policy``    — ``.seeknal/access.yml`` loader / resolver
+- ``pending``   — ``.seeknal/access_pending.json`` queue (Step 15)
+
+Imports here are kept lightweight so the module is safe to import at startup.
+"""
+
+from seeknal.ask.access.roles import Role
+from seeknal.ask.access.registry import (
+    tool_min_role,
+    iter_tool_min_roles,
+    register_tool_role,
+)
+from seeknal.ask.access.messages import role_denied_reply
+
+__all__ = [
+    "Role",
+    "tool_min_role",
+    "iter_tool_min_roles",
+    "register_tool_role",
+    "role_denied_reply",
+    "default_local_role",
+]
+
+
+def default_local_role() -> "Role":
+    """Default role for non-Telegram callers (CLI, programmatic Ask sessions).
+
+    Local CLI implies filesystem ownership of the project → ADMIN. The HTTP
+    gateway path must NOT rely on this default; it must supply the role
+    explicitly.
+    """
+    return Role.ADMIN

--- a/src/seeknal/ask/access/messages.py
+++ b/src/seeknal/ask/access/messages.py
@@ -1,0 +1,21 @@
+"""Canonical user-facing strings for the role-gated access surface.
+
+Kept in one module so the prose can be tweaked / localized centrally.
+Assertion contracts in tests check structured log fields, NOT this prose.
+"""
+
+from __future__ import annotations
+
+from seeknal.ask.access.roles import Role
+
+
+def role_denied_reply(tool: str, required: Role, actual: Role | None) -> str:
+    actual_label = actual.label() if actual is not None else "none"
+    return (
+        f"I can't run `{tool}` with your current role (`{actual_label}`). "
+        f"This requires `{required.label()}`. "
+        "Ask the admin to upgrade your access."
+    )
+
+
+__all__ = ["role_denied_reply"]

--- a/src/seeknal/ask/access/middleware.py
+++ b/src/seeknal/ask/access/middleware.py
@@ -1,0 +1,165 @@
+"""Role-gated tool wrapping.
+
+Wrap each tool function at ``create_ask_toolset()`` time. The wrapped tool
+preserves the original signature so pydantic-ai sees the same parameter
+schema as the unwrapped function.
+
+Exception hierarchy:
+- ``AccessError``           — base; **NOT** a ``RuntimeError`` subclass, so a
+  broad ``except RuntimeError`` elsewhere can't silently swallow access
+  failures.
+- ``MissingToolRoleError``  — raised at import / toolset-construction time
+  for any tool missing from the registry (fail-closed).
+- ``InsufficientRoleError`` — raised at call time when the caller's role is
+  below the tool's ``min_role``.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from functools import wraps
+from typing import Any, Awaitable, Callable, Optional
+
+from seeknal.ask.access.registry import tool_min_role
+from seeknal.ask.access.roles import Role
+
+
+access_logger = logging.getLogger("seeknal.access")
+
+
+class AccessError(Exception):
+    """Base class for access-control failures. Not a RuntimeError."""
+
+
+class MissingToolRoleError(AccessError):
+    """A tool was wrapped without a min_role registration."""
+
+    def __init__(self, tool: str):
+        super().__init__(
+            f"Tool {tool!r} has no min_role registration. "
+            "Refusing to wrap (fail closed)."
+        )
+        self.tool = tool
+
+
+class InsufficientRoleError(AccessError):
+    """Caller role rank < required tool role rank."""
+
+    def __init__(self, tool: str, required: Role, actual: Optional[Role]):
+        actual_label = actual.label() if actual is not None else "none"
+        super().__init__(
+            f"Tool {tool!r} requires role {required.label()!r}; "
+            f"caller has role {actual_label!r}."
+        )
+        self.tool = tool
+        self.required = required
+        self.actual = actual
+
+
+def _resolve_role(actual: Optional[Role]) -> Optional[Role]:
+    """Lookup helper: tolerate string-typed role values for forward compat."""
+    if actual is None:
+        return None
+    if isinstance(actual, Role):
+        return actual
+    if isinstance(actual, str):
+        try:
+            return Role.from_string(actual)
+        except ValueError:
+            return None
+    if isinstance(actual, int):
+        try:
+            return Role(actual)
+        except ValueError:
+            return None
+    return None
+
+
+def _emit_denial(
+    tool: str,
+    required: Role,
+    actual: Optional[Role],
+    user_id: Optional[int],
+) -> None:
+    """Structured log entry for AC15. Keys are the contract."""
+    access_logger.info(
+        "role_denied",
+        extra={
+            "event": "role_denied",
+            "user_id": user_id,
+            "tool": tool,
+            "required": required.label(),
+            "actual": actual.label() if actual is not None else None,
+        },
+    )
+
+
+def make_role_gated_tool(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Wrap a tool function so its declared ``min_role`` is enforced.
+
+    Reads ``requestor_role`` from the active ``ToolContext`` (per-task
+    ContextVar) at call time. If the role is missing or insufficient, raises
+    :class:`InsufficientRoleError`. The original tool signature is preserved
+    so pydantic-ai's tool-schema introspection still works.
+    """
+    name = fn.__name__
+    required = tool_min_role.get(name)
+    if required is None:
+        raise MissingToolRoleError(name)
+
+    is_coroutine = inspect.iscoroutinefunction(fn)
+
+    if is_coroutine:
+
+        @wraps(fn)
+        async def async_wrapper(*args, **kwargs):
+            _enforce_role(name, required)
+            return await fn(*args, **kwargs)
+
+        async_wrapper.__min_role__ = required  # type: ignore[attr-defined]
+        return async_wrapper
+
+    @wraps(fn)
+    def sync_wrapper(*args, **kwargs):
+        _enforce_role(name, required)
+        return fn(*args, **kwargs)
+
+    sync_wrapper.__min_role__ = required  # type: ignore[attr-defined]
+    return sync_wrapper
+
+
+def _enforce_role(tool_name: str, required: Role) -> None:
+    """Look up caller role; raise InsufficientRoleError on mismatch."""
+    from seeknal.ask.agents.tools._context import (  # local import — break cycle
+        get_tool_context,
+    )
+
+    try:
+        ctx = get_tool_context()
+    except Exception:
+        ctx = None
+
+    actual_raw = getattr(ctx, "requestor_role", None) if ctx is not None else None
+    actual = _resolve_role(actual_raw)
+    user_id = None
+    if ctx is not None:
+        for attr in ("telegram_user_id", "user_id", "_user_id"):
+            value = getattr(ctx, attr, None)
+            if isinstance(value, int):
+                user_id = value
+                break
+
+    if actual is None or not actual.can(required):
+        _emit_denial(tool_name, required, actual, user_id)
+        raise InsufficientRoleError(
+            tool=tool_name, required=required, actual=actual
+        )
+
+
+__all__ = [
+    "AccessError",
+    "InsufficientRoleError",
+    "MissingToolRoleError",
+    "make_role_gated_tool",
+]

--- a/src/seeknal/ask/access/pending.py
+++ b/src/seeknal/ask/access/pending.py
@@ -1,0 +1,193 @@
+"""Pending approval queue for unlisted users (Step 15).
+
+Stored at ``.seeknal/access_pending.json``. TTL default 30 days. Best-effort
+cleanup of expired entries runs at start of each tick (orchestrated by the
+caller, not enforced here).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+from seeknal.utils.path_security import is_insecure_path
+
+logger = logging.getLogger("seeknal.access.pending")
+
+DEFAULT_TTL_DAYS = 30
+
+
+def _utcnow() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso(value: str) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        if value.endswith("Z"):
+            return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=timezone.utc
+            )
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+@dataclass
+class PendingRequest:
+    telegram_user_id: int
+    telegram_username: Optional[str] = None
+    intro_message: str = ""
+    requested_at: str = ""
+    ttl_until: str = ""
+    notified_admins: list[int] = field(default_factory=list)
+
+
+@dataclass
+class PendingQueue:
+    requests: list[PendingRequest] = field(default_factory=list)
+    source_path: Optional[Path] = None
+
+    @classmethod
+    def load(cls, path: Path) -> "PendingQueue":
+        path = Path(path).expanduser()
+        if is_insecure_path(str(path)):
+            raise ValueError(
+                f"Insecure pending-queue path: {path!s}. "
+                "Use .seeknal/access_pending.json inside the project."
+            )
+        if not path.exists():
+            return cls(source_path=path)
+        try:
+            raw = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("Pending queue at %s is corrupt (%s); starting empty.", path, exc)
+            return cls(source_path=path)
+        if not isinstance(raw, list):
+            return cls(source_path=path)
+        queue = cls(source_path=path)
+        for entry in raw:
+            if not isinstance(entry, dict):
+                continue
+            user_id = entry.get("telegram_user_id")
+            if not isinstance(user_id, int):
+                continue
+            queue.requests.append(
+                PendingRequest(
+                    telegram_user_id=user_id,
+                    telegram_username=entry.get("telegram_username"),
+                    intro_message=entry.get("intro_message", "") or "",
+                    requested_at=entry.get("requested_at", "") or "",
+                    ttl_until=entry.get("ttl_until", "") or "",
+                    notified_admins=list(entry.get("notified_admins") or []),
+                )
+            )
+        return queue
+
+    def save(self, path: Optional[Path] = None) -> Path:
+        target = Path(path or self.source_path)
+        if is_insecure_path(str(target)):
+            raise ValueError(f"Insecure pending-queue save path: {target!s}.")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        payload = [
+            {
+                "telegram_user_id": req.telegram_user_id,
+                "telegram_username": req.telegram_username,
+                "intro_message": req.intro_message,
+                "requested_at": req.requested_at,
+                "ttl_until": req.ttl_until,
+                "notified_admins": list(req.notified_admins),
+            }
+            for req in self.requests
+        ]
+        fd, tmp = tempfile.mkstemp(
+            prefix=".access_pending.",
+            suffix=".json.tmp",
+            dir=str(target.parent),
+        )
+        try:
+            with os.fdopen(fd, "w") as fh:
+                json.dump(payload, fh, indent=2, sort_keys=True)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp, target)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except FileNotFoundError:
+                pass
+            raise
+        self.source_path = target
+        return target
+
+    def add(
+        self,
+        *,
+        telegram_user_id: int,
+        intro_message: str,
+        telegram_username: Optional[str] = None,
+        ttl_days: int = DEFAULT_TTL_DAYS,
+    ) -> PendingRequest:
+        # If already present, just refresh intro_message.
+        for req in self.requests:
+            if req.telegram_user_id == telegram_user_id:
+                req.intro_message = intro_message
+                req.telegram_username = telegram_username or req.telegram_username
+                return req
+        now = _utcnow()
+        req = PendingRequest(
+            telegram_user_id=telegram_user_id,
+            telegram_username=telegram_username,
+            intro_message=intro_message[:500],
+            requested_at=_iso(now),
+            ttl_until=_iso(now + timedelta(days=ttl_days)),
+        )
+        self.requests.append(req)
+        return req
+
+    def get(self, telegram_user_id: int) -> Optional[PendingRequest]:
+        for req in self.requests:
+            if req.telegram_user_id == telegram_user_id:
+                return req
+        return None
+
+    def remove(self, telegram_user_id: int) -> bool:
+        before = len(self.requests)
+        self.requests = [
+            r for r in self.requests if r.telegram_user_id != telegram_user_id
+        ]
+        return len(self.requests) < before
+
+    def mark_notified(self, telegram_user_id: int, admin_id: int) -> None:
+        req = self.get(telegram_user_id)
+        if req is None:
+            return
+        if admin_id not in req.notified_admins:
+            req.notified_admins.append(admin_id)
+
+    def cleanup_expired(self, now: Optional[datetime] = None) -> int:
+        now = now or _utcnow()
+        keep: list[PendingRequest] = []
+        dropped = 0
+        for req in self.requests:
+            ttl = _parse_iso(req.ttl_until)
+            if ttl is None or ttl > now:
+                keep.append(req)
+            else:
+                dropped += 1
+        self.requests = keep
+        return dropped
+
+
+__all__ = ["PendingQueue", "PendingRequest", "DEFAULT_TTL_DAYS"]

--- a/src/seeknal/ask/access/policy.py
+++ b/src/seeknal/ask/access/policy.py
@@ -1,0 +1,277 @@
+"""Access policy loader for ``.seeknal/access.yml``.
+
+Schema (validated at load time):
+
+    schema_version: 1
+    default_role: none            # or viewer/analyst/operator/engineer/admin
+    allowlist:
+      - telegram_user_id: 123456
+        telegram_username: alice  # display only; not authoritative
+        role: viewer
+        notes: "CEO"
+        added_at: 2026-05-15T10:00:00Z
+        added_by: founder
+      - telegram_chat_id: -100123456
+        role: viewer
+        notes: "Leadership group"
+    deny_list:
+      - telegram_user_id: 987654
+        reason: "removed 2026-04-01"
+
+``user_id`` is the security primary key. ``username`` is display only and
+must never be used for security decisions.
+
+``AccessPolicy.resolve(user_id, username, chat_id) -> Role | None``:
+    1. ``deny_list[user_id]`` → ``None`` (no access).
+    2. ``allowlist[user_id]`` → role.
+    3. ``allowlist[chat_id]`` → group role.
+    4. ``default_role`` (returns ``None`` for ``"none"``).
+
+Atomic save via tempfile + os.replace. Path security validated via
+``is_insecure_path``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+from seeknal.ask.access.roles import Role
+from seeknal.utils.path_security import is_insecure_path
+
+logger = logging.getLogger("seeknal.access.policy")
+
+
+@dataclass
+class AllowlistEntry:
+    telegram_user_id: Optional[int] = None
+    telegram_chat_id: Optional[int] = None
+    telegram_username: Optional[str] = None
+    role: Optional[Role] = None
+    notes: str = ""
+    added_at: str = ""
+    added_by: str = ""
+
+    def to_yaml(self) -> dict[str, Any]:
+        data: dict[str, Any] = {}
+        if self.telegram_user_id is not None:
+            data["telegram_user_id"] = self.telegram_user_id
+        if self.telegram_chat_id is not None:
+            data["telegram_chat_id"] = self.telegram_chat_id
+        if self.telegram_username:
+            data["telegram_username"] = self.telegram_username
+        if self.role is not None:
+            data["role"] = self.role.label()
+        if self.notes:
+            data["notes"] = self.notes
+        if self.added_at:
+            data["added_at"] = self.added_at
+        if self.added_by:
+            data["added_by"] = self.added_by
+        return data
+
+
+@dataclass
+class DenyEntry:
+    telegram_user_id: int
+    reason: str = ""
+    added_at: str = ""
+
+    def to_yaml(self) -> dict[str, Any]:
+        data: dict[str, Any] = {"telegram_user_id": self.telegram_user_id}
+        if self.reason:
+            data["reason"] = self.reason
+        if self.added_at:
+            data["added_at"] = self.added_at
+        return data
+
+
+@dataclass
+class AccessPolicy:
+    schema_version: int = 1
+    default_role: Optional[Role] = None
+    allowlist: list[AllowlistEntry] = field(default_factory=list)
+    deny_list: list[DenyEntry] = field(default_factory=list)
+    source_path: Optional[Path] = None
+
+    @classmethod
+    def empty(cls, source_path: Optional[Path] = None) -> "AccessPolicy":
+        return cls(source_path=source_path)
+
+    @classmethod
+    def load(cls, path: Path) -> "AccessPolicy":
+        path = Path(path).expanduser()
+        if is_insecure_path(str(path)):
+            raise ValueError(
+                f"Insecure access policy path: {path!s}. "
+                "Use .seeknal/access.yml inside the project."
+            )
+        if not path.exists():
+            return cls.empty(source_path=path)
+        with open(path, "r") as fh:
+            raw = yaml.safe_load(fh) or {}
+        if not isinstance(raw, dict):
+            raise ValueError(
+                f"access.yml at {path} did not parse to a mapping."
+            )
+
+        policy = cls(source_path=path)
+        policy.schema_version = int(raw.get("schema_version", 1))
+
+        default = raw.get("default_role")
+        if default and str(default).lower() != "none":
+            policy.default_role = Role.from_string(str(default))
+
+        for entry in raw.get("allowlist", []) or []:
+            if not isinstance(entry, dict):
+                continue
+            role_raw = entry.get("role")
+            role = Role.from_string(str(role_raw)) if role_raw else None
+            policy.allowlist.append(
+                AllowlistEntry(
+                    telegram_user_id=entry.get("telegram_user_id"),
+                    telegram_chat_id=entry.get("telegram_chat_id"),
+                    telegram_username=entry.get("telegram_username"),
+                    role=role,
+                    notes=entry.get("notes", "") or "",
+                    added_at=entry.get("added_at", "") or "",
+                    added_by=entry.get("added_by", "") or "",
+                )
+            )
+        for entry in raw.get("deny_list", []) or []:
+            if not isinstance(entry, dict):
+                continue
+            user_id = entry.get("telegram_user_id")
+            if not isinstance(user_id, int):
+                continue
+            policy.deny_list.append(
+                DenyEntry(
+                    telegram_user_id=user_id,
+                    reason=entry.get("reason", "") or "",
+                    added_at=entry.get("added_at", "") or "",
+                )
+            )
+        return policy
+
+    def save(self, path: Optional[Path] = None) -> Path:
+        target = Path(path or self.source_path)
+        if is_insecure_path(str(target)):
+            raise ValueError(
+                f"Insecure save path: {target!s}. "
+                "Use a project-local .seeknal/ path."
+            )
+        target.parent.mkdir(parents=True, exist_ok=True)
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "default_role": self.default_role.label() if self.default_role else "none",
+            "allowlist": [entry.to_yaml() for entry in self.allowlist],
+            "deny_list": [entry.to_yaml() for entry in self.deny_list],
+        }
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=".access.", suffix=".yml.tmp", dir=str(target.parent)
+        )
+        try:
+            with os.fdopen(fd, "w") as fh:
+                yaml.safe_dump(payload, fh, sort_keys=False)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp_path, target)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+            raise
+        self.source_path = target
+        return target
+
+    def resolve(
+        self,
+        user_id: int,
+        username: Optional[str] = None,
+        chat_id: Optional[int] = None,
+    ) -> Optional[Role]:
+        """Resolve a caller's effective role. ``None`` means no access."""
+        del username  # display-only; never used for security decisions.
+
+        for entry in self.deny_list:
+            if entry.telegram_user_id == user_id:
+                return None
+
+        for entry in self.allowlist:
+            if entry.role is None:
+                continue
+            if entry.telegram_user_id is not None and entry.telegram_user_id == user_id:
+                return entry.role
+
+        if chat_id is not None:
+            for entry in self.allowlist:
+                if entry.role is None:
+                    continue
+                if (
+                    entry.telegram_chat_id is not None
+                    and entry.telegram_chat_id == chat_id
+                ):
+                    return entry.role
+
+        return self.default_role
+
+    def grant(
+        self,
+        *,
+        telegram_user_id: Optional[int] = None,
+        telegram_chat_id: Optional[int] = None,
+        role: Role,
+        username: Optional[str] = None,
+        notes: str = "",
+        added_by: str = "",
+        added_at: str = "",
+    ) -> AllowlistEntry:
+        """Add or replace an allowlist entry."""
+        if telegram_user_id is None and telegram_chat_id is None:
+            raise ValueError(
+                "grant() requires telegram_user_id or telegram_chat_id."
+            )
+        # Remove any prior entry on the same primary key.
+        self.allowlist = [
+            e
+            for e in self.allowlist
+            if e.telegram_user_id != telegram_user_id
+            or e.telegram_chat_id != telegram_chat_id
+        ]
+        entry = AllowlistEntry(
+            telegram_user_id=telegram_user_id,
+            telegram_chat_id=telegram_chat_id,
+            telegram_username=username,
+            role=role,
+            notes=notes,
+            added_at=added_at,
+            added_by=added_by,
+        )
+        self.allowlist.append(entry)
+        return entry
+
+    def revoke(self, telegram_user_id: int, *, deny_reason: Optional[str] = None) -> bool:
+        """Remove a user from the allowlist; optionally add to deny_list."""
+        before = len(self.allowlist)
+        self.allowlist = [
+            e for e in self.allowlist if e.telegram_user_id != telegram_user_id
+        ]
+        removed = len(self.allowlist) < before
+        if deny_reason is not None:
+            self.deny_list = [
+                e for e in self.deny_list if e.telegram_user_id != telegram_user_id
+            ]
+            self.deny_list.append(
+                DenyEntry(telegram_user_id=telegram_user_id, reason=deny_reason)
+            )
+        return removed
+
+
+__all__ = ["AccessPolicy", "AllowlistEntry", "DenyEntry"]

--- a/src/seeknal/ask/access/registry.py
+++ b/src/seeknal/ask/access/registry.py
@@ -1,0 +1,120 @@
+"""Per-tool ``min_role`` registry.
+
+Single source of truth for which role is required to invoke each Ask tool.
+A contract test enforces that every tool registered in
+``seeknal.ask.agents.tools.toolset`` has an entry here — any missing entry
+fails the build (Principle 7: fail-closed; AC15).
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from seeknal.ask.access.roles import Role
+
+# Tools the Telegram bot exposes to all listed users (read-only discovery
+# + low-risk reads).
+_VIEWER_TOOLS = {
+    "list_tables",
+    "describe_table",
+    "query_metric",
+    "preview_query",
+    "execute_sql",
+    "list_ask_tests",
+    "read_ask_test",
+    "list_ask_test_results",
+    "read_ask_test_result",
+    "read_pipeline",
+    "read_project_file",
+    "read_source_context",
+    "read_sql_pair",
+    "list_sql_pairs",
+    "list_context_files",
+    "list_source_context",
+    "read_tabular",
+    "show_lineage",
+    "get_entities",
+    "get_entity_schema",
+    "profile_data",
+    "inspect_output",
+    "open_in_browser",
+    "web_firecrawl",
+    "read_proof_document",
+    "parse_record",
+    "extract_from_image",
+    "extract_finance_document",
+    "ask_user",
+}
+
+# Analysts can additionally save personal preferences, draft pipelines, and
+# generate reports — but they cannot run pipelines or write to bronze tables.
+_ANALYST_TOOLS = {
+    "save_metric",
+    "save_preference",
+    "save_ingestion_skill",
+    "save_report_exposure",
+    "draft_node",
+    "dry_run_draft",
+    "propose_record_table",
+    "plan_pipeline",
+    "submit_plan",
+    "generate_report",
+    "publish_to_proof",
+    "edit_proof_document",
+    "bootstrap_semantic_model",
+    "execute_python",
+    "execute_uv_script",
+    "execute_sql_pair",
+    "run_ask_test",
+}
+
+# Operators can ingest data into bronze tables, run pipelines, and publish.
+_OPERATOR_TOOLS = {
+    "write_ingested_table",
+    "run_pipeline",
+    "check_ingestion_drift",
+    "search_pipelines",
+    "search_project_files",
+    "publish_to_seeknal_report",
+}
+
+# Engineers can edit project structure.
+_ENGINEER_TOOLS = {
+    "apply_draft",
+    "edit_node",
+    "write_project_file",
+    "write_seeknal_project_asset",
+}
+
+
+tool_min_role: dict[str, Role] = {}
+for name in _VIEWER_TOOLS:
+    tool_min_role[name] = Role.VIEWER
+for name in _ANALYST_TOOLS:
+    tool_min_role[name] = Role.ANALYST
+for name in _OPERATOR_TOOLS:
+    tool_min_role[name] = Role.OPERATOR
+for name in _ENGINEER_TOOLS:
+    tool_min_role[name] = Role.ENGINEER
+
+
+def register_tool_role(name: str, role: Role, *, overwrite: bool = False) -> None:
+    """Add a tool → role mapping. Used by tests and future plugins."""
+    if not overwrite and name in tool_min_role:
+        raise ValueError(
+            f"Tool {name!r} already registered with role "
+            f"{tool_min_role[name].label()!r}. Pass overwrite=True to replace."
+        )
+    tool_min_role[name] = role
+
+
+def iter_tool_min_roles() -> Iterable[tuple[str, Role]]:
+    """Yield ``(tool_name, role)`` pairs (sorted, stable order)."""
+    return sorted(tool_min_role.items())
+
+
+__all__ = [
+    "tool_min_role",
+    "register_tool_role",
+    "iter_tool_min_roles",
+]

--- a/src/seeknal/ask/access/roles.py
+++ b/src/seeknal/ask/access/roles.py
@@ -1,0 +1,39 @@
+"""Role hierarchy — integer-rank IntEnum.
+
+Hierarchy: ``viewer < analyst < operator < engineer < admin``. Higher roles
+inherit every lower role's capabilities (integer comparison, not duplicated
+capability lists).
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum
+
+
+class Role(IntEnum):
+    VIEWER = 1
+    ANALYST = 2
+    OPERATOR = 3
+    ENGINEER = 4
+    ADMIN = 5
+
+    def can(self, required: "Role") -> bool:
+        """True iff this role rank ≥ ``required`` rank."""
+        return self.value >= required.value
+
+    @classmethod
+    def from_string(cls, name: str) -> "Role":
+        """Parse a role name (case-insensitive). Raises ValueError on unknown."""
+        try:
+            return cls[name.upper()]
+        except KeyError as exc:
+            raise ValueError(
+                f"Unknown role {name!r}. "
+                "Valid: viewer, analyst, operator, engineer, admin"
+            ) from exc
+
+    def label(self) -> str:
+        return self.name.lower()
+
+
+__all__ = ["Role"]

--- a/src/seeknal/ask/agents/tools/execute_sql.py
+++ b/src/seeknal/ask/agents/tools/execute_sql.py
@@ -262,6 +262,27 @@ def execute_sql(
     has_more_rows = len(rows) > effective_limit
     trimmed_rows = rows[:effective_limit]
 
+    # Runtime governance: when Atlas is configured (ATLAS_API_URL), access-check the
+    # tables this query references and mask sensitive columns before results reach the
+    # model. Inactive (passthrough) when Atlas is not configured. A denial is surfaced
+    # to the agent as a tool message rather than raising.
+    from seeknal.integrations.atlas_client import AtlasPolicyDenied
+    from seeknal.integrations.atlas_governance import (
+        create_governance_gate_from_env,
+        govern_query,
+    )
+
+    _gov_gate = create_governance_gate_from_env()
+    if _gov_gate is not None:
+        try:
+            trimmed_rows = govern_query(
+                _gov_gate, sql=sql, columns=columns, rows=trimmed_rows
+            )
+        except AtlasPolicyDenied as denial:
+            result = f"Access denied by Atlas governance policy: {denial}"
+            record_tool_result("execute_sql", result, args={"sql": sql})
+            return result
+
     # Resolve the real total only when we actually hit the cap — saves the
     # round-trip for normal-sized results.
     total_rows: int | None = None

--- a/src/seeknal/ask/agents/tools/extract_finance_document.py
+++ b/src/seeknal/ask/agents/tools/extract_finance_document.py
@@ -1,0 +1,212 @@
+"""Extract finance documents into reviewable drafts.
+
+Supports PDF invoices plus receipt/payment proof images. The tool returns a
+structured JSON draft only; it never writes trusted records. Agents must ask
+for human review before calling write_ingested_table or any project writer.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+try:
+    from pydantic_ai import Agent, BinaryContent  # type: ignore[import]
+except ImportError:  # pragma: no cover - pydantic_ai is a hard dependency
+    Agent = None  # type: ignore[assignment]
+    BinaryContent = None  # type: ignore[assignment]
+
+_MAX_DOCUMENT_BYTES = 25 * 1024 * 1024
+_MIME_BY_SUFFIX = {
+    ".pdf": "application/pdf",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".webp": "image/webp",
+    ".heic": "image/heic",
+    ".heif": "image/heif",
+}
+
+_EXTRACTION_PROMPT = (
+    "You are extracting a finance document for a small business operations "
+    "workflow. The document may be a supplier invoice, customer invoice, "
+    "receipt, payment proof, bank statement page, purchase order, or other "
+    "finance artifact. Prioritize Malaysian MSME fields, including SST and "
+    "e-Invoice readiness fields, but do not provide tax advice.\n\n"
+    "Return one JSON object only. Never invent values. Use null when uncertain. "
+    "Amounts must be numeric decimal values, not formatted strings. Dates must "
+    "be ISO 8601 when visible. Currency defaults to MYR only when no other "
+    "currency is visible.\n\n"
+    "Required JSON schema:\n"
+    "{\n"
+    "  \"document_kind\": \"supplier_invoice\" | \"customer_invoice\" | "
+    "\"receipt\" | \"payment_proof\" | \"bank_statement\" | "
+    "\"purchase_order\" | \"other\",\n"
+    "  \"direction\": \"ar\" | \"ap\" | \"payment\" | \"other\",\n"
+    "  \"document_number\": string | null,\n"
+    "  \"counterparty_name\": string | null,\n"
+    "  \"counterparty_tax_id\": string | null,\n"
+    "  \"issue_date\": string | null,\n"
+    "  \"due_date\": string | null,\n"
+    "  \"payment_date\": string | null,\n"
+    "  \"po_number\": string | null,\n"
+    "  \"bank_reference\": string | null,\n"
+    "  \"currency\": string,\n"
+    "  \"subtotal_amount\": number | null,\n"
+    "  \"tax_amount\": number | null,\n"
+    "  \"sst_amount\": number | null,\n"
+    "  \"total_amount\": number | null,\n"
+    "  \"line_items\": [{\"description\": string, \"sku\": string | null, "
+    "\"quantity\": number | null, \"unit_price\": number | null, "
+    "\"amount\": number | null}] | [],\n"
+    "  \"readiness_flags\": [string],\n"
+    "  \"confidence\": number,\n"
+    "  \"raw_text\": string\n"
+    "}\n\n"
+    "Readiness flags should call out missing tax info, missing due date, "
+    "missing PO, duplicate-looking document number, amount ambiguity, or "
+    "low OCR confidence when visible. Return JSON only. No markdown."
+)
+
+
+def extract_finance_document(document_path: str, hint: str = "") -> str:
+    """Extract finance fields from a PDF or receipt/payment image.
+
+    The returned JSON is a DRAFT only. Use this for PDF invoices, purchase
+    orders, receipts, bank statement pages, and payment proof images. The
+    agent must present the draft for human review before writing normalized
+    records.
+
+    Args:
+        document_path: Absolute or project-relative local path to PDF/image.
+        hint: Optional free-text hint, e.g. "supplier invoice from textile mill".
+    """
+    from seeknal.ask.agents.tools._context import get_tool_context
+
+    ctx = get_tool_context()
+    path = _resolve_document_path(document_path, ctx.project_path)
+    if path is None:
+        return f"Error: document not found at {document_path}"
+
+    suffix = path.suffix.lower()
+    mime = _MIME_BY_SUFFIX.get(suffix)
+    if not mime:
+        return (
+            f"Error: unsupported finance document format '{suffix}'. "
+            f"Supported: {', '.join(sorted(_MIME_BY_SUFFIX))}."
+        )
+
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        return f"Error: cannot access document: {exc}"
+    if size > _MAX_DOCUMENT_BYTES:
+        return (
+            f"Error: document is {size / 1024 / 1024:.1f} MB, exceeds "
+            f"{_MAX_DOCUMENT_BYTES / 1024 / 1024:.0f} MB limit."
+        )
+
+    try:
+        draft = _call_model(path, mime, hint)
+    except Exception as exc:
+        return f"Error: finance document extraction failed: {exc}"
+
+    try:
+        ctx.last_read_staging_path = str(path)
+    except Exception:
+        pass
+
+    return _format_draft(path, draft, hint)
+
+
+def _resolve_document_path(raw_path: str, project_path: Path) -> Path | None:
+    candidate = Path(raw_path or "").expanduser()
+    if not candidate:
+        return None
+    if not candidate.is_absolute():
+        candidate = (project_path / candidate).resolve()
+    else:
+        candidate = candidate.resolve()
+    if not candidate.exists() or not candidate.is_file():
+        return None
+    return candidate
+
+
+def _call_model(path: Path, mime: str, hint: str) -> dict:
+    from seeknal.ask.agents.providers import get_model_string
+
+    if Agent is None or BinaryContent is None:
+        raise RuntimeError(
+            "pydantic_ai is required for finance document extraction."
+        )
+
+    prompt = _EXTRACTION_PROMPT
+    if hint:
+        prompt = f"{prompt}\n\nUser hint: {hint.strip()}"
+
+    agent = Agent(get_model_string())
+    result = agent.run_sync([
+        prompt,
+        BinaryContent(data=path.read_bytes(), media_type=mime),
+    ])
+    text = (result.output or "").strip()
+    return _parse_json_output(text)
+
+
+def _parse_json_output(raw: str) -> dict:
+    text = raw.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json)?\s*", "", text, flags=re.IGNORECASE)
+        text = re.sub(r"\s*```$", "", text)
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"model returned non-JSON output: {exc}. Raw (first 500 chars): {text[:500]!r}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"model output was not a JSON object: {type(payload).__name__}")
+
+    payload.setdefault("currency", "MYR")
+    payload.setdefault("line_items", [])
+    payload.setdefault("readiness_flags", [])
+    payload.setdefault("confidence", 0)
+    return payload
+
+
+def _format_draft(path: Path, draft: dict, hint: str) -> str:
+    missing = _missing_review_fields(draft)
+    lines = ["## Extracted finance document draft"]
+    lines.append(f"- **Source:** `{path.name}`")
+    if hint:
+        lines.append(f"- **Hint:** {hint}")
+    lines.append("")
+    lines.append("```json")
+    lines.append(json.dumps(draft, ensure_ascii=False, indent=2))
+    lines.append("```")
+    lines.append("")
+    if missing:
+        lines.append("**Fields needing review:** " + ", ".join(missing))
+    else:
+        lines.append("No required review fields are obviously missing.")
+    lines.append("")
+    lines.append(
+        "This is not a trusted accounting record yet. Present the draft to the "
+        "user with `ask_user`, resolve missing fields, then normalize into the "
+        "KAFI canonical tables or route through `propose_record_table` and "
+        "`write_ingested_table`."
+    )
+    return "\n".join(lines)
+
+
+def _missing_review_fields(draft: dict) -> list[str]:
+    kind = str(draft.get("document_kind") or "").lower()
+    required = ["document_kind", "counterparty_name", "total_amount"]
+    if kind in {"supplier_invoice", "customer_invoice"}:
+        required.extend(["document_number", "issue_date"])
+    if kind == "supplier_invoice":
+        required.append("due_date")
+    if kind == "payment_proof":
+        required.extend(["payment_date", "bank_reference"])
+    return [field for field in required if not draft.get(field)]

--- a/src/seeknal/ask/agents/tools/write_seeknal_project_asset.py
+++ b/src/seeknal/ask/agents/tools/write_seeknal_project_asset.py
@@ -1,0 +1,199 @@
+"""Write Seeknal project-prep assets safely.
+
+This tool is intentionally narrower than a general coding-agent filesystem
+writer.  It lets Ask project-setup mode create or update durable Seeknal Ask
+assets (agent config, context notes, SQL pairs, Ask tests, and project skills)
+without granting arbitrary repository write access.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from urllib.parse import urlparse
+
+import yaml
+
+_SUPPORTED_SUFFIXES_BY_ROOT = {
+    "context": {".md", ".yml", ".yaml", ".txt"},
+    "seeknal/sql_pairs": {".yml", ".yaml"},
+    "seeknal/tests": {".yml", ".yaml"},
+}
+_TOP_LEVEL_FILES = {"SEEKNAL_ASK.md", "seeknal_agent.yml"}
+_MAX_CONTENT_BYTES = 100 * 1024
+_SAFE_SEGMENT_RE = re.compile(r"^[a-zA-Z0-9_\-. ]+$")
+_SECRET_KEY_RE = re.compile(
+    r"(?i)(api[_-]?key|secret|token|password|passwd|pwd|dsn|database[_-]?url)\s*[:=]"
+)
+_BEARER_RE = re.compile(r"(?i)bearer\s+[a-z0-9._~+/=-]{12,}")
+_URL_RE = re.compile(r"[a-z][a-z0-9+.-]*://[^\s'\"]+")
+
+
+def write_seeknal_project_asset(
+    path: str,
+    content: str,
+    overwrite: bool = False,
+) -> str:
+    """Create or update a durable Seeknal project-prep asset.
+
+    Allowed targets are deliberately scoped to Ask/project-setup assets:
+
+    - ``SEEKNAL_ASK.md``
+    - ``seeknal_agent.yml``
+    - ``context/**/*.md|yml|yaml|txt``
+    - ``seeknal/sql_pairs/**/*.yml|yaml``
+    - ``seeknal/tests/**/*.yml|yaml``
+    - ``seeknal/skills/<skill-name>/SKILL.md``
+
+    Use ``draft_node``/``dry_run_draft``/``apply_draft`` for managed pipeline
+    definitions instead of writing ``seeknal/sources`` or ``seeknal/transforms``
+    directly.
+
+    Args:
+        path: Project-relative path from the allowed set above. No absolute
+            paths or ``..`` traversal.
+        content: UTF-8 text content. Secrets, DSNs, and credential-looking
+            values are rejected.
+        overwrite: Existing files are protected unless this is ``True``.
+
+    Returns:
+        A confirmation with the written relative path, or ``Error: ...``.
+    """
+    from seeknal.ask.agents.tools._context import get_tool_context
+
+    ctx = get_tool_context()
+    project_root = ctx.project_path.resolve()
+
+    validation = _validate_write_request(path, content)
+    if validation.startswith("Error:"):
+        return validation
+    rel_path = validation
+
+    target = (project_root / rel_path).resolve()
+    try:
+        target.relative_to(project_root)
+    except ValueError:
+        return f"Error: resolved path escapes project root: {target}"
+
+    if target.exists() and not overwrite:
+        return (
+            f"Error: `{rel_path}` already exists. Re-read it first, then call "
+            "write_seeknal_project_asset(..., overwrite=True) only when the "
+            "replacement is intentional."
+        )
+
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with ctx.fs_lock:
+            target.write_text(content, encoding="utf-8")
+    except OSError as exc:
+        return f"Error: failed to write `{rel_path}`: {exc}"
+
+    try:
+        rel_display = target.relative_to(project_root).as_posix()
+    except ValueError:
+        rel_display = rel_path
+    return f"Wrote `{rel_display}` ({len(content.encode('utf-8')):,} bytes)."
+
+
+def _validate_write_request(path: str, content: str) -> str:
+    if not path or not isinstance(path, str):
+        return "Error: path is required."
+    if content is None or not isinstance(content, str):
+        return "Error: content must be a string."
+    if not content.strip():
+        return "Error: content is empty."
+
+    body = content.encode("utf-8")
+    if len(body) > _MAX_CONTENT_BYTES:
+        return (
+            f"Error: content is {len(body)} bytes, exceeds "
+            f"{_MAX_CONTENT_BYTES} byte limit."
+        )
+    if _looks_like_secret(content):
+        return (
+            "Error: content appears to contain a secret or connection string. "
+            "Use .env for real credentials and store only env var names such "
+            "as dsn_env: WAREHOUSE_URL in committed project assets."
+        )
+
+    raw = path.strip()
+    if raw.startswith("/") or raw.startswith("\\") or Path(raw).is_absolute():
+        return f"Error: path `{path}` must be relative to the project root."
+    if ".." in raw.split("/") or ".." in raw.split("\\"):
+        return f"Error: path `{path}` contains '..' — traversal not allowed."
+
+    normalized = Path(raw).as_posix()
+    parts = Path(normalized).parts
+    for part in parts:
+        if not _SAFE_SEGMENT_RE.match(part):
+            return (
+                f"Error: invalid path segment `{part}`. Use letters, digits, "
+                "dots, hyphens, underscores, or spaces."
+            )
+
+    if normalized in _TOP_LEVEL_FILES:
+        if normalized == "seeknal_agent.yml":
+            config_error = _validate_seeknal_agent_yml(content)
+            if config_error:
+                return config_error
+        return normalized
+
+    if normalized.startswith("seeknal/skills/") and normalized.endswith("/SKILL.md"):
+        if len(Path(normalized).parts) != 4:
+            return "Error: project skills must use `seeknal/skills/<skill-name>/SKILL.md`."
+        return normalized
+
+    suffix = Path(normalized).suffix.lower()
+    for root, suffixes in _SUPPORTED_SUFFIXES_BY_ROOT.items():
+        prefix = f"{root}/"
+        if normalized.startswith(prefix):
+            if suffix not in suffixes:
+                return (
+                    f"Error: unsupported extension `{suffix}` for `{root}`. "
+                    f"Supported: {', '.join(sorted(suffixes))}."
+                )
+            if normalized == prefix.rstrip("/"):
+                return f"Error: `{normalized}` is a directory, not a file."
+            return normalized
+
+    return (
+        "Error: unsupported path. Allowed targets: SEEKNAL_ASK.md, "
+        "seeknal_agent.yml, context/**, seeknal/sql_pairs/**, "
+        "seeknal/tests/**, and seeknal/skills/<skill-name>/SKILL.md."
+    )
+
+
+def _validate_seeknal_agent_yml(content: str) -> str | None:
+    try:
+        data = yaml.safe_load(content)
+    except yaml.YAMLError as exc:
+        return f"Error: seeknal_agent.yml is not valid YAML: {exc}"
+    if data is not None and not isinstance(data, dict):
+        return "Error: seeknal_agent.yml must be a YAML mapping."
+    return None
+
+
+def _looks_like_secret(text: str) -> bool:
+    if _SECRET_KEY_RE.search(text) or _BEARER_RE.search(text):
+        return True
+    for match in _URL_RE.finditer(text):
+        parsed = urlparse(match.group(0))
+        if parsed.password:
+            return True
+        if parsed.username and parsed.scheme in {
+            "postgres",
+            "postgresql",
+            "mysql",
+            "mariadb",
+            "redshift",
+            "snowflake",
+            "clickhouse",
+            "mongodb",
+            "redis",
+        }:
+            return True
+    return False
+
+
+__all__ = ["write_seeknal_project_asset"]

--- a/src/seeknal/ask/builtin_skills/prepare-seeknal-project/SKILL.md
+++ b/src/seeknal/ask/builtin_skills/prepare-seeknal-project/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: prepare-seeknal-project
+description: Use when helping initialize, configure, or prepare a Seeknal project like a coding agent
+---
+
+# Prepare Seeknal Project Skill
+
+Use this skill when the user asks Ask to help create, initialize, configure, or
+prepare a Seeknal project. The goal is to turn user/project knowledge into
+safe, durable Seeknal assets rather than hardcoding project logic in the Ask
+harness.
+
+## First steps
+
+1. Read existing project assets when they exist:
+   - `AGENTS.md`
+   - `seeknal_agent.yml`
+   - `SEEKNAL_ASK.md`
+   - relevant files under `context/`, `seeknal/sql_pairs/`, and `seeknal/tests/`
+2. Decide the setup lane and state it clearly:
+   - **Tap-in / read-only connected-source analyst**: existing analytical DB is the source of truth.
+   - **Data pipeline builder**: Seeknal should create managed data assets.
+   - **Hybrid**: both connected sources and managed pipelines are used.
+3. Ask one concise scoping question if the lane, source type, or expected
+   deliverable is unclear. Do not ask for secrets.
+
+## Safe write rules
+
+- Use `write_seeknal_project_asset` for durable Ask/setup assets only:
+  - `SEEKNAL_ASK.md`
+  - `seeknal_agent.yml`
+  - `context/**/*.md|yml|yaml|txt`
+  - `seeknal/sql_pairs/**/*.yml|yaml`
+  - `seeknal/tests/**/*.yml|yaml`
+  - `seeknal/skills/<skill-name>/SKILL.md`
+- Use `draft_node` → `dry_run_draft` → `apply_draft` for pipeline definitions.
+- Never write actual DSNs, passwords, tokens, API keys, or bearer tokens.
+  `seeknal_agent.yml` must store env-var names such as `dsn_env: WAREHOUSE_URL`.
+- Do not edit generated `.seeknal/context/sources/` files; tell the user to run
+  `seeknal source sync <source> --project .` instead.
+
+## Tap-in / connected-source checklist
+
+1. Ensure `seeknal_agent.yml` has `mode.default: auto` or `project_setup` during setup.
+2. Add or explain a source registry entry with:
+   - `source_kind: connected`
+   - `source_type: database`
+   - `connector: postgresql|duckdb|mysql|...`
+   - `access: read_only`
+   - `dsn_env: <SAFE_ENV_VAR_NAME>`
+   - `context_sync.enabled: true`
+3. Write durable business context to `SEEKNAL_ASK.md` or `context/*.md`.
+4. Create reusable SQL examples in `seeknal/sql_pairs/*.yml`.
+5. Create executable QA cases in `seeknal/tests/*.yml`.
+6. Tell the user to put the real DSN in `.env`, then run:
+   - `seeknal source connect ...` if the source was not registered yet
+   - `seeknal source sync <source> --project .`
+   - `seeknal source test <source> --project .`
+   - `seeknal ask test --project . --sql-only`
+   - `seeknal ask chat --project .`
+
+## Pipeline-builder checklist
+
+1. Identify the first source, transform, feature group, model, metric, or semantic model.
+2. Create a draft with `draft_node`.
+3. Validate with `dry_run_draft`.
+4. Apply with `apply_draft(..., confirmed=True)` only after the user explicitly approves or the task clearly authorizes implementation.
+5. Use `plan_pipeline` and `run_pipeline` only when the user asked for validation/execution.
+6. Add tests or context explaining expected outputs and business meaning.
+
+## Output pattern
+
+When done, summarize:
+
+- Files created/updated
+- Chosen project mode and why
+- Secrets the user still needs to place in `.env`
+- Commands to run next
+- Any assumptions or TODOs that remain

--- a/src/seeknal/ask/gateway/ingest_service.py
+++ b/src/seeknal/ask/gateway/ingest_service.py
@@ -1,0 +1,349 @@
+"""Deterministic ingestion service for the gateway one-shot channels.
+
+The conversational `data-ingest` skill relies on interactive `ask_user`, which
+does not work over the gateway's one-shot `/ask` (Telegram / web). This module
+exposes the SAME create/append/dedup engine (`write_ingested_table`) behind two
+deterministic endpoints — `propose` and `commit` — so an owner can upload a file,
+see a structured proposal, and approve with one tap.
+
+Pipeline: stage raw → **normalize headers** to valid snake_case identifiers (so a
+column like ``No. Pesanan`` can be a business key) → classify a table name →
+infer a business key → compute a create-vs-append plan (with dup/drift counts).
+On commit, the staged normalized parquet is handed to the tested
+`write_ingested_table(user_confirmed=True, ...)`, which writes
+``target/ask_ingest/{table}.parquet`` + provenance and is auto-registered as the
+`ingest_{table}` view on the next agent turn (REPL._register_ask_ingest).
+
+Nothing here talks to the LLM — it is deterministic and reusable.
+"""
+
+from __future__ import annotations
+
+import base64
+import re
+import shutil
+import uuid
+from pathlib import Path
+from typing import Any
+
+_TABLE_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+_COLUMN_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+_SUPPORTED_SUFFIXES = {".csv", ".tsv", ".json", ".xlsx", ".parquet"}
+_ID_HINTS = (
+    "order_id", "no_pesanan", "nomor_pesanan", "no_invoice", "nomor_invoice",
+    "invoice", "no_resi", "pesanan", "order_sn", "order", "transaction", "trx",
+    "sku", "id",
+)
+# Header signatures (normalized) that map an upload onto a canonical entity. The
+# owner can always override the proposed table name before committing.
+_MARKETPLACE_SIGNATURE = {"no_pesanan", "status_pesanan", "total_pembayaran"}
+
+
+def _duck():
+    """A fresh in-memory DuckDB with extension autoload disabled, so even a future
+    SQL-injection regression cannot reach httpfs (no SSRF / network exfil). Core
+    CSV/JSON/Parquet readers are statically linked and unaffected."""
+    import duckdb
+
+    con = duckdb.connect(":memory:")
+    for pragma in (
+        "SET autoinstall_known_extensions=false",
+        "SET autoload_known_extensions=false",
+    ):
+        try:
+            con.execute(pragma)
+        except Exception:
+            pass
+    return con
+
+
+# ---------------------------------------------------------------------------
+# Header normalization
+# ---------------------------------------------------------------------------
+
+
+def normalize_header(name: str, used: set[str]) -> str:
+    """Map an arbitrary column header to a unique snake_case SQL identifier."""
+    s = re.sub(r"[^a-z0-9]+", "_", str(name).strip().lower()).strip("_")
+    if not s:
+        s = "col"
+    if s[0].isdigit():
+        s = f"_{s}"
+    base, i, out = s, 2, s
+    while out in used:
+        out = f"{base}_{i}"
+        i += 1
+    used.add(out)
+    return out
+
+
+def sanitize_table_name(name: str) -> str:
+    s = re.sub(r"[^a-z0-9]+", "_", str(name).strip().lower()).strip("_")
+    s = re.sub(r"_(csv|tsv|json|xlsx|xls|parquet)$", "", s)
+    if not s:
+        s = "uploaded_data"
+    if s[0].isdigit():
+        s = f"data_{s}"
+    return s[:48]
+
+
+def _reader_expr(path: Path) -> str:
+    safe = str(path.resolve()).replace("'", "''")
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        return f"read_csv_auto('{safe}', all_varchar=false)"
+    if suffix == ".tsv":
+        return f"read_csv_auto('{safe}', delim='\\t')"
+    if suffix == ".json":
+        return f"read_json_auto('{safe}')"
+    if suffix == ".parquet":
+        return f"read_parquet('{safe}')"
+    raise ValueError(f"unsupported suffix: {suffix}")
+
+
+def _xlsx_to_csv(xlsx_path: Path) -> Path:
+    import pandas as pd
+
+    df = pd.read_excel(xlsx_path, engine="openpyxl")
+    out = xlsx_path.with_suffix(".csv")
+    df.to_csv(out, index=False)
+    return out
+
+
+def normalize_to_parquet(raw_path: Path, out_path: Path) -> tuple[dict[str, str], list[str], int]:
+    """Read raw → write a parquet with normalized headers. Returns (mapping, cols, rows)."""
+    import duckdb
+
+    if raw_path.suffix.lower() == ".xlsx":
+        raw_path = _xlsx_to_csv(raw_path)
+
+    con = _duck()
+    try:
+        reader = _reader_expr(raw_path)
+        original = [r[0] for r in con.execute(f"DESCRIBE SELECT * FROM {reader}").fetchall()]
+        if not original:
+            raise ValueError("file has no columns")
+        used: set[str] = set()
+        mapping: dict[str, str] = {}
+        selects: list[str] = []
+        for col in original:
+            clean = normalize_header(col, used)
+            mapping[col] = clean
+            safe_col = col.replace('"', '""')
+            selects.append(f'"{safe_col}" AS "{clean}"')
+        safe_out = str(out_path.resolve()).replace("'", "''")
+        con.execute(
+            f"COPY (SELECT {', '.join(selects)} FROM {reader}) TO '{safe_out}' (FORMAT PARQUET)"
+        )
+        (rows,) = con.execute(f"SELECT COUNT(*) FROM read_parquet('{safe_out}')").fetchone()
+    finally:
+        con.close()
+    return mapping, list(mapping.values()), int(rows)
+
+
+def infer_business_key(parquet_path: Path, columns: list[str]) -> str:
+    """Pick a business key: a unique id-like column, else most-unique id-like, else widest."""
+    import duckdb
+
+    con = _duck()
+    safe = str(parquet_path.resolve()).replace("'", "''")
+    try:
+        (total,) = con.execute(f"SELECT COUNT(*) FROM read_parquet('{safe}')").fetchone()
+        cards: list[tuple[str, int]] = []
+        for c in columns:
+            (u,) = con.execute(
+                f'SELECT COUNT(DISTINCT "{c}") FROM read_parquet(\'{safe}\')'
+            ).fetchone()
+            cards.append((c, int(u)))
+    finally:
+        con.close()
+
+    unique_cols = [c for c, u in cards if total > 0 and u == total]
+    for c in unique_cols:
+        if any(h in c for h in _ID_HINTS):
+            return c
+    if unique_cols:
+        return unique_cols[0]
+    id_like = [(c, u) for c, u in cards if any(h in c for h in _ID_HINTS)]
+    if id_like:
+        return max(id_like, key=lambda x: x[1])[0]
+    return max(cards, key=lambda x: x[1])[0] if cards else columns[0]
+
+
+def classify_table_name(columns: list[str], filename: str) -> str:
+    cset = set(columns)
+    if len(_MARKETPLACE_SIGNATURE & cset) >= 2:
+        return "marketplace"
+    if {"nomor_invoice", "nomor_pesanan", "order_sn"} & cset:
+        return "marketplace"
+    return sanitize_table_name(Path(filename).stem)
+
+
+def _compute_append_plan(new_parquet: Path, existing_parquet: Path, business_key: str) -> dict[str, Any]:
+    import duckdb
+
+    con = _duck()
+    nn = str(new_parquet.resolve()).replace("'", "''")
+    ee = str(existing_parquet.resolve()).replace("'", "''")
+    try:
+        new_cols = [r[0] for r in con.execute(f"DESCRIBE SELECT * FROM read_parquet('{nn}')").fetchall()]
+        ex_cols = [r[0] for r in con.execute(f"DESCRIBE SELECT * FROM read_parquet('{ee}')").fetchall()]
+        (new_rows,) = con.execute(f"SELECT COUNT(*) FROM read_parquet('{nn}')").fetchone()
+        (ex_rows,) = con.execute(f"SELECT COUNT(*) FROM read_parquet('{ee}')").fetchone()
+        bk = [c.strip() for c in business_key.split(",") if c.strip()]
+        missing_bk = [c for c in bk if c not in new_cols or c not in ex_cols]
+        dup = 0
+        if not missing_bk:
+            sel = ", ".join('"' + c.replace('"', '""') + '"' for c in bk)
+            (dup,) = con.execute(
+                f"SELECT COUNT(*) FROM (SELECT {sel} FROM read_parquet('{nn}') "
+                f"INTERSECT SELECT {sel} FROM read_parquet('{ee}'))"
+            ).fetchone()
+    finally:
+        con.close()
+    new_rows, ex_rows, dup = int(new_rows), int(ex_rows), int(dup)
+    return {
+        "new_rows": new_rows,
+        "existing_rows": ex_rows,
+        "duplicate_count": dup,
+        "new_unique": new_rows - dup,
+        "missing_in_new": [c for c in ex_cols if c not in new_cols],
+        "extra_in_new": [c for c in new_cols if c not in ex_cols],
+        "missing_business_key": missing_bk,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public: propose / commit
+# ---------------------------------------------------------------------------
+
+
+def _staging_dir(project_path: Path, token: str) -> Path:
+    return project_path / "target" / "ask_ingest" / "_staging" / f"propose-{token}"
+
+
+def _sweep_old_staging(project_path: Path, max_age_seconds: int = 3600) -> None:
+    """Delete abandoned propose-* staging dirs (a proposal the owner never committed)."""
+    import time
+
+    base = project_path / "target" / "ask_ingest" / "_staging"
+    if not base.exists():
+        return
+    now = time.time()
+    for d in base.glob("propose-*"):
+        try:
+            if d.is_dir() and (now - d.stat().st_mtime) > max_age_seconds:
+                shutil.rmtree(d, ignore_errors=True)
+        except Exception:
+            pass
+
+
+def propose(
+    project_path: Path,
+    *,
+    filename: str,
+    data_base64: str | None = None,
+    source_path: str | None = None,
+    table_name: str | None = None,
+    business_key: str | None = None,
+) -> dict[str, Any]:
+    """Stage + normalize an upload and return a create/append proposal (no write)."""
+    project_path = Path(project_path)
+    _sweep_old_staging(project_path)
+    suffix = Path(filename or "upload.csv").suffix.lower()
+    if suffix not in _SUPPORTED_SUFFIXES:
+        return {"ok": False, "error": f"unsupported file type '{suffix}'"}
+
+    token = uuid.uuid4().hex[:12]
+    staging = _staging_dir(project_path, token)
+    staging.mkdir(parents=True, exist_ok=True)
+    raw = staging / f"raw{suffix}"
+    try:
+        if data_base64:
+            raw.write_bytes(base64.b64decode(data_base64))
+        elif source_path:
+            shutil.copy(Path(source_path).expanduser(), raw)
+        else:
+            return {"ok": False, "error": "no data_base64 or source_path provided"}
+
+        norm = staging / "normalized.parquet"
+        mapping, columns, row_count = normalize_to_parquet(raw, norm)
+    except Exception as exc:  # noqa: BLE001 — surface parse errors to the owner
+        shutil.rmtree(staging, ignore_errors=True)
+        return {"ok": False, "error": f"could not read file: {exc}"}
+
+    tbl = sanitize_table_name(table_name) if table_name else classify_table_name(columns, filename)
+    bk = business_key.strip() if business_key else infer_business_key(norm, columns)
+
+    # A business key must be normalized identifier(s) — it is interpolated into SQL
+    # (quoted) downstream, so reject anything outside [a-zA-Z_][a-zA-Z0-9_]*.
+    bk_cols = [c.strip() for c in bk.split(",") if c.strip()]
+    if not bk_cols or not all(_COLUMN_NAME_RE.match(c) for c in bk_cols):
+        shutil.rmtree(staging, ignore_errors=True)
+        return {"ok": False, "error": f"invalid business key '{bk}'"}
+    if any(c not in columns for c in bk_cols):
+        shutil.rmtree(staging, ignore_errors=True)
+        return {"ok": False, "error": f"business key not found in file: '{bk}'"}
+
+    existing = project_path / "target" / "ask_ingest" / f"{tbl}.parquet"
+    if existing.exists():
+        mode = "append"
+        plan = _compute_append_plan(norm, existing, bk)
+    else:
+        mode = "create"
+        plan = {"new_rows": row_count, "new_unique": row_count, "duplicate_count": 0}
+
+    return {
+        "ok": True,
+        "token": token,
+        "table_name": tbl,
+        "view_name": f"ingest_{tbl}",
+        "mode": mode,
+        "business_key": bk,
+        "columns": columns,
+        "column_mapping": mapping,
+        "row_count": row_count,
+        "plan": plan,
+    }
+
+
+def commit(
+    project_path: Path,
+    *,
+    token: str,
+    table_name: str,
+    business_key: str,
+    mode: str = "create",
+    dedup_strategy: str = "skip",
+) -> dict[str, Any]:
+    """Persist the staged proposal via the tested write_ingested_table engine."""
+    project_path = Path(project_path)
+    if not token or not re.fullmatch(r"[a-f0-9]{6,32}", str(token)):
+        return {"ok": False, "error": "invalid token"}
+    table_name = sanitize_table_name(table_name)
+    if not _TABLE_NAME_RE.match(table_name):
+        return {"ok": False, "error": "invalid table_name"}
+    bk_cols = [c.strip() for c in business_key.split(",") if c.strip()]
+    if not bk_cols or not all(_COLUMN_NAME_RE.match(c) for c in bk_cols):
+        return {"ok": False, "error": "invalid business key"}
+
+    norm = _staging_dir(project_path, token) / "normalized.parquet"
+    if not norm.exists():
+        return {"ok": False, "error": "staged file expired — please upload again"}
+
+    from seeknal.ask.agents.tools._context import ToolContext, set_tool_context
+    from seeknal.ask.agents.tools.write_ingested_table import write_ingested_table
+
+    set_tool_context(ToolContext(repl=None, artifact_discovery=None, project_path=project_path))  # type: ignore[arg-type]
+    result = write_ingested_table(
+        source_path=str(norm),
+        table_name=table_name,
+        business_key=business_key,
+        mode=mode if mode in {"create", "append"} else "create",
+        user_confirmed=True,
+        dedup_strategy=dedup_strategy if dedup_strategy in {"skip", "replace"} else "skip",
+    )
+    ok = not result.lstrip().startswith("Error")
+    if ok:
+        shutil.rmtree(norm.parent, ignore_errors=True)
+    return {"ok": ok, "result": result, "view_name": f"ingest_{table_name}"}

--- a/src/seeknal/ask/gateway/server.py
+++ b/src/seeknal/ask/gateway/server.py
@@ -785,33 +785,121 @@ async def list_sessions(request: Request) -> JSONResponse:
     return JSONResponse(sessions)
 
 
+_STAGED_EXT_BY_MIME = {
+    "image/jpeg": ".jpg",
+    "image/jpg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
+    "image/heic": ".heic",
+    "image/heif": ".heif",
+}
+_MAX_STAGED_IMAGE_BYTES = 15 * 1024 * 1024
+# Cap the whole /ask request body. A 15 MB image is ~20 MB base64 + JSON overhead.
+_MAX_REQUEST_BYTES = 25 * 1024 * 1024
+
+
+def _stage_attachments_and_augment(
+    attachments: Any, question: str, session_id: str, project_path: Path
+) -> tuple[str, list[str]]:
+    """Decode image attachments to the ask_ingest staging dir and prepend an
+    ``extract_from_image`` directive so the agent OCRs them. Returns
+    ``(question, staged_paths)`` — a safe no-op (``(question, [])``) when there
+    are no valid image attachments. The caller MUST unlink ``staged_paths`` after
+    the agent run (they hold sensitive financial images).
+
+    The caller has already validated ``session_id``; staged filenames are random
+    UUIDs with a whitelisted extension, so there is no path-traversal surface.
+    """
+    if not isinstance(attachments, list) or not attachments:
+        return question, []
+    import base64
+    import uuid as _uuid
+
+    staging_dir = (
+        project_path / "target" / "ask_ingest" / "_staging" / f"ask-{session_id}"
+    )
+    staged: list[str] = []
+    for att in attachments:
+        if not isinstance(att, dict) or att.get("kind") != "image":
+            continue
+        ext = _STAGED_EXT_BY_MIME.get(str(att.get("mime") or "").lower())
+        if not ext:
+            continue
+        try:
+            raw = base64.b64decode(att.get("data_base64") or "", validate=True)
+        except Exception:
+            continue
+        if not raw or len(raw) > _MAX_STAGED_IMAGE_BYTES:
+            continue
+        try:
+            staging_dir.mkdir(parents=True, exist_ok=True)
+            path = staging_dir / f"{_uuid.uuid4().hex}{ext}"
+            path.write_bytes(raw)
+        except Exception:
+            continue
+        staged.append(str(path))
+
+    if not staged:
+        return question, []
+
+    listing = "\n".join(f"- {p}" for p in staged)
+    directive = (
+        "Pengguna mengirim gambar (kemungkinan struk, bukti transfer, atau "
+        "invoice). File tersimpan di:\n"
+        f"{listing}\n"
+        "Gunakan HANYA tool extract_from_image pada setiap path untuk membaca "
+        "isinya, lalu jawab pertanyaan pengguna berdasarkan hasil ekstraksi. "
+        "Ini hanya pembacaan: JANGAN menjalankan kode (execute_python) dan "
+        "JANGAN menulis ke tabel apa pun.\n\n"
+    )
+    base_q = (question or "").strip() or "Tolong baca gambar ini dan rangkum isinya."
+    return directive + base_q, staged
+
+
 async def ask_oneshot(request: Request) -> JSONResponse:
     """One-shot question → JSON response."""
     tenant_id, err = _safe_resolve_tenant(request)
     if err:
         return err
+    clen = request.headers.get("content-length")
+    if clen and clen.isdigit() and int(clen) > _MAX_REQUEST_BYTES:
+        return JSONResponse({"error": "payload too large"}, status_code=413)
     body = await request.json()
     question = body.get("question", "")
     session_id = body.get("session_id", "default")
-    if not question:
-        return JSONResponse({"error": "question is required"}, status_code=400)
     if not _validate_session_id(session_id):
         return JSONResponse({"error": "invalid session_id"}, status_code=400)
 
     project_path = Path(request.app.state.project_path)
+    # Telegram photos (forwarded by Tower) are staged to disk and the question is
+    # augmented with an extract_from_image directive so the agent OCRs them. The
+    # staged files are unlinked after the run (they hold sensitive financial images).
+    question, staged_paths = _stage_attachments_and_augment(
+        body.get("attachments"), question, session_id, project_path
+    )
+    if not question:
+        return JSONResponse({"error": "question is required"}, status_code=400)
+
     events = []
     answer = ""
-    async for event in _run_agent_streaming(
-        project_path,
-        session_id,
-        question,
-        tenant_id=tenant_id,
-        lock_backend=getattr(request.app.state, "session_lock", None),
-        broadcaster=getattr(request.app.state, "broadcaster", None),
-    ):
-        events.append(event)
-        if event["type"] == "answer":
-            answer = event["data"]
+    try:
+        async for event in _run_agent_streaming(
+            project_path,
+            session_id,
+            question,
+            tenant_id=tenant_id,
+            lock_backend=getattr(request.app.state, "session_lock", None),
+            broadcaster=getattr(request.app.state, "broadcaster", None),
+        ):
+            events.append(event)
+            if event["type"] == "answer":
+                answer = event["data"]
+    finally:
+        for _staged in staged_paths:
+            try:
+                Path(_staged).unlink(missing_ok=True)
+            except Exception:
+                pass
 
     return JSONResponse({"answer": answer, "events": events})
 

--- a/src/seeknal/ask/gateway/server.py
+++ b/src/seeknal/ask/gateway/server.py
@@ -785,7 +785,7 @@ async def list_sessions(request: Request) -> JSONResponse:
     return JSONResponse(sessions)
 
 
-_STAGED_EXT_BY_MIME = {
+_STAGED_IMAGE_EXT_BY_MIME = {
     "image/jpeg": ".jpg",
     "image/jpg": ".jpg",
     "image/png": ".png",
@@ -793,66 +793,107 @@ _STAGED_EXT_BY_MIME = {
     "image/heic": ".heic",
     "image/heif": ".heif",
 }
-_MAX_STAGED_IMAGE_BYTES = 15 * 1024 * 1024
-# Cap the whole /ask request body. A 15 MB image is ~20 MB base64 + JSON overhead.
+# Tabular data files (CSV/Excel/JSON) the agent reads with read_tabular.
+_TABULAR_EXT_BY_MIME = {
+    "text/csv": ".csv",
+    "application/csv": ".csv",
+    "text/tab-separated-values": ".tsv",
+    "application/vnd.ms-excel": ".xls",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",
+    "application/json": ".json",
+}
+_TABULAR_EXTS = (".csv", ".tsv", ".xlsx", ".xls", ".json")
+_MAX_STAGED_BYTES = 15 * 1024 * 1024
+# Cap the whole /ask request body. A 15 MB file is ~20 MB base64 + JSON overhead.
 _MAX_REQUEST_BYTES = 25 * 1024 * 1024
+
+
+def _decode_and_write(att: Any, staging_dir: Path, ext: str) -> str | None:
+    import base64
+    import uuid as _uuid
+
+    try:
+        raw = base64.b64decode(att.get("data_base64") or "", validate=True)
+    except Exception:
+        return None
+    if not raw or len(raw) > _MAX_STAGED_BYTES:
+        return None
+    try:
+        staging_dir.mkdir(parents=True, exist_ok=True)
+        path = staging_dir / f"{_uuid.uuid4().hex}{ext}"
+        path.write_bytes(raw)
+    except Exception:
+        return None
+    return str(path)
 
 
 def _stage_attachments_and_augment(
     attachments: Any, question: str, session_id: str, project_path: Path
 ) -> tuple[str, list[str]]:
-    """Decode image attachments to the ask_ingest staging dir and prepend an
-    ``extract_from_image`` directive so the agent OCRs them. Returns
-    ``(question, staged_paths)`` — a safe no-op (``(question, [])``) when there
-    are no valid image attachments. The caller MUST unlink ``staged_paths`` after
-    the agent run (they hold sensitive financial images).
+    """Decode image + tabular-file attachments to the ask_ingest staging dir and
+    prepend a directive (``extract_from_image`` for photos, ``read_tabular`` for
+    CSV/Excel) so the agent reads them. Returns ``(question, staged_paths)`` — a
+    safe no-op when there are no valid attachments. The caller MUST unlink
+    ``staged_paths`` after the run (they hold sensitive data).
 
-    The caller has already validated ``session_id``; staged filenames are random
-    UUIDs with a whitelisted extension, so there is no path-traversal surface.
+    ``session_id`` is already validated; staged filenames are random UUIDs with a
+    whitelisted extension, so there is no path-traversal surface.
     """
     if not isinstance(attachments, list) or not attachments:
         return question, []
-    import base64
-    import uuid as _uuid
 
     staging_dir = (
         project_path / "target" / "ask_ingest" / "_staging" / f"ask-{session_id}"
     )
-    staged: list[str] = []
+    images: list[str] = []
+    files: list[str] = []
     for att in attachments:
-        if not isinstance(att, dict) or att.get("kind") != "image":
+        if not isinstance(att, dict):
             continue
-        ext = _STAGED_EXT_BY_MIME.get(str(att.get("mime") or "").lower())
-        if not ext:
-            continue
-        try:
-            raw = base64.b64decode(att.get("data_base64") or "", validate=True)
-        except Exception:
-            continue
-        if not raw or len(raw) > _MAX_STAGED_IMAGE_BYTES:
-            continue
-        try:
-            staging_dir.mkdir(parents=True, exist_ok=True)
-            path = staging_dir / f"{_uuid.uuid4().hex}{ext}"
-            path.write_bytes(raw)
-        except Exception:
-            continue
-        staged.append(str(path))
+        kind = att.get("kind")
+        if kind == "image":
+            ext = _STAGED_IMAGE_EXT_BY_MIME.get(str(att.get("mime") or "").lower())
+            if ext:
+                p = _decode_and_write(att, staging_dir, ext)
+                if p:
+                    images.append(p)
+        elif kind == "file":
+            filename = str(att.get("filename") or "").lower()
+            ext = next((e for e in _TABULAR_EXTS if filename.endswith(e)), None)
+            if not ext:
+                ext = _TABULAR_EXT_BY_MIME.get(str(att.get("mime") or "").lower())
+            if ext:
+                p = _decode_and_write(att, staging_dir, ext)
+                if p:
+                    files.append(p)
 
+    staged = images + files
     if not staged:
         return question, []
 
-    listing = "\n".join(f"- {p}" for p in staged)
+    parts: list[str] = []
+    if images:
+        listing = "\n".join(f"- {p}" for p in images)
+        parts.append(
+            "Pengguna mengirim gambar (kemungkinan struk, bukti transfer, atau "
+            f"invoice). File:\n{listing}\n"
+            "Gunakan tool extract_from_image pada setiap path untuk membacanya."
+        )
+    if files:
+        listing = "\n".join(f"- {p}" for p in files)
+        parts.append(
+            "Pengguna mengirim file data (CSV/Excel/JSON) untuk dilihat. File:\n"
+            f"{listing}\n"
+            "Gunakan tool read_tabular pada setiap path untuk membacanya, lalu "
+            "tampilkan ringkasan singkat (nama kolom + beberapa baris contoh) dalam "
+            "bahasa awam. JANGAN minta path file ke pengguna — filenya sudah ada."
+        )
     directive = (
-        "Pengguna mengirim gambar (kemungkinan struk, bukti transfer, atau "
-        "invoice). File tersimpan di:\n"
-        f"{listing}\n"
-        "Gunakan HANYA tool extract_from_image pada setiap path untuk membaca "
-        "isinya, lalu jawab pertanyaan pengguna berdasarkan hasil ekstraksi. "
-        "Ini hanya pembacaan: JANGAN menjalankan kode (execute_python) dan "
-        "JANGAN menulis ke tabel apa pun.\n\n"
+        "\n\n".join(parts)
+        + "\n\nIni hanya pembacaan: JANGAN menjalankan kode (execute_python) dan "
+        "JANGAN menulis ke tabel apa pun kecuali pengguna memintanya secara eksplisit.\n\n"
     )
-    base_q = (question or "").strip() or "Tolong baca gambar ini dan rangkum isinya."
+    base_q = (question or "").strip() or "Tolong baca file/gambar yang saya kirim dan rangkum isinya."
     return directive + base_q, staged
 
 
@@ -902,6 +943,68 @@ async def ask_oneshot(request: Request) -> JSONResponse:
                 pass
 
     return JSONResponse({"answer": answer, "events": events})
+
+
+async def ingest_propose(request: Request) -> JSONResponse:
+    """Stage + auto-judge an uploaded file → structured create/append proposal (no write)."""
+    _tenant_id, err = _safe_resolve_tenant(request)
+    if err:
+        return err
+    # Ingest WRITES tenant data — fail closed if the token registry isn't configured
+    # (do not inherit the read path's unauthenticated DEFAULT_TENANT fallback).
+    if _token_registry_from_state(request.app.state) is None:
+        return JSONResponse(
+            {"ok": False, "error": "ingest requires authentication"}, status_code=403
+        )
+    clen = request.headers.get("content-length")
+    if clen and clen.isdigit() and int(clen) > _MAX_REQUEST_BYTES:
+        return JSONResponse({"ok": False, "error": "payload too large"}, status_code=413)
+    body = await request.json()
+    project_path = Path(request.app.state.project_path)
+    from seeknal.ask.gateway.ingest_service import propose as _propose
+
+    # NOTE: source_path is intentionally NOT accepted over HTTP — it would be an
+    # arbitrary-local-file read sink. The web/Telegram path always sends data_base64.
+    try:
+        result = await asyncio.to_thread(
+            _propose,
+            project_path,
+            filename=str(body.get("filename") or "upload.csv"),
+            data_base64=body.get("data_base64"),
+            table_name=body.get("table_name"),
+            business_key=body.get("business_key"),
+        )
+    except Exception as exc:  # noqa: BLE001 — surface to the owner
+        return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
+    return JSONResponse(result)
+
+
+async def ingest_commit(request: Request) -> JSONResponse:
+    """Commit an owner-approved ingest proposal → create/append parquet + register view."""
+    _tenant_id, err = _safe_resolve_tenant(request)
+    if err:
+        return err
+    if _token_registry_from_state(request.app.state) is None:
+        return JSONResponse(
+            {"ok": False, "error": "ingest requires authentication"}, status_code=403
+        )
+    body = await request.json()
+    project_path = Path(request.app.state.project_path)
+    from seeknal.ask.gateway.ingest_service import commit as _commit
+
+    try:
+        result = await asyncio.to_thread(
+            _commit,
+            project_path,
+            token=str(body.get("token") or ""),
+            table_name=str(body.get("table_name") or ""),
+            business_key=str(body.get("business_key") or ""),
+            mode=str(body.get("mode") or "create"),
+            dedup_strategy=str(body.get("dedup_strategy") or "skip"),
+        )
+    except Exception as exc:  # noqa: BLE001
+        return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
+    return JSONResponse(result)
 
 
 async def cancel_session_run(request: Request) -> JSONResponse:
@@ -1672,6 +1775,8 @@ def create_gateway_app(
     # is configured. In backend-only mode the client must use /temporal/start.
     if not backend_only:
         routes.insert(4, Route("/ask", ask_oneshot, methods=["POST"]))
+        routes.append(Route("/ingest/propose", ingest_propose, methods=["POST"]))
+        routes.append(Route("/ingest/commit", ingest_commit, methods=["POST"]))
         routes.append(Route("/upload", upload_file, methods=["POST"]))
         routes.append(Route("/record", post_record, methods=["POST"]))
         routes.append(WebSocketRoute("/ws/{session_id}", websocket_endpoint))

--- a/src/seeknal/cli/admin.py
+++ b/src/seeknal/cli/admin.py
@@ -1,0 +1,277 @@
+"""`seeknal admin` CLI — governance commands for the v0.5 access surface.
+
+Sub-commands:
+  access list / grant / revoke / pending / set-default / export / import
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from seeknal.ask.access.pending import PendingQueue
+from seeknal.ask.access.policy import AccessPolicy
+from seeknal.ask.access.roles import Role
+
+app = typer.Typer(help="Admin commands for managing Ask access policy.")
+access_app = typer.Typer(help="Manage .seeknal/access.yml and the pending queue.")
+app.add_typer(access_app, name="access")
+
+
+def _echo_info(msg: str) -> None:
+    typer.secho(msg, fg=typer.colors.CYAN)
+
+
+def _echo_success(msg: str) -> None:
+    typer.secho(msg, fg=typer.colors.GREEN)
+
+
+def _echo_error(msg: str) -> None:
+    typer.secho(msg, fg=typer.colors.RED, err=True)
+
+
+def _policy_path() -> Path:
+    return Path.cwd() / ".seeknal" / "access.yml"
+
+
+def _pending_path() -> Path:
+    return Path.cwd() / ".seeknal" / "access_pending.json"
+
+
+def _load_policy() -> AccessPolicy:
+    return AccessPolicy.load(_policy_path())
+
+
+def _load_pending() -> PendingQueue:
+    return PendingQueue.load(_pending_path())
+
+
+def _resolve_user_id(value: str) -> tuple[Optional[int], Optional[str]]:
+    """Parse "12345" → (12345, None) or "alice" → (None, "alice")."""
+    if value.isdigit():
+        return int(value), None
+    return None, value
+
+
+@access_app.command("list")
+def list_cmd():
+    """Print current allowlist, pending requests, and deny_list."""
+    policy = _load_policy()
+    pending = _load_pending()
+
+    _echo_info(
+        f"Default role: {policy.default_role.label() if policy.default_role else 'none'}"
+    )
+    _echo_info(f"Allowlist ({len(policy.allowlist)} entries):")
+    for entry in policy.allowlist:
+        ident = (
+            f"user={entry.telegram_user_id}"
+            if entry.telegram_user_id is not None
+            else f"chat={entry.telegram_chat_id}"
+        )
+        role = entry.role.label() if entry.role else "—"
+        username = entry.telegram_username or "—"
+        _echo_info(f"  {ident}  role={role}  @{username}  notes={entry.notes!r}")
+
+    _echo_info(f"Pending ({len(pending.requests)} entries):")
+    for req in pending.requests:
+        _echo_info(
+            f"  user={req.telegram_user_id}  @{req.telegram_username or '—'}  "
+            f"requested={req.requested_at}"
+        )
+
+    _echo_info(f"Deny list ({len(policy.deny_list)} entries):")
+    for entry in policy.deny_list:
+        _echo_info(
+            f"  user={entry.telegram_user_id}  reason={entry.reason!r}  "
+            f"added={entry.added_at}"
+        )
+
+
+@access_app.command("grant")
+def grant_cmd(
+    user_id: int = typer.Argument(..., help="Telegram numeric user_id."),
+    role: str = typer.Argument(..., help="viewer | analyst | operator | engineer | admin"),
+    username: Optional[str] = typer.Option(None, "--username", "-u"),
+    notes: str = typer.Option("", "--notes"),
+):
+    """Grant a role to a Telegram user. Overwrites prior entry on the same user_id."""
+    policy = _load_policy()
+    try:
+        role_enum = Role.from_string(role)
+    except ValueError as exc:
+        _echo_error(str(exc))
+        raise typer.Exit(1)
+    policy.grant(
+        telegram_user_id=user_id, role=role_enum, username=username, notes=notes
+    )
+    policy.save(_policy_path())
+    _echo_success(
+        f"Granted {role_enum.label()} to user_id={user_id}."
+    )
+
+
+@access_app.command("revoke")
+def revoke_cmd(
+    user_id: int = typer.Argument(..., help="Telegram numeric user_id."),
+    deny: bool = typer.Option(False, "--deny", help="Also add to deny_list."),
+    reason: str = typer.Option("", "--reason"),
+):
+    """Remove a user from the allowlist; optionally add to deny_list."""
+    policy = _load_policy()
+    removed = policy.revoke(user_id, deny_reason=reason if deny else None)
+    policy.save(_policy_path())
+    if removed:
+        _echo_success(f"Revoked user_id={user_id}.")
+    else:
+        _echo_info(f"user_id={user_id} was not in the allowlist.")
+    if deny:
+        _echo_success(f"Added user_id={user_id} to deny_list.")
+
+
+@access_app.command("pending")
+def pending_cmd(
+    approve: Optional[int] = typer.Option(None, "--approve", help="Approve a pending user_id."),
+    role: Optional[str] = typer.Option(None, "--role", help="Role for --approve."),
+    deny: Optional[int] = typer.Option(None, "--deny", help="Deny a pending user_id."),
+    reason: str = typer.Option("", "--reason"),
+):
+    """Inspect or resolve pending access requests."""
+    pending = _load_pending()
+    if approve is None and deny is None:
+        if not pending.requests:
+            _echo_info("No pending requests.")
+            return
+        for req in pending.requests:
+            _echo_info(
+                f"  user={req.telegram_user_id}  @{req.telegram_username or '—'}  "
+                f"intro={req.intro_message[:60]!r}  ttl_until={req.ttl_until}"
+            )
+        return
+
+    if approve is not None:
+        if not role:
+            _echo_error("--approve requires --role.")
+            raise typer.Exit(1)
+        try:
+            role_enum = Role.from_string(role)
+        except ValueError as exc:
+            _echo_error(str(exc))
+            raise typer.Exit(1)
+        req = pending.get(approve)
+        if req is None:
+            _echo_error(f"No pending request for user_id={approve}.")
+            raise typer.Exit(1)
+        policy = _load_policy()
+        policy.grant(
+            telegram_user_id=approve,
+            role=role_enum,
+            username=req.telegram_username,
+        )
+        policy.save(_policy_path())
+        pending.remove(approve)
+        pending.save(_pending_path())
+        _echo_success(f"Approved user_id={approve} as {role_enum.label()}.")
+
+    if deny is not None:
+        policy = _load_policy()
+        if reason:
+            policy.revoke(deny, deny_reason=reason)
+            policy.save(_policy_path())
+        pending.remove(deny)
+        pending.save(_pending_path())
+        _echo_success(f"Denied user_id={deny}.")
+
+
+@access_app.command("set-default")
+def set_default_cmd(
+    role: str = typer.Argument(..., help="none | viewer | analyst | operator | engineer | admin"),
+):
+    """Change the default role applied to listed-but-roleless callers."""
+    policy = _load_policy()
+    if role.lower() == "none":
+        policy.default_role = None
+    else:
+        try:
+            policy.default_role = Role.from_string(role)
+        except ValueError as exc:
+            _echo_error(str(exc))
+            raise typer.Exit(1)
+    policy.save(_policy_path())
+    _echo_success(f"default_role set to {role}.")
+
+
+@access_app.command("export")
+def export_cmd(
+    target: Path = typer.Argument(..., help="Path to write the export to."),
+):
+    """Dump the policy to a JSON file (for backup)."""
+    policy = _load_policy()
+    payload = {
+        "schema_version": policy.schema_version,
+        "default_role": policy.default_role.label() if policy.default_role else "none",
+        "allowlist": [entry.to_yaml() for entry in policy.allowlist],
+        "deny_list": [entry.to_yaml() for entry in policy.deny_list],
+    }
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload, indent=2, sort_keys=True))
+    _echo_success(f"Wrote {target}.")
+
+
+@access_app.command("import")
+def import_cmd(
+    source: Path = typer.Argument(..., help="Path to a JSON export to import."),
+    overwrite: bool = typer.Option(False, "--overwrite", help="Replace current policy."),
+):
+    """Restore policy from a JSON export."""
+    if not source.exists():
+        _echo_error(f"Source file does not exist: {source}")
+        raise typer.Exit(1)
+    payload = json.loads(source.read_text())
+    policy_path = _policy_path()
+    if policy_path.exists() and not overwrite:
+        _echo_error(
+            f"Policy already exists at {policy_path}. Pass --overwrite to replace."
+        )
+        raise typer.Exit(1)
+    policy = AccessPolicy.empty(source_path=policy_path)
+    policy.schema_version = int(payload.get("schema_version", 1))
+    default_role = payload.get("default_role")
+    if default_role and default_role != "none":
+        policy.default_role = Role.from_string(default_role)
+    for entry in payload.get("allowlist", []) or []:
+        role_str = entry.get("role")
+        role_enum = Role.from_string(role_str) if role_str else None
+        if role_enum is None:
+            continue
+        policy.grant(
+            telegram_user_id=entry.get("telegram_user_id"),
+            telegram_chat_id=entry.get("telegram_chat_id"),
+            role=role_enum,
+            username=entry.get("telegram_username"),
+            notes=entry.get("notes", "") or "",
+            added_at=entry.get("added_at", "") or "",
+            added_by=entry.get("added_by", "") or "",
+        )
+    # Deny list
+    from seeknal.ask.access.policy import DenyEntry
+
+    for entry in payload.get("deny_list", []) or []:
+        user_id = entry.get("telegram_user_id")
+        if not isinstance(user_id, int):
+            continue
+        policy.deny_list.append(
+            DenyEntry(
+                telegram_user_id=user_id,
+                reason=entry.get("reason", "") or "",
+                added_at=entry.get("added_at", "") or "",
+            )
+        )
+    policy.save(policy_path)
+    _echo_success(f"Imported policy from {source}.")
+
+
+__all__ = ["app"]

--- a/src/seeknal/cli/atlas.py
+++ b/src/seeknal/cli/atlas.py
@@ -607,6 +607,78 @@ def governance_audit_logs(
         raise typer.Exit(1)
 
 
+@governance_app.command("status")
+def governance_status():
+    """Show whether runtime Atlas governance enforcement is active.
+
+    Enforcement activates when ``ATLAS_API_URL`` is configured. When active, Seeknal
+    delegates data-access decisions and column masking to the Atlas backend on every
+    governed read — the rules live in Atlas, not in editable local files.
+
+    Example:
+        seeknal atlas governance status
+    """
+    from seeknal.integrations.atlas_governance import create_governance_gate_from_env
+
+    gate = create_governance_gate_from_env()
+    typer.echo("")
+    typer.echo(typer.style("Atlas Runtime Governance", bold=True))
+    typer.echo("=" * 40)
+    if gate is None:
+        _echo_warning("Inactive — ATLAS_API_URL is not set.")
+        typer.echo("Reads pass through ungoverned. Set ATLAS_API_URL to enable enforcement.")
+        typer.echo("")
+        return
+    _echo_success("Active — access decisions delegated to Atlas.")
+    typer.echo(f"  Endpoint:  {gate.config.base_url}")
+    typer.echo(f"  Token:     {'set' if gate.config.token else '(none)'}")
+    typer.echo(f"  Fail mode: {'fail-open' if gate.fail_open else 'fail-closed'}")
+    typer.echo("")
+
+
+@governance_app.command("check")
+def governance_check(
+    resource: str = typer.Argument(
+        ..., help="Resource identifier, e.g. prod.gold.customer"
+    ),
+    action: str = typer.Option(
+        "read", "--action", "-a", help="Action to check (read, write, ...)"
+    ),
+    actor: Optional[str] = typer.Option(
+        None, "--actor", help="Actor (defaults to ATLAS_ACTOR or the current user)"
+    ),
+):
+    """Check the Atlas access decision for a resource (exit 1 if denied).
+
+    Uses the configured Atlas backend (``ATLAS_API_URL``). The exit code is scriptable:
+    a non-zero exit means access is denied, so this can gate shell pipelines.
+
+    Example:
+        seeknal atlas governance check prod.gold.customer --action read
+    """
+    from seeknal.integrations.atlas_governance import create_governance_gate_from_env
+
+    gate = create_governance_gate_from_env()
+    if gate is None:
+        _echo_error("Atlas governance is not configured (set ATLAS_API_URL).")
+        raise typer.Exit(2)
+
+    decision = gate.check_access(resource=resource, action=action, actor=actor)
+    typer.echo("")
+    if decision.allowed:
+        _echo_success(f"ALLOW  {action} {resource}")
+        if decision.masked_columns:
+            typer.echo(f"  Masked columns: {', '.join(decision.masked_columns)}")
+        typer.echo(f"  Classification: {decision.classification}")
+        typer.echo("")
+    else:
+        _echo_error(f"DENY   {action} {resource}")
+        if decision.reason:
+            typer.echo(f"  Reason: {decision.reason}")
+        typer.echo("")
+        raise typer.Exit(1)
+
+
 # =============================================================================
 # Lineage Commands
 # =============================================================================

--- a/src/seeknal/cli/atlas.py
+++ b/src/seeknal/cli/atlas.py
@@ -708,28 +708,68 @@ def lineage_show(
         help="Output format (tree, json)"
     ),
 ):
-    """Show lineage for a feature group or entity.
+    """Show lineage for a dataset, feature group, or entity.
 
-    Displays upstream and downstream dependencies.
+    Reads DataHub-backed upstream/downstream lineage through the Atlas catalog
+    (the same source as ``seeknal dataset lineage``). Requires only
+    ``ATLAS_API_URL`` — the optional ``atlas-data-platform`` package is not
+    needed.
 
     Example:
         seeknal atlas lineage show user_features --direction upstream
     """
-    _require_atlas()
+    import json as _json
 
-    typer.echo(f"Fetching lineage for: {name}")
-    typer.echo(f"  Direction: {direction}")
-    typer.echo(f"  Depth: {depth}")
-    typer.echo("")
+    # Reuse the proven resolver/reader from the `dataset` command group so this
+    # command is a real DataHub-backed reader, not a placeholder.
+    from seeknal.cli.dataset import (
+        _require_catalog,
+        _resolve_dataset,
+        _dataset_urn,
+        _lineage_nodes,
+        _print_lineage,
+    )
+    from seeknal.integrations.atlas_client import (
+        AtlasAuthError,
+        AtlasContractError,
+    )
 
-    # Note: In a full implementation, this would call the DataHub lineage API
-    # For now, we provide a placeholder
-    _echo_info("Lineage visualization requires a running Atlas API and DataHub")
-    typer.echo("")
-    typer.echo("To enable lineage:")
-    typer.echo("  1. Start the Atlas API: seeknal atlas api start")
-    typer.echo("  2. Configure DATAHUB_GMS_URL environment variable")
-    typer.echo("  3. Publish lineage: seeknal atlas lineage publish")
+    client = _require_catalog()
+    resolved = _resolve_dataset(client, name)
+    try:
+        data = client.lineage(_dataset_urn(resolved))
+    except AtlasAuthError as exc:
+        _echo_error(str(exc))
+        raise typer.Exit(1)
+    except AtlasContractError as exc:
+        _echo_error(f"Lineage lookup failed: {exc}")
+        raise typer.Exit(1)
+
+    upstream = _lineage_nodes(data.get("upstreamLineage") or data.get("upstream"))
+    downstream = _lineage_nodes(
+        data.get("downstreamLineage") or data.get("downstream")
+    )
+
+    if format == "json":
+        typer.echo(
+            _json.dumps(
+                {
+                    "dataset": resolved.fqn,
+                    "upstream": upstream,
+                    "downstream": downstream,
+                },
+                indent=2,
+            )
+        )
+        return
+
+    _echo_success(f"Lineage for {resolved.fqn}")
+    if direction in ("upstream", "both"):
+        _print_lineage("upstream", upstream)
+    if direction in ("downstream", "both"):
+        _print_lineage("downstream", downstream)
+    if not upstream and not downstream:
+        _echo_info("No lineage recorded in DataHub for this dataset.")
 
 
 @lineage_app.command("publish")
@@ -770,13 +810,25 @@ def lineage_publish(
         _echo_error("Both --inputs and --outputs are required")
         raise typer.Exit(1)
 
-    _require_atlas()
-
     import uuid
 
+    from seeknal.integrations.atlas_client import (
+        AtlasContractError,
+        create_atlas_contract_client_from_env,
+    )
+
+    # Route through the always-available contract client (same
+    # /api/contracts/lineage/publish path the apply flow uses) so manual
+    # lineage publishing works in a standard install without the optional
+    # atlas-data-platform package.
+    client = create_atlas_contract_client_from_env()
+    if client is None:
+        _echo_error("Atlas is not configured (set ATLAS_API_URL).")
+        raise typer.Exit(2)
+
     final_run_id = run_id or str(uuid.uuid4())
-    input_list = [i.strip() for i in inputs.split(",")]
-    output_list = [o.strip() for o in outputs.split(",")]
+    input_list = [i.strip() for i in inputs.split(",") if i.strip()]
+    output_list = [o.strip() for o in outputs.split(",") if o.strip()]
 
     typer.echo(f"Publishing lineage for: {pipeline}")
     typer.echo(f"  Run ID: {final_run_id}")
@@ -784,47 +836,35 @@ def lineage_publish(
     typer.echo(f"  Outputs: {output_list}")
     typer.echo("")
 
+    project = os.getenv("SEEKNAL_PROJECT_NAME") or "seeknal"
+    environment = os.getenv("ATLAS_ENVIRONMENT", os.getenv("SEEKNAL_ENV", "dev"))
+
+    def _ref(dataset_name: str) -> dict:
+        return {
+            "asset_type": "dataset",
+            "name": dataset_name,
+            "namespace": f"{project}/{environment}/dataset",
+            "source_system": "seeknal",
+            "source_id": f"dataset:{dataset_name}",
+            "metadata": {"pipeline": pipeline, "run_id": final_run_id},
+        }
+
+    upstreams = [_ref(name) for name in input_list]
     try:
-        from atlas.seeknal.governance_tools import (
-            create_lineage_publishing_tool,
-            create_governance_tools_config,
-        )
-
-        config = create_governance_tools_config()
-        tool = create_lineage_publishing_tool(config)
-
-        # Convert to URNs (simplified)
-        def to_urn(name: str) -> str:
-            return f"urn:li:dataset:(urn:li:dataPlatform:iceberg,{name},PROD)"
-
-        input_urns = [to_urn(i) for i in input_list]
-        output_urns = [to_urn(o) for o in output_list]
-
-        result = tool.publish_lineage(
-            pipeline_name=pipeline,
-            run_id=final_run_id,
-            inputs=input_urns,
-            outputs=output_urns,
-        )
-
-        if result.success:
-            _echo_success("Lineage published successfully")
-            typer.echo(f"  Upstream datasets: {result.upstream_count}")
-            typer.echo(f"  Downstream datasets: {result.downstream_count}")
-            typer.echo(f"  Latency: {result.latency_ms:.1f}ms")
-        else:
-            _echo_error(f"Failed to publish lineage: {result.error_message}")
-            raise typer.Exit(1)
-
-    except ImportError:
-        _echo_warning("DataHub client not fully configured")
-        typer.echo("")
-        typer.echo("Lineage publishing requires:")
-        typer.echo("  - DATAHUB_GMS_URL environment variable")
-        typer.echo("  - DATAHUB_TOKEN environment variable (optional)")
-    except Exception as e:
-        _echo_error(f"Error publishing lineage: {e}")
+        for output_name in output_list:
+            client.publish_lineage(
+                project_name=project,
+                environment=environment,
+                asset=_ref(output_name),
+                upstreams=upstreams,
+            )
+    except AtlasContractError as exc:
+        _echo_error(f"Failed to publish lineage: {exc}")
         raise typer.Exit(1)
+
+    _echo_success("Lineage published successfully")
+    typer.echo(f"  Upstream datasets: {len(input_list)}")
+    typer.echo(f"  Downstream datasets: {len(output_list)}")
 
 
 # =============================================================================

--- a/src/seeknal/cli/auth.py
+++ b/src/seeknal/cli/auth.py
@@ -35,6 +35,12 @@ from typing import Any, Optional
 import httpx
 import typer
 
+from seeknal.integrations.atlas_config import (
+    atlas_config,
+    config_path,
+    derive_config,
+    save_atlas_config,
+)
 from seeknal.integrations.atlas_governance import (
     credentials_path,
     user_email_from_credentials,
@@ -62,13 +68,21 @@ _CALLBACK_TIMEOUT_SECONDS = 300.0
 def _issuer() -> str:
     """Return the configured Keycloak issuer URL (trailing slash stripped)."""
 
-    return (os.getenv("KEYCLOAK_ISSUER", "").strip() or _DEFAULT_ISSUER).rstrip("/")
+    return (
+        os.getenv("KEYCLOAK_ISSUER", "").strip()
+        or atlas_config().keycloak_issuer
+        or _DEFAULT_ISSUER
+    ).rstrip("/")
 
 
 def _client_id() -> str:
     """Return the configured public OIDC client id."""
 
-    return os.getenv("SEEKNAL_OIDC_CLIENT_ID", "").strip() or _DEFAULT_CLIENT_ID
+    return (
+        os.getenv("SEEKNAL_OIDC_CLIENT_ID", "").strip()
+        or atlas_config().oidc_client_id
+        or _DEFAULT_CLIENT_ID
+    )
 
 
 def _redirect_port() -> int:
@@ -311,15 +325,35 @@ def login(
         "--no-browser",
         help="Print the authorization URL instead of opening a browser.",
     ),
+    host: Optional[str] = typer.Option(
+        None,
+        "--host",
+        help="Configure the Atlas host (derives api/portal/keycloak URLs) before logging in.",
+    ),
+    api_url: Optional[str] = typer.Option(
+        None,
+        "--api-url",
+        help="Configure the Atlas API URL (derives portal/keycloak) before logging in.",
+    ),
 ) -> None:
     """Log in via the Keycloak Authorization Code + PKCE loopback flow.
 
+    Pass ``--host``/``--api-url`` to configure the connection and sign in in one step
+    (it persists ~/.config/seeknal/atlas.json, so later commands need no env vars).
     Discovers the OIDC endpoints from the issuer well-known document, generates a
     PKCE verifier/challenge and CSRF state, opens (or prints) the authorization URL,
     captures the redirect on the loopback port, exchanges the code for tokens, and
     writes them to the credentials file. Prints the logged-in subject and email on
     success; exits with code 1 on any failure.
     """
+
+    if host or api_url:
+        cfg = derive_config(host=host or "", api_url=api_url or "")
+        path = save_atlas_config(cfg)
+        echo_info(
+            f"Configured Atlas ({path}): api={cfg.api_url} portal={cfg.portal_url} "
+            f"keycloak={cfg.keycloak_issuer}"
+        )
 
     issuer = _issuer()
     client_id = _client_id()
@@ -427,3 +461,78 @@ def logout() -> None:
         echo_error(f"Failed to remove credentials: {exc}")
         raise typer.Exit(1)
     echo_success(f"Logged out (removed {path}).")
+
+
+config_app = typer.Typer(
+    name="config",
+    help="Configure the Atlas connection (persists ~/.config/seeknal/atlas.json).",
+)
+auth_app.add_typer(config_app, name="config")
+
+
+@config_app.command("set")
+def config_set(
+    host: Optional[str] = typer.Option(
+        None,
+        "--host",
+        help="Atlas host; derives api :8000, portal :4200, keycloak :8080/realms/<realm>.",
+    ),
+    api_url: Optional[str] = typer.Option(
+        None, "--api-url", help="Atlas API URL (derives portal/keycloak from its host)."
+    ),
+    portal_url: Optional[str] = typer.Option(None, "--portal-url", help="Override the portal URL."),
+    keycloak_issuer: Optional[str] = typer.Option(
+        None, "--keycloak-issuer", help="Override the Keycloak issuer."
+    ),
+    realm: str = typer.Option("atlas", "--realm", help="Keycloak realm (for the derived issuer)."),
+    client_id: Optional[str] = typer.Option(
+        None, "--client-id", help="OIDC client id (default seeknal-cli)."
+    ),
+) -> None:
+    """Persist the Atlas connection so commands don't need env vars.
+
+    Give ``--host`` to derive all three URLs from one host, or set them explicitly.
+    Environment variables (ATLAS_API_URL, ATLAS_PORTAL_URL, KEYCLOAK_ISSUER) still
+    override this file.
+    """
+
+    if not host and not api_url:
+        echo_error("Provide --host (derives all URLs) or --api-url.")
+        raise typer.Exit(1)
+    cfg = derive_config(
+        host=host or "",
+        api_url=api_url or "",
+        portal_url=portal_url or "",
+        keycloak_issuer=keycloak_issuer or "",
+        realm=realm,
+        oidc_client_id=client_id or "",
+    )
+    path = save_atlas_config(cfg)
+    echo_success(f"Wrote Atlas config to {path}")
+    typer.echo(f"  api_url        : {cfg.api_url}")
+    typer.echo(f"  portal_url     : {cfg.portal_url}")
+    typer.echo(f"  keycloak_issuer: {cfg.keycloak_issuer}")
+    typer.echo(f"  oidc_client_id : {cfg.oidc_client_id}")
+    echo_info("Run `seeknal auth login` to sign in.")
+
+
+@config_app.command("show")
+def config_show() -> None:
+    """Show the effective Atlas connection settings and where each value comes from."""
+
+    cfg = atlas_config()
+    typer.echo(f"Atlas config ({config_path()}):")
+    for label, env_var, file_value in (
+        ("api_url", "ATLAS_API_URL", cfg.api_url),
+        ("portal_url", "ATLAS_PORTAL_URL", cfg.portal_url),
+        ("keycloak_issuer", "KEYCLOAK_ISSUER", cfg.keycloak_issuer),
+        ("oidc_client_id", "SEEKNAL_OIDC_CLIENT_ID", cfg.oidc_client_id),
+    ):
+        env_value = os.getenv(env_var, "").strip()
+        if env_value:
+            value, source = env_value, "env"
+        elif file_value:
+            value, source = file_value, "config"
+        else:
+            value, source = "(unset)", "default"
+        typer.echo(f"  {label:16}: {value}  [{source}]")

--- a/src/seeknal/cli/auth.py
+++ b/src/seeknal/cli/auth.py
@@ -1,0 +1,429 @@
+"""
+Seeknal CLI - Keycloak/OIDC authentication.
+
+A command group for logging the engine user in against the Atlas Keycloak realm
+using the OAuth 2.0 Authorization Code flow with PKCE (S256) over a localhost
+loopback redirect. The resulting tokens are written to the seeknal credentials
+file so the governance gate and ``seeknal gov`` commands can attribute requests
+to the logged-in user.
+
+Usage:
+    seeknal auth login
+    seeknal auth login --no-browser
+    seeknal auth status
+    seeknal auth logout
+
+The Keycloak ``seeknal-cli`` client is public (no secret) with PKCE S256 and the
+standard authorization-code flow enabled; RFC 8628 device flow is *not* enabled,
+so login uses a browser-based loopback redirect on ``http://127.0.0.1:8765/callback``.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import http.server
+import json
+import os
+import secrets
+import threading
+import urllib.parse
+import webbrowser
+from pathlib import Path
+from typing import Any, Optional
+
+import httpx
+import typer
+
+from seeknal.integrations.atlas_governance import (
+    credentials_path,
+    user_email_from_credentials,
+    user_sub_from_credentials,
+)
+from seeknal.ui.output import echo_error, echo_info, echo_success, echo_warning
+
+auth_app = typer.Typer(
+    name="auth",
+    help="Authenticate against the Atlas Keycloak realm (login, status, logout).",
+)
+
+#: Default Keycloak issuer for the Atlas realm (overridable via KEYCLOAK_ISSUER).
+_DEFAULT_ISSUER = "http://localhost:8080/realms/atlas"
+#: Default public OIDC client id (overridable via SEEKNAL_OIDC_CLIENT_ID).
+_DEFAULT_CLIENT_ID = "seeknal-cli"
+#: Default loopback redirect port; the registered redirect URIs use 8765.
+_DEFAULT_REDIRECT_PORT = 8765
+#: Seconds to wait for the OIDC discovery / token endpoints before giving up.
+_HTTP_TIMEOUT_SECONDS = 30.0
+#: Seconds to wait for the browser to complete the redirect before aborting login.
+_CALLBACK_TIMEOUT_SECONDS = 300.0
+
+
+def _issuer() -> str:
+    """Return the configured Keycloak issuer URL (trailing slash stripped)."""
+
+    return (os.getenv("KEYCLOAK_ISSUER", "").strip() or _DEFAULT_ISSUER).rstrip("/")
+
+
+def _client_id() -> str:
+    """Return the configured public OIDC client id."""
+
+    return os.getenv("SEEKNAL_OIDC_CLIENT_ID", "").strip() or _DEFAULT_CLIENT_ID
+
+
+def _redirect_port() -> int:
+    """Return the loopback redirect port (env override falls back to the default)."""
+
+    raw = os.getenv("SEEKNAL_OIDC_REDIRECT_PORT", "").strip()
+    if not raw:
+        return _DEFAULT_REDIRECT_PORT
+    try:
+        return int(raw)
+    except ValueError:
+        return _DEFAULT_REDIRECT_PORT
+
+
+def _redirect_uri(port: int) -> str:
+    """Build the loopback redirect URI for ``port`` (matches Keycloak config)."""
+
+    return f"http://127.0.0.1:{port}/callback"
+
+
+def _pkce_pair() -> tuple[str, str]:
+    """Generate a PKCE ``(code_verifier, code_challenge)`` pair using S256.
+
+    The verifier is a high-entropy URL-safe random string (RFC 7636 §4.1) and the
+    challenge is the base64url-encoded SHA-256 of the verifier with padding removed
+    (RFC 7636 §4.2). Both are returned as ASCII strings.
+
+    Returns:
+        A ``(code_verifier, code_challenge)`` tuple.
+    """
+
+    verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode("ascii")
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+def _discover_endpoints(issuer: str, *, client: httpx.Client | None = None) -> dict[str, Any]:
+    """Fetch the OIDC discovery document from ``<issuer>/.well-known/openid-configuration``.
+
+    Args:
+        issuer: The Keycloak realm issuer URL.
+        client: Optional pre-built httpx client (used in tests). When ``None`` a
+            one-shot request is made.
+
+    Returns:
+        The parsed discovery document, which carries ``authorization_endpoint`` and
+        ``token_endpoint`` among other fields.
+
+    Raises:
+        httpx.HTTPError: If the discovery request fails.
+    """
+
+    url = f"{issuer}/.well-known/openid-configuration"
+    if client is not None:
+        response = client.get(url, timeout=_HTTP_TIMEOUT_SECONDS)
+    else:
+        response = httpx.get(url, timeout=_HTTP_TIMEOUT_SECONDS)
+    response.raise_for_status()
+    return response.json()
+
+
+def _build_authorize_url(
+    endpoints: dict[str, Any],
+    *,
+    client_id: str,
+    redirect_uri: str,
+    code_challenge: str,
+    state: str,
+    scope: str = "openid email profile",
+) -> str:
+    """Build the OIDC authorization-endpoint URL for the PKCE code flow.
+
+    Args:
+        endpoints: The OIDC discovery document (must contain ``authorization_endpoint``).
+        client_id: The public OIDC client id.
+        redirect_uri: The loopback redirect URI registered with Keycloak.
+        code_challenge: The S256 PKCE challenge derived from the verifier.
+        state: Opaque CSRF state echoed back on the redirect.
+        scope: Space-delimited OIDC scopes (default requests an id token + email/profile).
+
+    Returns:
+        The fully-qualified authorization URL to open in the browser.
+    """
+
+    authorization_endpoint = endpoints["authorization_endpoint"]
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "scope": scope,
+        "state": state,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    }
+    return f"{authorization_endpoint}?{urllib.parse.urlencode(params)}"
+
+
+def _exchange_code(
+    token_endpoint: str,
+    *,
+    code: str,
+    code_verifier: str,
+    client_id: str,
+    redirect_uri: str,
+    client: httpx.Client | None = None,
+) -> dict[str, Any]:
+    """Exchange an authorization ``code`` for tokens at the token endpoint.
+
+    Uses ``grant_type=authorization_code`` with the PKCE ``code_verifier``. The
+    client is public (no secret), so no client authentication is sent.
+
+    Args:
+        token_endpoint: The OIDC token endpoint URL.
+        code: The authorization code captured from the loopback redirect.
+        code_verifier: The PKCE verifier matching the challenge sent on authorize.
+        client_id: The public OIDC client id.
+        redirect_uri: The redirect URI used on the authorize request (must match).
+        client: Optional pre-built httpx client (used in tests).
+
+    Returns:
+        The parsed token response (``access_token``, ``refresh_token``, ...).
+
+    Raises:
+        httpx.HTTPError: If the token request fails.
+    """
+
+    data = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "client_id": client_id,
+        "code_verifier": code_verifier,
+    }
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    if client is not None:
+        response = client.post(
+            token_endpoint, data=data, headers=headers, timeout=_HTTP_TIMEOUT_SECONDS
+        )
+    else:
+        response = httpx.post(
+            token_endpoint, data=data, headers=headers, timeout=_HTTP_TIMEOUT_SECONDS
+        )
+    response.raise_for_status()
+    return response.json()
+
+
+def _write_credentials(tokens: dict[str, Any]) -> Path:
+    """Persist the OIDC token response to the seeknal credentials file.
+
+    Writes ``access_token``, ``refresh_token``, ``expires_in`` and
+    ``refresh_expires_in`` as JSON. The parent directory is created mode ``0700``
+    and the file itself is written mode ``0600`` so the tokens are not world- or
+    group-readable.
+
+    Args:
+        tokens: The token response from :func:`_exchange_code`.
+
+    Returns:
+        The path the credentials were written to.
+    """
+
+    path = credentials_path()
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    payload = {
+        "access_token": tokens.get("access_token"),
+        "refresh_token": tokens.get("refresh_token"),
+        "expires_in": tokens.get("expires_in"),
+        "refresh_expires_in": tokens.get("refresh_expires_in"),
+    }
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    os.chmod(path, 0o600)
+    return path
+
+
+class _CallbackHandler(http.server.BaseHTTPRequestHandler):
+    """Single-shot HTTP handler that captures the OIDC redirect query params."""
+
+    # Populated on the server instance by ``_capture_authorization_code``.
+    server_version = "seeknal-auth/1.0"
+
+    def do_GET(self) -> None:  # noqa: N802 (http.server API)
+        """Record the ``code``/``state``/``error`` from the redirect and respond."""
+
+        parsed = urllib.parse.urlparse(self.path)
+        query = urllib.parse.parse_qs(parsed.query)
+        self.server.oidc_result = {  # type: ignore[attr-defined]
+            "code": query.get("code", [None])[0],
+            "state": query.get("state", [None])[0],
+            "error": query.get("error", [None])[0],
+            "error_description": query.get("error_description", [None])[0],
+        }
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.end_headers()
+        body = (
+            "<html><body><h2>Seeknal login complete.</h2>"
+            "<p>You may close this tab and return to the terminal.</p></body></html>"
+        )
+        self.wfile.write(body.encode("utf-8"))
+
+    def log_message(self, *args: Any) -> None:  # noqa: D401 (silence default logging)
+        """Suppress the default stderr request logging."""
+
+
+def _capture_authorization_code(port: int, *, timeout: float = _CALLBACK_TIMEOUT_SECONDS) -> dict:
+    """Run a one-shot loopback HTTP server and return the captured redirect params.
+
+    Starts an :class:`http.server.HTTPServer` bound to ``127.0.0.1:port`` in a
+    background thread, services exactly one request (the OIDC redirect), and shuts
+    down. The returned dict carries ``code``/``state``/``error``.
+
+    Args:
+        port: The loopback port to bind (must match the registered redirect URI).
+        timeout: Seconds to wait for the redirect before giving up.
+
+    Returns:
+        The captured redirect parameters, or an ``error`` of ``"timeout"`` if no
+        request arrived in time.
+    """
+
+    server = http.server.HTTPServer(("127.0.0.1", port), _CallbackHandler)
+    server.oidc_result = None  # type: ignore[attr-defined]
+
+    thread = threading.Thread(target=server.handle_request, daemon=True)
+    thread.start()
+    thread.join(timeout=timeout)
+    server.server_close()
+
+    result = getattr(server, "oidc_result", None)
+    if not result:
+        return {"code": None, "state": None, "error": "timeout"}
+    return result
+
+
+@auth_app.command("login")
+def login(
+    no_browser: bool = typer.Option(
+        False,
+        "--no-browser",
+        help="Print the authorization URL instead of opening a browser.",
+    ),
+) -> None:
+    """Log in via the Keycloak Authorization Code + PKCE loopback flow.
+
+    Discovers the OIDC endpoints from the issuer well-known document, generates a
+    PKCE verifier/challenge and CSRF state, opens (or prints) the authorization URL,
+    captures the redirect on the loopback port, exchanges the code for tokens, and
+    writes them to the credentials file. Prints the logged-in subject and email on
+    success; exits with code 1 on any failure.
+    """
+
+    issuer = _issuer()
+    client_id = _client_id()
+    port = _redirect_port()
+    redirect_uri = _redirect_uri(port)
+
+    try:
+        endpoints = _discover_endpoints(issuer)
+    except httpx.HTTPError as exc:
+        echo_error(f"OIDC discovery failed for {issuer}: {exc}")
+        raise typer.Exit(1)
+
+    token_endpoint = endpoints.get("token_endpoint")
+    if not token_endpoint or "authorization_endpoint" not in endpoints:
+        echo_error("OIDC discovery document is missing authorization/token endpoints.")
+        raise typer.Exit(1)
+
+    verifier, challenge = _pkce_pair()
+    state = secrets.token_urlsafe(24)
+    authorize_url = _build_authorize_url(
+        endpoints,
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        code_challenge=challenge,
+        state=state,
+    )
+
+    if no_browser:
+        echo_info("Open this URL in your browser to log in:")
+        typer.echo(authorize_url)
+    else:
+        echo_info(f"Opening browser for login (listening on {redirect_uri})...")
+        webbrowser.open(authorize_url)
+
+    result = _capture_authorization_code(port)
+
+    if result.get("error"):
+        detail = result.get("error_description") or result["error"]
+        echo_error(f"Login failed: {detail}")
+        raise typer.Exit(1)
+    if result.get("state") != state:
+        echo_error("Login failed: state mismatch (possible CSRF); aborting.")
+        raise typer.Exit(1)
+    code = result.get("code")
+    if not code:
+        echo_error("Login failed: no authorization code returned.")
+        raise typer.Exit(1)
+
+    try:
+        tokens = _exchange_code(
+            token_endpoint,
+            code=code,
+            code_verifier=verifier,
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+        )
+    except httpx.HTTPError as exc:
+        echo_error(f"Token exchange failed: {exc}")
+        raise typer.Exit(1)
+
+    if not tokens.get("access_token"):
+        echo_error("Token exchange returned no access token.")
+        raise typer.Exit(1)
+
+    path = _write_credentials(tokens)
+
+    sub = user_sub_from_credentials()
+    email = user_email_from_credentials()
+    echo_success(f"Logged in as {email or sub or '(unknown)'}")
+    echo_info(f"sub: {sub or '(none)'} | credentials: {path}")
+
+
+@auth_app.command("status")
+def status() -> None:
+    """Print whether the user is authenticated, with their sub and email.
+
+    Reads the stored access token's claims. Exits with code 1 (and prints
+    ``authenticated: no``) when no usable credentials are present.
+    """
+
+    sub = user_sub_from_credentials()
+    email = user_email_from_credentials()
+    if not sub and not email:
+        echo_warning("authenticated: no")
+        raise typer.Exit(1)
+    echo_success("authenticated: yes")
+    echo_info(f"sub: {sub or '(none)'}")
+    echo_info(f"email: {email or '(none)'}")
+
+
+@auth_app.command("logout")
+def logout() -> None:
+    """Delete the seeknal credentials file, logging the user out locally.
+
+    A missing credentials file is treated as already logged out (success).
+    """
+
+    path = credentials_path()
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        echo_info("Already logged out (no credentials file).")
+        return
+    except OSError as exc:
+        echo_error(f"Failed to remove credentials: {exc}")
+        raise typer.Exit(1)
+    echo_success(f"Logged out (removed {path}).")

--- a/src/seeknal/cli/dataset.py
+++ b/src/seeknal/cli/dataset.py
@@ -326,11 +326,15 @@ def annotate_dataset(
     tags: Optional[List[str]] = typer.Option(None, "--tag", help="Tag to add (repeatable)."),
     description: Optional[str] = typer.Option(None, "--description", help="Set the description."),
     owners: Optional[List[str]] = typer.Option(None, "--owner", help="Owner to add (repeatable)."),
+    terms: Optional[List[str]] = typer.Option(None, "--term", help="Glossary term to add (repeatable)."),
+    domain: Optional[str] = typer.Option(None, "--domain", help="Set the business domain ('' clears it)."),
 ) -> None:
-    """Annotate a dataset (tags / description / owners) in the Atlas catalog."""
+    """Annotate a dataset (tags / description / owners / terms / domain) in the Atlas catalog."""
 
-    if not tags and description is None and not owners:
-        echo_error("Provide at least one of --tag, --description, --owner.")
+    if not tags and description is None and not owners and not terms and domain is None:
+        echo_error(
+            "Provide at least one of --tag, --description, --owner, --term, --domain."
+        )
         raise typer.Exit(1)
     client = _require_catalog()
     resolved = _resolve_dataset(client, dataset)
@@ -340,6 +344,8 @@ def annotate_dataset(
             tags=tags or None,
             description=description,
             owners=owners or None,
+            terms=terms or None,
+            domain=domain,
         )
     except AtlasContractError as exc:
         echo_error(f"Annotation failed: {exc}")

--- a/src/seeknal/cli/dataset.py
+++ b/src/seeknal/cli/dataset.py
@@ -491,4 +491,87 @@ def lineage_dataset(
         echo_info("No lineage recorded in DataHub for this dataset.")
 
 
+def _render_iceberg_source(name: str, namespace: str, table: str) -> str:
+    """Render a governed ``kind: source`` (iceberg) node for a Lakekeeper table.
+
+    ``table`` is addressed as ``atlas.<namespace>.<table>`` (the catalog name the
+    REPL/materialization attach the Lakekeeper warehouse under). ``catalog_uri`` and
+    ``warehouse`` are intentionally omitted — they resolve from the project's
+    ``profiles.yml`` (``materialization.catalog``) or ``source_defaults.iceberg`` —
+    so the snippet stays portable.
+    """
+
+    return (
+        "\n".join(
+            [
+                "kind: source",
+                f"name: {name}",
+                "source: iceberg",
+                f"table: atlas.{namespace}.{table}",
+                "# catalog_uri + warehouse resolve from profiles.yml "
+                "(materialization.catalog) or source_defaults.iceberg.",
+                "# `seeknal run` access-checks + masks this table via the Atlas gate.",
+            ]
+        )
+        + "\n"
+    )
+
+
+@dataset_app.command("use")
+def use_dataset(
+    dataset: str = typer.Argument(..., help="Dataset id or name."),
+    name: Optional[str] = typer.Option(
+        None, "--name", help="Source node name (default: the table name)."
+    ),
+    write: bool = typer.Option(
+        False, "--write", help="Write the source into seeknal/sources/<name>.yml."
+    ),
+) -> None:
+    """Scaffold a governed seeknal source for a dataset, ready to use in a pipeline.
+
+    Emits a ``kind: source`` (iceberg) node referencing the governed Lakekeeper
+    table. Drop it into your project (or use ``--write``) and ``seeknal run`` will
+    access-check + mask it via the Atlas gate — bridging discover → use.
+    """
+
+    client = _require_catalog()
+    resolved = _resolve_dataset(client, dataset)
+
+    if (resolved.source_system or resolved.asset_type).lower() == "cube":
+        echo_error(
+            f"'{resolved.fqn}' is a cube data product, not an iceberg table; "
+            "it cannot be scaffolded as an iceberg pipeline source."
+        )
+        raise typer.Exit(1)
+
+    segments = resolved.fqn.split(".")
+    if len(segments) < 2:
+        echo_error(
+            f"'{resolved.fqn}' is not a namespace.table identifier; only governed "
+            "Lakekeeper tables can be used as an iceberg source."
+        )
+        raise typer.Exit(1)
+    namespace, table = segments[-2], segments[-1]
+    node_name = name or table
+    snippet = _render_iceberg_source(node_name, namespace, table)
+
+    if write:
+        dest = os.path.join("seeknal", "sources", f"{node_name}.yml")
+        if os.path.exists(dest):
+            echo_error(f"{dest} already exists — choose --name or remove it first.")
+            raise typer.Exit(1)
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        with open(dest, "w", encoding="utf-8") as handle:
+            handle.write(snippet)
+        echo_success(f"Wrote {dest}")
+        echo_info(f"Reference it in a transform as ref('source.{node_name}'), then `seeknal run`.")
+        return
+
+    typer.echo(snippet)
+    echo_info(
+        f"Save as seeknal/sources/{node_name}.yml (or re-run with --write); "
+        "`seeknal run` will govern it."
+    )
+
+
 __all__ = ["dataset_app"]

--- a/src/seeknal/cli/dataset.py
+++ b/src/seeknal/cli/dataset.py
@@ -32,11 +32,17 @@ from seeknal.integrations.atlas_catalog import (
     Dataset,
     create_catalog_client_from_env,
 )
-from seeknal.integrations.atlas_client import AtlasContractError, AtlasPolicyDenied
+from seeknal.integrations.atlas_client import (
+    AtlasAuthError,
+    AtlasContractError,
+    AtlasPolicyDenied,
+    SESSION_EXPIRED_HINT,
+)
 from seeknal.integrations.atlas_governance import (
     AccessDecision,
     apply_column_masks,
     create_governance_gate_from_env,
+    refresh_access_token,
     user_email_from_credentials,
     user_token_from_credentials,
 )
@@ -77,10 +83,20 @@ def _resolve_dataset(client: AtlasCatalogClient, ref: str) -> Dataset:
     if _UUID_RE.match(ref):
         try:
             return client.get_dataset(ref)
+        except AtlasAuthError as exc:
+            echo_error(str(exc))
+            raise typer.Exit(1) from exc
         except AtlasContractError:
             pass  # fall through to a name search
 
-    matches = client.list_datasets(query=ref, limit=10)
+    try:
+        matches = client.list_datasets(query=ref, limit=10)
+    except AtlasAuthError as exc:
+        echo_error(str(exc))
+        raise typer.Exit(1) from exc
+    except AtlasContractError as exc:
+        echo_error(f"Catalog lookup failed: {exc}")
+        raise typer.Exit(1) from exc
     for dataset in matches:
         if ref in (dataset.name, dataset.fqn, dataset.id):
             return dataset
@@ -115,8 +131,17 @@ def _extract_sample(data: Any) -> tuple[list[str], list[list[Any]]]:
     """Normalise a ``/api/sample`` response into ``(columns, rows)``.
 
     Tolerant of the common shapes: ``{columns, rows}``, ``{schema, data}``, a list of
-    row dicts, or a list of row sequences.
+    row dicts, or a list of row sequences. The Atlas backend wraps each row as
+    ``{"values": {col: val}}``, so unwrap that envelope before projecting columns.
     """
+
+    def _row_dict(row: Any) -> dict[str, Any]:
+        if isinstance(row, dict):
+            inner = row.get("values")
+            if isinstance(inner, dict):
+                return inner
+            return row
+        return {}
 
     if isinstance(data, dict):
         raw_cols = data.get("columns") or data.get("schema") or []
@@ -124,15 +149,15 @@ def _extract_sample(data: Any) -> tuple[list[str], list[list[Any]]]:
         raw_rows = data.get("rows") or data.get("data") or []
         if raw_rows and isinstance(raw_rows[0], dict):
             if not columns:
-                columns = list(raw_rows[0].keys())
-            rows = [[r.get(c) for c in columns] for r in raw_rows]
+                columns = list(_row_dict(raw_rows[0]).keys())
+            rows = [[_row_dict(r).get(c) for c in columns] for r in raw_rows]
         else:
             rows = [list(r) for r in raw_rows]
         return [str(c) for c in columns], rows
     if isinstance(data, list):
         if data and isinstance(data[0], dict):
-            columns = list(data[0].keys())
-            return columns, [[r.get(c) for c in columns] for r in data]
+            columns = list(_row_dict(data[0]).keys())
+            return columns, [[_row_dict(r).get(c) for c in columns] for r in data]
         return [], [list(r) for r in data]
     return [], []
 
@@ -147,6 +172,9 @@ def _print_sample(
 
     try:
         data = client.sample(dataset.fqn, limit=limit)
+    except AtlasAuthError as exc:
+        echo_error(str(exc))
+        return
     except AtlasContractError as exc:
         echo_error(f"Sample failed: {exc}")
         return
@@ -300,20 +328,29 @@ def request_access(
         "priority": priority,
         "type": "dataset",
     }
-    headers = {"Content-Type": "application/json"}
-    token = user_token_from_credentials()
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-
-    try:
-        response = httpx.post(
+    def _post_access_request(bearer: str | None) -> httpx.Response:
+        headers = {"Content-Type": "application/json"}
+        if bearer:
+            headers["Authorization"] = f"Bearer {bearer}"
+        return httpx.post(
             f"{base}/governance/access-requests",
             json=body,
             headers=headers,
             timeout=_REQUEST_TIMEOUT_SECONDS,
         )
+
+    try:
+        response = _post_access_request(user_token_from_credentials())
+        # On an expired session, refresh the access token once and retry.
+        if response.status_code == 401:
+            new_token = refresh_access_token()
+            if new_token:
+                response = _post_access_request(new_token)
     except httpx.HTTPError as exc:
         echo_error(f"Access request failed: {exc}")
+        raise typer.Exit(1)
+    if response.status_code == 401:
+        echo_error(SESSION_EXPIRED_HINT)
         raise typer.Exit(1)
     if not (200 <= response.status_code < 300):
         detail = response.text.strip() or f"HTTP {response.status_code}"

--- a/src/seeknal/cli/dataset.py
+++ b/src/seeknal/cli/dataset.py
@@ -99,9 +99,15 @@ def _resolve_dataset(client: AtlasCatalogClient, ref: str) -> Dataset:
     except AtlasContractError as exc:
         echo_error(f"Catalog lookup failed: {exc}")
         raise typer.Exit(1) from exc
-    for dataset in matches:
-        if ref in (dataset.name, dataset.fqn, dataset.id):
-            return dataset
+    exact = [d for d in matches if ref in (d.name, d.fqn, d.id)]
+    if exact:
+        if len(exact) > 1:
+            others = ", ".join(d.fqn for d in exact[1:6])
+            echo_info(
+                f"'{ref}' matches {len(exact)} datasets; using {exact[0].fqn}. "
+                f"Others: {others}. Pass the full namespace.table to choose another."
+            )
+        return exact[0]
     if matches:
         return matches[0]
 

--- a/src/seeknal/cli/dataset.py
+++ b/src/seeknal/cli/dataset.py
@@ -38,6 +38,7 @@ from seeknal.integrations.atlas_client import (
     AtlasPolicyDenied,
     SESSION_EXPIRED_HINT,
 )
+from seeknal.integrations.atlas_config import atlas_config
 from seeknal.integrations.atlas_governance import (
     AccessDecision,
     apply_column_masks,
@@ -251,10 +252,10 @@ def list_datasets(
         tabulate(rows, headers=["Name", "Namespace", "Source", "Type", "Tags"], tablefmt="simple")
     )
     echo_info(f"{len(datasets)} {'accessible ' if accessible else ''}dataset(s).")
-    if not os.getenv("ATLAS_PORTAL_URL", "").strip():
+    if not (os.getenv("ATLAS_PORTAL_URL", "").strip() or atlas_config().portal_url):
         echo_info(
-            "Showing the seeknal asset registry. Set ATLAS_PORTAL_URL to list the full "
-            "Atlas catalog (the datasets the web portal shows)."
+            "Showing the seeknal asset registry. Run `seeknal auth config set --host <host>` "
+            "(or set ATLAS_PORTAL_URL) to list the full Atlas catalog (what the web shows)."
         )
 
 
@@ -360,7 +361,10 @@ def request_access(
     resolved = _resolve_dataset(client, dataset)
 
     base = (
-        os.getenv("SEEKNAL_API_URL") or os.getenv("ATLAS_API_URL") or "http://localhost:8000"
+        os.getenv("SEEKNAL_API_URL")
+        or os.getenv("ATLAS_API_URL")
+        or atlas_config().api_url
+        or "http://localhost:8000"
     ).rstrip("/")
     body: dict[str, Any] = {
         "requester": user_email_from_credentials() or os.getenv("USER", ""),

--- a/src/seeknal/cli/dataset.py
+++ b/src/seeknal/cli/dataset.py
@@ -55,6 +55,8 @@ dataset_app = typer.Typer(
 
 #: Seconds to wait for the Atlas governance API before giving up.
 _REQUEST_TIMEOUT_SECONDS = 30.0
+#: Max columns ``show`` prints inline before truncating with a "+N more" line.
+_SHOW_COLUMN_LIMIT = 50
 _UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{12}$")
 #: A dotted ``namespace.table`` identifier (a governed Lakekeeper table that may not
 #: be a registered catalog asset). No slashes/spaces — distinguishes it from an
@@ -124,6 +126,7 @@ def _dataset_dict(dataset: Dataset) -> dict[str, Any]:
         "description": dataset.description,
         "tags": list(dataset.tags),
         "fqn": dataset.fqn,
+        "columns": [{"name": name, "type": col_type} for name, col_type in dataset.columns],
     }
 
 
@@ -261,6 +264,13 @@ def show_dataset(
     if resolved.tags:
         typer.echo(f"  tags      : {', '.join(resolved.tags)}")
     typer.echo(f"  id        : {resolved.id}")
+    if resolved.columns:
+        typer.echo(f"  columns   : {len(resolved.columns)}")
+        for col_name, col_type in resolved.columns[:_SHOW_COLUMN_LIMIT]:
+            suffix = f" ({col_type})" if col_type else ""
+            typer.echo(f"    - {col_name}{suffix}")
+        if len(resolved.columns) > _SHOW_COLUMN_LIMIT:
+            typer.echo(f"    … (+{len(resolved.columns) - _SHOW_COLUMN_LIMIT} more)")
     if decision is not None:
         mark = "ALLOW" if decision.allowed else "DENY"
         masked = (

--- a/src/seeknal/cli/dataset.py
+++ b/src/seeknal/cli/dataset.py
@@ -206,6 +206,11 @@ def list_datasets(
     asset_type: Optional[str] = typer.Option(None, "--type", help="Filter by asset type."),
     namespace: Optional[str] = typer.Option(None, "--namespace", help="Filter by namespace."),
     limit: int = typer.Option(50, "--limit", help="Maximum number of datasets."),
+    accessible: bool = typer.Option(
+        False,
+        "--accessible",
+        help="Show only datasets you can read (runs an access check per row; slower).",
+    ),
     as_json: bool = typer.Option(False, "--json", help="Output JSON instead of a table."),
 ) -> None:
     """List datasets in the Atlas catalog."""
@@ -219,15 +224,33 @@ def list_datasets(
         echo_error(f"Failed to list datasets: {exc}")
         raise typer.Exit(1)
 
+    if accessible:
+        gate = create_governance_gate_from_env()
+        if gate is None:
+            echo_error("--accessible needs the governance gate (set ATLAS_API_URL).")
+            raise typer.Exit(2)
+        kept: list[Dataset] = []
+        for dataset in datasets:
+            try:
+                if gate.check_access(resource=dataset.fqn, action="read").allowed:
+                    kept.append(dataset)
+            except AtlasContractError:
+                pass  # fail closed: drop from the accessible list
+        datasets = kept
+
     if as_json:
         typer.echo(_json.dumps([_dataset_dict(d) for d in datasets], indent=2))
         return
     if not datasets:
-        echo_info("No datasets found.")
+        echo_info("No accessible datasets found." if accessible else "No datasets found.")
         return
-    rows = [[d.name, d.namespace, d.asset_type, ", ".join(d.tags)] for d in datasets]
-    typer.echo(tabulate(rows, headers=["Name", "Namespace", "Type", "Tags"], tablefmt="simple"))
-    echo_info(f"{len(datasets)} dataset(s).")
+    rows = [
+        [d.name, d.namespace, d.source_system, d.asset_type, ", ".join(d.tags)] for d in datasets
+    ]
+    typer.echo(
+        tabulate(rows, headers=["Name", "Namespace", "Source", "Type", "Tags"], tablefmt="simple")
+    )
+    echo_info(f"{len(datasets)} {'accessible ' if accessible else ''}dataset(s).")
     if not os.getenv("ATLAS_PORTAL_URL", "").strip():
         echo_info(
             "Showing the seeknal asset registry. Set ATLAS_PORTAL_URL to list the full "

--- a/src/seeknal/cli/dataset.py
+++ b/src/seeknal/cli/dataset.py
@@ -222,6 +222,11 @@ def list_datasets(
     rows = [[d.name, d.namespace, d.asset_type, ", ".join(d.tags)] for d in datasets]
     typer.echo(tabulate(rows, headers=["Name", "Namespace", "Type", "Tags"], tablefmt="simple"))
     echo_info(f"{len(datasets)} dataset(s).")
+    if not os.getenv("ATLAS_PORTAL_URL", "").strip():
+        echo_info(
+            "Showing the seeknal asset registry. Set ATLAS_PORTAL_URL to list the full "
+            "Atlas catalog (the datasets the web portal shows)."
+        )
 
 
 @dataset_app.command("show")

--- a/src/seeknal/cli/dataset.py
+++ b/src/seeknal/cli/dataset.py
@@ -407,4 +407,88 @@ def query_dataset(
     _print_sample(client, resolved, limit, decision)
 
 
+def _dataset_urn(dataset: Dataset) -> str:
+    """Best-effort DataHub dataset URN for a lineage lookup.
+
+    Prefers the urn the portal already carried in ``metadata``/``id``; otherwise
+    composes the iceberg URN from the fqn so a governed table resolved as a direct
+    ``namespace.table`` identifier still looks up lineage.
+    """
+
+    urn = str(dataset.metadata.get("urn") or "")
+    if urn.startswith("urn:"):
+        return urn
+    if dataset.id.startswith("urn:"):
+        return dataset.id
+    platform = str(dataset.metadata.get("platform") or dataset.source_system or "iceberg")
+    return f"urn:li:dataset:(urn:li:dataPlatform:{platform},{dataset.fqn},PROD)"
+
+
+def _name_from_urn(urn: str) -> str:
+    match = re.match(r"urn:li:dataset:\(urn:li:dataPlatform:\w+,([^,]+),", urn)
+    return match.group(1) if match else ""
+
+
+def _lineage_nodes(raw: Any) -> list[dict[str, str]]:
+    """Normalise a lineage relationship list into ``{name, type}`` dicts."""
+
+    nodes: list[dict[str, str]] = []
+    for node in raw or []:
+        if not isinstance(node, dict):
+            continue
+        urn = str(node.get("urn", ""))
+        name = node.get("name") or _name_from_urn(urn) or urn
+        nodes.append(
+            {"name": str(name), "type": str(node.get("type") or node.get("platform") or "")}
+        )
+    return nodes
+
+
+def _print_lineage(label: str, nodes: list[dict[str, str]]) -> None:
+    typer.echo(f"  {label}:")
+    if not nodes:
+        typer.echo("    (none)")
+        return
+    for node in nodes:
+        suffix = f" [{node['type']}]" if node["type"] else ""
+        typer.echo(f"    - {node['name']}{suffix}")
+
+
+@dataset_app.command("lineage")
+def lineage_dataset(
+    dataset: str = typer.Argument(..., help="Dataset id or name."),
+    as_json: bool = typer.Option(False, "--json", help="Output JSON instead of text."),
+) -> None:
+    """Show a dataset's upstream/downstream lineage (DataHub-backed)."""
+
+    client = _require_catalog()
+    resolved = _resolve_dataset(client, dataset)
+    try:
+        data = client.lineage(_dataset_urn(resolved))
+    except AtlasAuthError as exc:
+        echo_error(str(exc))
+        raise typer.Exit(1)
+    except AtlasContractError as exc:
+        echo_error(f"Lineage lookup failed: {exc}")
+        raise typer.Exit(1)
+
+    upstream = _lineage_nodes(data.get("upstreamLineage") or data.get("upstream"))
+    downstream = _lineage_nodes(data.get("downstreamLineage") or data.get("downstream"))
+
+    if as_json:
+        typer.echo(
+            _json.dumps(
+                {"dataset": resolved.fqn, "upstream": upstream, "downstream": downstream},
+                indent=2,
+            )
+        )
+        return
+
+    echo_success(f"Lineage for {resolved.fqn}")
+    _print_lineage("upstream", upstream)
+    _print_lineage("downstream", downstream)
+    if not upstream and not downstream:
+        echo_info("No lineage recorded in DataHub for this dataset.")
+
+
 __all__ = ["dataset_app"]

--- a/src/seeknal/cli/dataset.py
+++ b/src/seeknal/cli/dataset.py
@@ -1,0 +1,363 @@
+"""Seeknal CLI - Atlas data catalog.
+
+A first-class command group for browsing and querying the Atlas data catalog from
+the engine side. Active only when Atlas is configured (``ATLAS_API_URL`` set); every
+command exits with code 2 and a hint when it is not.
+
+Usage:
+    seeknal dataset list [-q TEXT] [--type T] [--namespace NS]
+    seeknal dataset show <dataset> [--sample]
+    seeknal dataset annotate <dataset> --tag pii --description "..."
+    seeknal dataset request-access <dataset> --reason "need it for X"
+    seeknal dataset query <dataset> [--limit N]
+
+Reads (``list``/``show``/``query``) flow the logged-in user's token to Atlas; the
+access decision and any column masking come from the governance gate, so the CLI
+shows exactly what the user is permitted to see.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import os
+import re
+from typing import Any, List, Optional
+
+import httpx
+import typer
+from tabulate import tabulate
+
+from seeknal.integrations.atlas_catalog import (
+    AtlasCatalogClient,
+    Dataset,
+    create_catalog_client_from_env,
+)
+from seeknal.integrations.atlas_client import AtlasContractError, AtlasPolicyDenied
+from seeknal.integrations.atlas_governance import (
+    AccessDecision,
+    apply_column_masks,
+    create_governance_gate_from_env,
+    user_email_from_credentials,
+    user_token_from_credentials,
+)
+from seeknal.ui.output import echo_error, echo_info, echo_success
+
+dataset_app = typer.Typer(
+    name="dataset",
+    help="Browse and query the Atlas data catalog (requires ATLAS_API_URL).",
+)
+
+#: Seconds to wait for the Atlas governance API before giving up.
+_REQUEST_TIMEOUT_SECONDS = 30.0
+_UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{12}$")
+#: A dotted ``namespace.table`` identifier (a governed Lakekeeper table that may not
+#: be a registered catalog asset). No slashes/spaces — distinguishes it from an
+#: asset's path-style namespace.
+_TABLE_ID_RE = re.compile(r"^[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)+$")
+
+
+def _require_catalog() -> AtlasCatalogClient:
+    """Return a catalog client or exit(2) when Atlas is not configured."""
+
+    client = create_catalog_client_from_env()
+    if client is None:
+        echo_error("Atlas is not configured (set ATLAS_API_URL).")
+        raise typer.Exit(2)
+    return client
+
+
+def _resolve_dataset(client: AtlasCatalogClient, ref: str) -> Dataset:
+    """Resolve a dataset reference (id or name) to a :class:`Dataset`.
+
+    A UUID-looking ``ref`` is fetched directly; otherwise the catalog is searched and
+    the best name/fqn match (else the first hit) is returned. Exits 1 when nothing
+    matches.
+    """
+
+    if _UUID_RE.match(ref):
+        try:
+            return client.get_dataset(ref)
+        except AtlasContractError:
+            pass  # fall through to a name search
+
+    matches = client.list_datasets(query=ref, limit=10)
+    for dataset in matches:
+        if ref in (dataset.name, dataset.fqn, dataset.id):
+            return dataset
+    if matches:
+        return matches[0]
+
+    # Not a registered catalog asset. If it looks like a governed table identifier
+    # (``namespace.table``), treat it as a direct dataset so show/query/access-check
+    # work against governed Lakekeeper tables that aren't in the unified catalog.
+    if _TABLE_ID_RE.match(ref):
+        namespace, _, name = ref.rpartition(".")
+        return Dataset(id=ref, name=name or ref, namespace=namespace, asset_type="table")
+
+    echo_error(f"No dataset found matching '{ref}'.")
+    raise typer.Exit(1)
+
+
+def _dataset_dict(dataset: Dataset) -> dict[str, Any]:
+    return {
+        "id": dataset.id,
+        "name": dataset.name,
+        "namespace": dataset.namespace,
+        "asset_type": dataset.asset_type,
+        "source_system": dataset.source_system,
+        "description": dataset.description,
+        "tags": list(dataset.tags),
+        "fqn": dataset.fqn,
+    }
+
+
+def _extract_sample(data: Any) -> tuple[list[str], list[list[Any]]]:
+    """Normalise a ``/api/sample`` response into ``(columns, rows)``.
+
+    Tolerant of the common shapes: ``{columns, rows}``, ``{schema, data}``, a list of
+    row dicts, or a list of row sequences.
+    """
+
+    if isinstance(data, dict):
+        raw_cols = data.get("columns") or data.get("schema") or []
+        columns = [c.get("name") if isinstance(c, dict) else c for c in raw_cols]
+        raw_rows = data.get("rows") or data.get("data") or []
+        if raw_rows and isinstance(raw_rows[0], dict):
+            if not columns:
+                columns = list(raw_rows[0].keys())
+            rows = [[r.get(c) for c in columns] for r in raw_rows]
+        else:
+            rows = [list(r) for r in raw_rows]
+        return [str(c) for c in columns], rows
+    if isinstance(data, list):
+        if data and isinstance(data[0], dict):
+            columns = list(data[0].keys())
+            return columns, [[r.get(c) for c in columns] for r in data]
+        return [], [list(r) for r in data]
+    return [], []
+
+
+def _print_sample(
+    client: AtlasCatalogClient,
+    dataset: Dataset,
+    limit: int,
+    decision: Optional[AccessDecision],
+) -> None:
+    """Fetch + render a row sample, applying any masking the gate requires."""
+
+    try:
+        data = client.sample(dataset.fqn, limit=limit)
+    except AtlasContractError as exc:
+        echo_error(f"Sample failed: {exc}")
+        return
+    columns, rows = _extract_sample(data)
+    if decision is not None and decision.masked_columns and rows and columns:
+        masked = apply_column_masks(
+            [dict(zip(columns, row)) for row in rows], decision.masked_columns
+        )
+        rows = [[m.get(c) for c in columns] for m in masked]
+    if not rows:
+        echo_info("(no rows)")
+        return
+    typer.echo(tabulate(rows, headers=columns, tablefmt="simple"))
+    echo_info(f"{len(rows)} row(s).")
+
+
+@dataset_app.command("list")
+def list_datasets(
+    query: Optional[str] = typer.Option(None, "-q", "--query", help="Search text."),
+    asset_type: Optional[str] = typer.Option(None, "--type", help="Filter by asset type."),
+    namespace: Optional[str] = typer.Option(None, "--namespace", help="Filter by namespace."),
+    limit: int = typer.Option(50, "--limit", help="Maximum number of datasets."),
+    as_json: bool = typer.Option(False, "--json", help="Output JSON instead of a table."),
+) -> None:
+    """List datasets in the Atlas catalog."""
+
+    client = _require_catalog()
+    try:
+        datasets = client.list_datasets(
+            query=query, asset_type=asset_type, namespace=namespace, limit=limit
+        )
+    except AtlasContractError as exc:
+        echo_error(f"Failed to list datasets: {exc}")
+        raise typer.Exit(1)
+
+    if as_json:
+        typer.echo(_json.dumps([_dataset_dict(d) for d in datasets], indent=2))
+        return
+    if not datasets:
+        echo_info("No datasets found.")
+        return
+    rows = [[d.name, d.namespace, d.asset_type, ", ".join(d.tags)] for d in datasets]
+    typer.echo(tabulate(rows, headers=["Name", "Namespace", "Type", "Tags"], tablefmt="simple"))
+    echo_info(f"{len(datasets)} dataset(s).")
+
+
+@dataset_app.command("show")
+def show_dataset(
+    dataset: str = typer.Argument(..., help="Dataset id or name."),
+    sample: bool = typer.Option(False, "-s", "--sample", help="Include a row sample."),
+    limit: int = typer.Option(20, "--limit", help="Sample row limit."),
+    as_json: bool = typer.Option(False, "--json", help="Output JSON instead of text."),
+) -> None:
+    """Show a dataset's metadata, your live access decision, and (optionally) a sample."""
+
+    client = _require_catalog()
+    resolved = _resolve_dataset(client, dataset)
+
+    gate = create_governance_gate_from_env()
+    decision: Optional[AccessDecision] = None
+    if gate is not None:
+        try:
+            decision = gate.check_access(resource=resolved.fqn, action="read")
+        except AtlasContractError:
+            decision = None
+
+    if as_json:
+        out = _dataset_dict(resolved)
+        if decision is not None:
+            out["access"] = {
+                "allowed": decision.allowed,
+                "masked_columns": list(decision.masked_columns),
+                "reason": decision.reason,
+            }
+        typer.echo(_json.dumps(out, indent=2))
+        return
+
+    echo_success(resolved.name)
+    typer.echo(f"  namespace : {resolved.namespace}")
+    typer.echo(f"  type      : {resolved.asset_type}")
+    typer.echo(f"  source    : {resolved.source_system}")
+    if resolved.description:
+        typer.echo(f"  description: {resolved.description}")
+    if resolved.tags:
+        typer.echo(f"  tags      : {', '.join(resolved.tags)}")
+    typer.echo(f"  id        : {resolved.id}")
+    if decision is not None:
+        mark = "ALLOW" if decision.allowed else "DENY"
+        masked = (
+            f" (masked: {', '.join(decision.masked_columns)})"
+            if decision.masked_columns
+            else ""
+        )
+        typer.echo(f"  access    : {mark}{masked}")
+        if not decision.allowed and decision.reason:
+            typer.echo(f"  reason    : {decision.reason}")
+    if sample:
+        _print_sample(client, resolved, limit, decision)
+
+
+@dataset_app.command("annotate")
+def annotate_dataset(
+    dataset: str = typer.Argument(..., help="Dataset id or name."),
+    tags: Optional[List[str]] = typer.Option(None, "--tag", help="Tag to add (repeatable)."),
+    description: Optional[str] = typer.Option(None, "--description", help="Set the description."),
+    owners: Optional[List[str]] = typer.Option(None, "--owner", help="Owner to add (repeatable)."),
+) -> None:
+    """Annotate a dataset (tags / description / owners) in the Atlas catalog."""
+
+    if not tags and description is None and not owners:
+        echo_error("Provide at least one of --tag, --description, --owner.")
+        raise typer.Exit(1)
+    client = _require_catalog()
+    resolved = _resolve_dataset(client, dataset)
+    try:
+        client.annotate(
+            resolved.id,
+            tags=tags or None,
+            description=description,
+            owners=owners or None,
+        )
+    except AtlasContractError as exc:
+        echo_error(f"Annotation failed: {exc}")
+        raise typer.Exit(1)
+    echo_success(f"Annotated {resolved.name}.")
+
+
+@dataset_app.command("request-access")
+def request_access(
+    dataset: str = typer.Argument(..., help="Dataset id or name."),
+    reason: str = typer.Option(..., "--reason", help="Justification for the request."),
+    access: str = typer.Option("read", "--access", help="Access type (read, write)."),
+    duration: str = typer.Option("90d", "--duration", help="Requested grant duration."),
+    priority: str = typer.Option("medium", "--priority", help="Request priority."),
+) -> None:
+    """Request access to a dataset via the Atlas governance backend."""
+
+    client = _require_catalog()
+    resolved = _resolve_dataset(client, dataset)
+
+    base = (
+        os.getenv("SEEKNAL_API_URL") or os.getenv("ATLAS_API_URL") or "http://localhost:8000"
+    ).rstrip("/")
+    body: dict[str, Any] = {
+        "requester": user_email_from_credentials() or os.getenv("USER", ""),
+        "entityName": resolved.fqn,
+        "entityUrn": "",
+        "requestedAccess": access,
+        "reason": reason,
+        "duration": duration,
+        "priority": priority,
+        "type": "dataset",
+    }
+    headers = {"Content-Type": "application/json"}
+    token = user_token_from_credentials()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    try:
+        response = httpx.post(
+            f"{base}/governance/access-requests",
+            json=body,
+            headers=headers,
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        )
+    except httpx.HTTPError as exc:
+        echo_error(f"Access request failed: {exc}")
+        raise typer.Exit(1)
+    if not (200 <= response.status_code < 300):
+        detail = response.text.strip() or f"HTTP {response.status_code}"
+        echo_error(f"Access request rejected ({response.status_code}): {detail[:200]}")
+        raise typer.Exit(1)
+    try:
+        record = response.json()
+    except ValueError:
+        record = {}
+    echo_success(
+        f"Access request {record.get('id', '(unknown)')} created for {resolved.fqn}"
+    )
+    echo_info(f"Status: {record.get('status', 'pending')} | access: {access} | duration: {duration}")
+
+
+@dataset_app.command("query")
+def query_dataset(
+    dataset: str = typer.Argument(..., help="Dataset id or name."),
+    limit: int = typer.Option(20, "--limit", help="Row limit."),
+) -> None:
+    """Preview a governed dataset (access-checked + masked).
+
+    This is a quick, governed ``SELECT *`` preview. For ad-hoc SQL across Atlas
+    datasets, use the REPL (``seeknal repl``) — when Atlas is connected it lists and
+    queries the governed catalog directly.
+    """
+
+    client = _require_catalog()
+    resolved = _resolve_dataset(client, dataset)
+
+    gate = create_governance_gate_from_env()
+    decision: Optional[AccessDecision] = None
+    if gate is not None:
+        try:
+            decision = gate.enforce_access(resource=resolved.fqn, action="read")
+        except AtlasPolicyDenied as exc:
+            echo_error(str(exc))
+            echo_info(f'Run: seeknal dataset request-access {resolved.name} --reason "<why>"')
+            raise typer.Exit(1)
+        except AtlasContractError as exc:
+            echo_error(f"Access check failed: {exc}")
+            raise typer.Exit(1)
+
+    _print_sample(client, resolved, limit, decision)
+
+
+__all__ = ["dataset_app"]

--- a/src/seeknal/cli/gov.py
+++ b/src/seeknal/cli/gov.py
@@ -1,0 +1,135 @@
+"""
+Seeknal CLI - Atlas data-access governance.
+
+A command group for interacting with the Atlas governance backend from the engine
+side. The first command lets a user request access to a dataset; the request is
+created server-side and returned with an auto-assigned id (e.g. ``AR-12``).
+
+Usage:
+    seeknal gov request-access warehouse.namespace.table --reason "need it for X"
+    seeknal gov request-access prod.gold.customer --reason "..." --access write
+    seeknal gov request-access prod.gold.customer --reason "..." --duration 30d
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+import httpx
+import typer
+
+from seeknal.integrations.atlas_governance import (
+    user_email_from_credentials,
+    user_token_from_credentials,
+)
+from seeknal.ui.output import echo_error, echo_info, echo_success
+
+gov_app = typer.Typer(
+    name="gov",
+    help="Atlas data-access governance (request access, etc.).",
+)
+
+#: Seconds to wait for the Atlas governance API before giving up.
+_REQUEST_TIMEOUT_SECONDS = 30.0
+
+
+def _atlas_base_url() -> str:
+    """Resolve the Atlas API base URL from the environment.
+
+    Honours ``SEEKNAL_API_URL`` first, then ``ATLAS_API_URL``, defaulting to the
+    local dev server. A trailing slash is stripped so paths join cleanly.
+    """
+
+    base = os.getenv("SEEKNAL_API_URL") or os.getenv("ATLAS_API_URL") or "http://localhost:8000"
+    return base.rstrip("/")
+
+
+def _requester_email() -> str:
+    """Best-effort caller identity for the request body.
+
+    Prefers the email/username claim from the logged-in credentials token, falling
+    back to the ``USER`` environment variable, then an empty string.
+    """
+
+    return user_email_from_credentials() or os.getenv("USER", "")
+
+
+@gov_app.command("request-access")
+def request_access(
+    dataset: str = typer.Argument(
+        ...,
+        help="Fully-qualified table, e.g. warehouse.namespace.table.",
+    ),
+    reason: str = typer.Option(
+        ...,
+        "--reason",
+        help="Justification for the access request.",
+    ),
+    access: str = typer.Option(
+        "read",
+        "--access",
+        help="Access type requested (e.g. read, write).",
+    ),
+    duration: str = typer.Option(
+        "90d",
+        "--duration",
+        help="Requested grant duration (e.g. 90d).",
+    ),
+    urn: Optional[str] = typer.Option(
+        None,
+        "--urn",
+        help="Optional entity URN for the dataset.",
+    ),
+    priority: str = typer.Option(
+        "medium",
+        "--priority",
+        help="Request priority (e.g. low, medium, high).",
+    ),
+) -> None:
+    """Request access to a dataset via the Atlas governance backend.
+
+    Builds a governance access-request body and ``POST``s it to
+    ``{API}/governance/access-requests``. When the user has logged in, the stored
+    access token is sent as a bearer credential so the request is attributed to
+    them. On success the created request id and status are printed; a non-2xx
+    response prints an error and exits with code 1.
+    """
+
+    body: dict[str, Any] = {
+        "requester": _requester_email(),
+        "entityName": dataset,
+        "entityUrn": urn or "",
+        "requestedAccess": access,
+        "reason": reason,
+        "duration": duration,
+        "priority": priority,
+        "type": "dataset",
+    }
+
+    headers = {"Content-Type": "application/json"}
+    token = user_token_from_credentials()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    url = f"{_atlas_base_url()}/governance/access-requests"
+    try:
+        response = httpx.post(url, json=body, headers=headers, timeout=_REQUEST_TIMEOUT_SECONDS)
+    except httpx.HTTPError as exc:
+        echo_error(f"Access request failed: {exc}")
+        raise typer.Exit(1)
+
+    if not (200 <= response.status_code < 300):
+        detail = response.text.strip() or f"HTTP {response.status_code}"
+        echo_error(f"Access request rejected ({response.status_code}): {detail}")
+        raise typer.Exit(1)
+
+    try:
+        record = response.json()
+    except ValueError:
+        record = {}
+
+    request_id = record.get("id") or "(unknown)"
+    status = record.get("status") or "pending"
+    echo_success(f"Access request {request_id} created for {dataset}")
+    echo_info(f"Status: {status} | access: {access} | duration: {duration}")

--- a/src/seeknal/cli/heartbeat.py
+++ b/src/seeknal/cli/heartbeat.py
@@ -1,0 +1,224 @@
+"""`seeknal heartbeat` CLI sub-app.
+
+Commands:
+  start  — run the polling daemon (loops until SIGTERM/SIGINT).
+  tick   — run a single tick and exit (for cron/k8s).
+  status — print a tail of recent runs.
+  review — interactive quarantine review (placeholder for Step 14 CLI parity).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from seeknal.heartbeat.config import HeartbeatConfig
+from seeknal.heartbeat.recorder import RunRecorder
+from seeknal.heartbeat.runner import HeartbeatRunner
+
+app = typer.Typer(
+    help=(
+        "Heartbeat polling daemon. Reads HEARTBEAT.md, scans inbox folders, "
+        "ingests new files, runs the DAG + exposures, and records each tick "
+        "to target/heartbeat/runs.jsonl."
+    )
+)
+
+
+def _echo_info(msg: str) -> None:
+    typer.secho(msg, fg=typer.colors.CYAN)
+
+
+def _echo_success(msg: str) -> None:
+    typer.secho(msg, fg=typer.colors.GREEN)
+
+
+def _echo_error(msg: str) -> None:
+    typer.secho(msg, fg=typer.colors.RED, err=True)
+
+
+def _load_profile_loader(profile_path: Optional[Path]):
+    try:
+        from seeknal.workflow.materialization.profile_loader import ProfileLoader
+
+        return ProfileLoader(profile_path=profile_path)
+    except Exception as exc:  # noqa: BLE001
+        _echo_error(f"Failed to load profile loader: {exc}")
+        return None
+
+
+def _resolve_project_root() -> Path:
+    return Path.cwd().resolve()
+
+
+@app.command("start")
+def start_cmd(
+    profile: Optional[Path] = typer.Option(
+        None, "--profile", "-p", help="Path to profiles.yml override."
+    ),
+):
+    """Start the heartbeat daemon (loops until SIGTERM/SIGINT)."""
+    project_root = _resolve_project_root()
+    profile_loader = _load_profile_loader(profile)
+    try:
+        config = HeartbeatConfig.load(project_root, profile_loader=profile_loader)
+    except Exception as exc:  # noqa: BLE001
+        _echo_error(f"Failed to load HEARTBEAT.md: {exc}")
+        raise typer.Exit(2)
+    if profile is not None:
+        config.profile_path = profile
+    if not config.enabled or config.interval_seconds <= 0:
+        _echo_info(
+            f"Heartbeat disabled (enabled={config.enabled}, "
+            f"interval={config.interval_seconds}s). Run `seeknal heartbeat tick` "
+            f"for one-shot ingestion."
+        )
+        raise typer.Exit(0)
+    runner = HeartbeatRunner(config, project_root, profile_loader=profile_loader)
+    _echo_info(
+        f"Starting heartbeat (interval={config.interval_seconds}s, "
+        f"target={config.ingested_target}, project={config.project_name})"
+    )
+    asyncio.run(runner.run_forever())
+
+
+@app.command("tick")
+def tick_cmd(
+    profile: Optional[Path] = typer.Option(
+        None, "--profile", "-p", help="Path to profiles.yml override."
+    ),
+):
+    """Run a single heartbeat tick and exit."""
+    project_root = _resolve_project_root()
+    profile_loader = _load_profile_loader(profile)
+    try:
+        config = HeartbeatConfig.load(project_root, profile_loader=profile_loader)
+    except Exception as exc:  # noqa: BLE001
+        _echo_error(f"Failed to load HEARTBEAT.md: {exc}")
+        raise typer.Exit(2)
+    if profile is not None:
+        config.profile_path = profile
+    runner = HeartbeatRunner(config, project_root, profile_loader=profile_loader)
+    run = asyncio.run(runner.tick_once(reason="manual"))
+    _echo_info(
+        f"Run {run.run_id}: status={run.status} "
+        f"ingested={len(run.ingested)} "
+        f"dag_failed={run.dag.nodes_failed} exposure={len(run.exposure)} "
+        f"duration={run.duration_ms}ms"
+    )
+    if run.errors:
+        for err in run.errors:
+            _echo_error(f"  ! {err}")
+
+
+@app.command("status")
+def status_cmd(
+    limit: int = typer.Option(10, "--limit", "-n", help="Number of recent runs to show."),
+):
+    """Print a tail of recent runs from runs.jsonl."""
+    project_root = _resolve_project_root()
+    recorder = RunRecorder(project_root / "target" / "heartbeat")
+    rows = recorder.tail(limit=limit)
+    if not rows:
+        _echo_info("No heartbeat runs recorded yet.")
+        return
+    for row in rows:
+        run_id = row.get("run_id", "?")
+        status = row.get("status", "?")
+        ingested = len(row.get("ingested", []))
+        dag = row.get("dag", {}) or {}
+        dag_failed = dag.get("nodes_failed", 0)
+        expo_count = len(row.get("exposure", []))
+        duration = row.get("duration_ms", 0)
+        reason = row.get("reason")
+        suffix = f" ({reason})" if reason else ""
+        _echo_info(
+            f"{run_id[:8]}  status={status}{suffix}  ingested={ingested}  "
+            f"dag_failed={dag_failed}  exposure={expo_count}  "
+            f"duration={duration}ms"
+        )
+
+
+@app.command("review")
+def review_cmd(
+    run_id: str = typer.Argument(..., help="Run ID containing quarantined items."),
+    confirm: bool = typer.Option(False, "--confirm", help="Confirm the first pending item."),
+    reject: bool = typer.Option(False, "--reject", help="Reject the first pending item."),
+    edit: Optional[str] = typer.Option(
+        None,
+        "--edit",
+        help="Apply edit-text directives (key=value lines) to the first pending item.",
+    ),
+):
+    """Interactive quarantine review (CLI parity with Telegram flow).
+
+    Flags map to the Telegram inline-keyboard actions. Without flags, the
+    command lists pending items and prints next-step hints.
+    """
+    from seeknal.heartbeat.quarantine.review import (
+        QuarantineSidecar,
+        apply_review_decision,
+        list_pending_reviews,
+    )
+
+    project_root = _resolve_project_root()
+    quarantine_dir = (
+        project_root / "target" / "heartbeat" / "quarantine" / "needs_review" / run_id
+    )
+    if not quarantine_dir.exists():
+        _echo_error(f"No quarantine entries for run {run_id} (dir not found).")
+        raise typer.Exit(1)
+    sidecars = sorted(quarantine_dir.glob("*.review.yml"))
+    if not sidecars:
+        _echo_info(f"No pending review items in {quarantine_dir}.")
+        return
+
+    _echo_info(f"Pending review for run {run_id} ({len(sidecars)} items):")
+    for sidecar in sidecars:
+        try:
+            sc = QuarantineSidecar.load(sidecar)
+            _echo_info(
+                f"  - {sidecar.name}  status={sc.status}  target={sc.target_table or '?'}"
+            )
+        except Exception as exc:  # noqa: BLE001
+            _echo_error(f"  - {sidecar.name}: {exc}")
+
+    if not (confirm or reject or edit):
+        _echo_info(
+            "Use --confirm, --reject, or --edit 'key=value\\n...' to act on the first item."
+        )
+        return
+
+    pending = list_pending_reviews(project_root)
+    target = next((p for p in pending if p.parent == quarantine_dir), None)
+    if target is None:
+        _echo_error("No pending items left for this run_id.")
+        raise typer.Exit(1)
+
+    if confirm:
+        result = apply_review_decision(
+            target, decision="confirm", resolved_by="cli"
+        )
+    elif reject:
+        result = apply_review_decision(
+            target, decision="reject", resolved_by="cli"
+        )
+    else:
+        result = apply_review_decision(
+            target, decision="edit", resolved_by="cli", edit_text=edit
+        )
+
+    if result.get("ok"):
+        _echo_success(f"Decision applied: {result.get('decision')}")
+    else:
+        for err in result.get("errors", []):
+            _echo_error(err)
+        if "error" in result:
+            _echo_error(result["error"])
+        raise typer.Exit(1)
+
+
+__all__ = ["app"]

--- a/src/seeknal/cli/main.py
+++ b/src/seeknal/cli/main.py
@@ -235,6 +235,12 @@ from seeknal.cli.gov import gov_app  # ty: ignore[unresolved-import]
 
 app.add_typer(gov_app, name="gov")
 
+# Keycloak/OIDC authentication (login, status, logout). Stdlib + httpx only, so it
+# is registered unconditionally regardless of whether Atlas governance is configured.
+from seeknal.cli.auth import auth_app  # ty: ignore[unresolved-import]
+
+app.add_typer(auth_app, name="auth")
+
 # Virtual environment management
 env_app = typer.Typer(
     help="Virtual environments for safe pipeline development (plan/apply/promote)"
@@ -634,6 +640,13 @@ from seeknal.ui.output import echo_success as _ui_echo_success
 from seeknal.ui.output import echo_error as _ui_echo_error
 from seeknal.ui.output import echo_warning as _ui_echo_warning
 from seeknal.ui.output import echo_info as _ui_echo_info
+
+# Atlas runtime governance gate factory. Imported at module scope so tests can
+# monkeypatch ``seeknal.cli.main.create_governance_gate_from_env``. Stdlib + httpx
+# only; returns ``None`` (governance inactive) unless ATLAS_API_URL is set.
+from seeknal.integrations.atlas_governance import (  # ty: ignore[unresolved-import]
+    create_governance_gate_from_env,
+)
 
 
 def _echo_success(message: str):
@@ -1577,6 +1590,104 @@ classifier:
         raise typer.Exit(1)
 
 
+def _source_fqtn(node: Any) -> Optional[str]:
+    """Resolve a source node's fully-qualified table id for governance checks.
+
+    Source nodes carry their config in ``node.config`` (an alias for the parsed
+    YAML). The resolution prefers the most-qualified identifier available:
+
+    * If ``config.table`` is already three-part (``warehouse.namespace.table`` /
+      ``catalog.namespace.table``, e.g. the Iceberg ``atlas.qa_iceberg.signal_events``
+      form), it is used verbatim.
+    * Otherwise, if a warehouse/catalog name is resolvable from ``config`` (the
+      ``warehouse`` key, or ``params.warehouse``/``params.catalog``), it is prepended
+      to ``table`` to make the id as qualified as the engine can determine here.
+    * Otherwise the bare ``config.table`` (e.g. ``namespace.table`` or a single name)
+      is returned.
+
+    Warehouse-context assumption: when no warehouse/catalog is resolvable from the
+    node config (common for csv/postgresql sources, whose ``table`` is a path or
+    ``schema.table``), we fall back to the most-qualified string available. Atlas-side
+    normalization is expected to canonicalize the remaining qualifier (project/env
+    defaults) when matching the resource against policy.
+
+    Args:
+        node: A DAG source node exposing ``config`` (parsed YAML) and ``kind``.
+
+    Returns:
+        The resolved table id, or ``None`` when the node carries no table and so
+        identifies no governed resource (such nodes are skipped by the caller).
+    """
+
+    config = getattr(node, "config", None) or {}
+    table = config.get("table")
+    if not isinstance(table, str) or not table.strip():
+        return None
+    table = table.strip()
+
+    # Already fully qualified (warehouse.namespace.table) -> use as-is.
+    if table.count(".") >= 2:
+        return table
+
+    params = config.get("params") or {}
+    warehouse = (
+        config.get("warehouse")
+        or (params.get("warehouse") if isinstance(params, dict) else None)
+        or (params.get("catalog") if isinstance(params, dict) else None)
+    )
+    if isinstance(warehouse, str) and warehouse.strip():
+        return f"{warehouse.strip()}.{table}"
+
+    # No warehouse/catalog context resolvable from node config; emit the most
+    # qualified string we have. Atlas-side normalization covers the remainder.
+    return table
+
+
+def _enforce_pre_run(nodes_to_run: set, dag_builder: Any, gate: Any) -> None:
+    """Enforce Atlas read access for every source node about to run.
+
+    For each node in ``nodes_to_run`` whose type is ``SOURCE``, the fully-qualified
+    table id is resolved via :func:`_source_fqtn` and access-checked against the
+    Atlas gate. A denial aborts the whole run with exit code 1 and a hint pointing
+    the user at ``seeknal gov request-access``.
+
+    Args:
+        nodes_to_run: Set of node ids selected for execution.
+        dag_builder: The built DAG (``dag_builder.nodes`` maps id -> source node).
+        gate: An active governance gate, or ``None`` to skip enforcement entirely
+            (Atlas not configured -> no behavior change).
+
+    Raises:
+        typer.Exit: With code 1 when Atlas denies read access to a source.
+    """
+
+    if gate is None:
+        return
+
+    from seeknal.dag.manifest import NodeType
+    from seeknal.integrations.atlas_client import AtlasPolicyDenied
+    from seeknal.integrations.atlas_governance import user_sub_from_credentials
+
+    actor = user_sub_from_credentials()
+
+    for node_id in nodes_to_run:
+        node = dag_builder.nodes.get(node_id)
+        if node is None:
+            continue
+        node_type = getattr(node, "node_type", None) or getattr(node, "kind", None)
+        if node_type is not NodeType.SOURCE:
+            continue
+        fqtn = _source_fqtn(node)
+        if not fqtn:
+            continue
+        try:
+            gate.enforce_access(resource=fqtn, action="read", actor=actor)
+        except AtlasPolicyDenied as exc:
+            _echo_error(f"Access denied for source '{fqtn}': {exc}")
+            _echo_info(f'Run: seeknal gov request-access {fqtn} --reason "<why>"')
+            raise typer.Exit(1)
+
+
 @app.command()
 def run(
     dry_run: bool = typer.Option(
@@ -2130,6 +2241,13 @@ def _run_yaml_pipeline(
     if not nodes_to_run:
         _echo_success("No changes detected. Nothing to run.")
         return
+
+    # Atlas pre-run access enforcement. When Atlas is configured (ATLAS_API_URL set)
+    # the gate is non-None and every source node about to run is access-checked; a
+    # denial aborts the run. When Atlas is not configured the gate is None and this
+    # is a no-op (full backward compatibility, no behavior change). The factory is
+    # referenced via the module global so tests can monkeypatch it.
+    _enforce_pre_run(nodes_to_run, dag_builder, create_governance_gate_from_env())
 
     _echo_info(f"Nodes to run: {len(nodes_to_run)}")
 

--- a/src/seeknal/cli/main.py
+++ b/src/seeknal/cli/main.py
@@ -241,6 +241,12 @@ from seeknal.cli.auth import auth_app  # ty: ignore[unresolved-import]
 
 app.add_typer(auth_app, name="auth")
 
+# Atlas data catalog (list/show/annotate/request-access/query). Same stdlib + httpx
+# + tabulate footprint as gov/auth, registered unconditionally alongside them.
+from seeknal.cli.dataset import dataset_app  # ty: ignore[unresolved-import]
+
+app.add_typer(dataset_app, name="dataset")
+
 # Virtual environment management
 env_app = typer.Typer(
     help="Virtual environments for safe pipeline development (plan/apply/promote)"

--- a/src/seeknal/cli/main.py
+++ b/src/seeknal/cli/main.py
@@ -300,17 +300,25 @@ app.add_typer(intervals_app, name="intervals")
 # =============================================================================
 # Heartbeat daemon (HEARTBEAT.md polling + smart inbox + DAG/exposure)
 # =============================================================================
-from seeknal.cli.heartbeat import app as heartbeat_app  # noqa: E402
+try:
+    from seeknal.cli.heartbeat import app as heartbeat_app  # noqa: E402
 
-app.add_typer(heartbeat_app, name="heartbeat")
+    app.add_typer(heartbeat_app, name="heartbeat")
+except ImportError:
+    # Optional command group — skip if the module is not present in this build.
+    pass
 
 
 # =============================================================================
 # Admin (Ask access policy + admin approval queue)
 # =============================================================================
-from seeknal.cli.admin import app as admin_app  # noqa: E402
+try:
+    from seeknal.cli.admin import app as admin_app  # noqa: E402
 
-app.add_typer(admin_app, name="admin")
+    app.add_typer(admin_app, name="admin")
+except ImportError:
+    # Optional command group — skip if the module is not present in this build.
+    pass
 
 
 # =============================================================================

--- a/src/seeknal/cli/main.py
+++ b/src/seeknal/cli/main.py
@@ -110,20 +110,19 @@ class SuggestGroup(_typer_core.TyperGroup):
                 raise
             cmd_name = args[0] if args else None
             if cmd_name is not None:
-                matches = get_close_matches(
-                    cmd_name, self.list_commands(ctx), n=3, cutoff=0.4
-                )
+                matches = get_close_matches(cmd_name, self.list_commands(ctx), n=3, cutoff=0.4)
                 if matches:
                     suggestion = ", ".join(f"'{m}'" for m in matches)
                     msg = f"No such command '{cmd_name}'.\n\nDid you mean: {suggestion}?"
                     raise type(e)(msg) from e
             raise
 
+
 # Load .env file if present (for local development)
 # This makes environment variables available for all CLI commands
 try:
     from dotenv import load_dotenv  # ty: ignore[unresolved-import]
-    
+
     # Try to find .env in current directory or up to 3 parent directories
     cwd = Path.cwd()
     for path in [cwd] + list(cwd.parents)[:3]:
@@ -155,7 +154,9 @@ def main_callback(
         is_eager=True,
     ),
     no_animation: bool = typer.Option(False, "--no-animation", help="Disable all animations"),
-    theme: str = typer.Option("", "--theme", help="UI theme: dark, light, dark-ansi, light-ansi, auto"),
+    theme: str = typer.Option(
+        "", "--theme", help="UI theme: dark, light, dark-ansi, light-ansi, auto"
+    ),
 ):
     """Seeknal — All-in-one platform for data and AI/ML engineering."""
     if no_animation:
@@ -228,8 +229,16 @@ from seeknal.cli.docs import docs_app  # ty: ignore[unresolved-import]
 
 app.add_typer(docs_app, name="docs")
 
+# Atlas data-access governance (request-access, etc.). Uses only stdlib + httpx,
+# so it is registered unconditionally (not behind the atlas-optional guard).
+from seeknal.cli.gov import gov_app  # ty: ignore[unresolved-import]
+
+app.add_typer(gov_app, name="gov")
+
 # Virtual environment management
-env_app = typer.Typer(help="Virtual environments for safe pipeline development (plan/apply/promote)")
+env_app = typer.Typer(
+    help="Virtual environments for safe pipeline development (plan/apply/promote)"
+)
 app.add_typer(env_app, name="env")
 
 # Entity consolidation management
@@ -277,7 +286,7 @@ Examples:
   seeknal intervals pending feature_group.user_features --start 2024-01-01
   seeknal intervals restatement-add feature_group.user_features --start 2024-01-01 --end 2024-01-31
   seeknal intervals backfill feature_group.user_features --start 2024-01-01 --end 2024-01-31
-"""
+""",
 )
 app.add_typer(intervals_app, name="intervals")
 
@@ -304,10 +313,12 @@ app.add_typer(admin_app, name="admin")
 # The Atlas command group is loaded dynamically if atlas-data-platform is installed.
 # This allows Seeknal to work standalone while providing Atlas features when available.
 
+
 def _register_atlas_commands():
     """Register Atlas commands if atlas-data-platform is available."""
     try:
         from seeknal.cli.atlas import atlas_app
+
         app.add_typer(atlas_app, name="atlas")
     except ImportError:
         # Atlas not installed, add a placeholder command
@@ -336,19 +347,27 @@ _register_atlas_commands()
 # =============================================================================
 # The Ask command group is loaded dynamically so broken/minimal environments get a useful error.
 
+
 def _register_ask_commands():
     """Register Ask commands if pydantic-deep dependencies are available."""
     try:
         from seeknal.cli.ask import ask_app
+
         app.add_typer(ask_app, name="ask")
     except ImportError:
+
         @app.command("ask", hidden=True)
         def ask_not_installed():
             """AI-powered data analysis (not installed).
 
             Install with: pip install --upgrade seeknal
             """
-            typer.echo(typer.style("✗ Seeknal Ask dependencies are missing from this environment.", fg=typer.colors.RED))
+            typer.echo(
+                typer.style(
+                    "✗ Seeknal Ask dependencies are missing from this environment.",
+                    fg=typer.colors.RED,
+                )
+            )
             typer.echo("")
             typer.echo("Install with:")
             typer.echo(typer.style("  pip install --upgrade seeknal", fg=typer.colors.CYAN))
@@ -373,9 +392,7 @@ prefect_app = typer.Typer(
 
 @prefect_app.command("serve")
 def prefect_serve(
-    project_path: Path = typer.Option(
-        ".", "--project-path", "-p", help="Path to seeknal project"
-    ),
+    project_path: Path = typer.Option(".", "--project-path", "-p", help="Path to seeknal project"),
     name: Optional[str] = typer.Option(
         None, "--name", "-n", help="Deployment name (default: project directory name)"
     ),
@@ -385,34 +402,26 @@ def prefect_serve(
     interval: Optional[int] = typer.Option(
         None, "--interval", "-i", help="Interval in seconds between runs"
     ),
-    full: bool = typer.Option(
-        False, "--full/--no-full", help="Force full refresh (ignore cache)"
-    ),
+    full: bool = typer.Option(False, "--full/--no-full", help="Force full refresh (ignore cache)"),
     continue_on_error: bool = typer.Option(
-        False, "--continue-on-error/--no-continue-on-error",
-        help="Continue after node failures"
+        False, "--continue-on-error/--no-continue-on-error", help="Continue after node failures"
     ),
     max_workers: int = typer.Option(
-        0, "--max-workers", "-w",
-        help="Max parallel tasks per layer (0=auto)"
+        0, "--max-workers", "-w", help="Max parallel tasks per layer (0=auto)"
     ),
-    env: Optional[str] = typer.Option(
-        None, "--env", "-e", help="Environment name"
-    ),
-    profile: Optional[str] = typer.Option(
-        None, "--profile", help="Profile path"
-    ),
+    env: Optional[str] = typer.Option(None, "--env", "-e", help="Environment name"),
+    profile: Optional[str] = typer.Option(None, "--profile", help="Profile path"),
     start_date: Optional[str] = typer.Option(
-        None, "--start-date",
-        help="Start date for filtering (YYYY-MM-DD). Available as {{ start_date }} in transform SQL"
+        None,
+        "--start-date",
+        help="Start date for filtering (YYYY-MM-DD). Available as {{ start_date }} in transform SQL",
     ),
     end_date: Optional[str] = typer.Option(
-        None, "--end-date",
-        help="End date for filtering (YYYY-MM-DD). Available as {{ end_date }} in transform SQL"
+        None,
+        "--end-date",
+        help="End date for filtering (YYYY-MM-DD). Available as {{ end_date }} in transform SQL",
     ),
-    params: Optional[str] = typer.Option(
-        None, "--params", help="JSON string of parameters"
-    ),
+    params: Optional[str] = typer.Option(None, "--params", help="JSON string of parameters"),
 ):
     """Start a long-running process serving the pipeline as a Prefect flow."""
     import json as _json
@@ -440,51 +449,34 @@ def prefect_serve(
 
 @prefect_app.command("deploy")
 def prefect_deploy(
-    project_path: Path = typer.Option(
-        ".", "--project-path", "-p", help="Path to seeknal project"
-    ),
-    work_pool: str = typer.Option(
-        ..., "--work-pool", help="Prefect work pool name (required)"
-    ),
-    name: Optional[str] = typer.Option(
-        None, "--name", "-n", help="Deployment name"
-    ),
+    project_path: Path = typer.Option(".", "--project-path", "-p", help="Path to seeknal project"),
+    work_pool: str = typer.Option(..., "--work-pool", help="Prefect work pool name (required)"),
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Deployment name"),
     cron: Optional[str] = typer.Option(
         None, "--cron", "-c", help='Cron schedule (e.g., "0 2 * * *")'
     ),
-    interval: Optional[int] = typer.Option(
-        None, "--interval", "-i", help="Interval in seconds"
-    ),
+    interval: Optional[int] = typer.Option(None, "--interval", "-i", help="Interval in seconds"),
     exposure: Optional[str] = typer.Option(
         None, "--exposure", help="Deploy a report exposure by name"
     ),
-    full: bool = typer.Option(
-        False, "--full/--no-full", help="Force full refresh"
-    ),
+    full: bool = typer.Option(False, "--full/--no-full", help="Force full refresh"),
     continue_on_error: bool = typer.Option(
-        False, "--continue-on-error/--no-continue-on-error",
-        help="Continue after node failures"
+        False, "--continue-on-error/--no-continue-on-error", help="Continue after node failures"
     ),
-    max_workers: int = typer.Option(
-        0, "--max-workers", "-w", help="Max parallel tasks (0=auto)"
-    ),
-    env: Optional[str] = typer.Option(
-        None, "--env", "-e", help="Environment name"
-    ),
-    profile: Optional[str] = typer.Option(
-        None, "--profile", help="Profile path"
-    ),
+    max_workers: int = typer.Option(0, "--max-workers", "-w", help="Max parallel tasks (0=auto)"),
+    env: Optional[str] = typer.Option(None, "--env", "-e", help="Environment name"),
+    profile: Optional[str] = typer.Option(None, "--profile", help="Profile path"),
     start_date: Optional[str] = typer.Option(
-        None, "--start-date",
-        help="Start date for filtering (YYYY-MM-DD). Available as {{ start_date }} in transform SQL"
+        None,
+        "--start-date",
+        help="Start date for filtering (YYYY-MM-DD). Available as {{ start_date }} in transform SQL",
     ),
     end_date: Optional[str] = typer.Option(
-        None, "--end-date",
-        help="End date for filtering (YYYY-MM-DD). Available as {{ end_date }} in transform SQL"
+        None,
+        "--end-date",
+        help="End date for filtering (YYYY-MM-DD). Available as {{ end_date }} in transform SQL",
     ),
-    params: Optional[str] = typer.Option(
-        None, "--params", help="JSON string of parameters"
-    ),
+    params: Optional[str] = typer.Option(None, "--params", help="JSON string of parameters"),
 ):
     """Deploy the pipeline (or a report exposure) to Prefect Server/Cloud."""
     import json as _json
@@ -518,12 +510,8 @@ def prefect_deploy(
 
 @prefect_app.command("generate")
 def prefect_generate(
-    project_path: Path = typer.Option(
-        ".", "--project-path", "-p", help="Path to seeknal project"
-    ),
-    max_workers: int = typer.Option(
-        8, "--max-workers", "-w", help="Max parallel tasks"
-    ),
+    project_path: Path = typer.Option(".", "--project-path", "-p", help="Path to seeknal project"),
+    max_workers: int = typer.Option(8, "--max-workers", "-w", help="Max parallel tasks"),
     output: Path = typer.Option(
         None, "--output", "-o", help="Output path (default: prefect.yaml in project root)"
     ),
@@ -563,18 +551,20 @@ def _register_prefect_commands():
     """Register Prefect commands with optional dependency guard."""
     try:
         from seeknal.workflow.prefect_integration import PREFECT_AVAILABLE
+
         # Always register the commands — they handle the ImportError themselves
         app.add_typer(prefect_app, name="prefect")
     except Exception:
+
         @app.command("prefect", hidden=True)
         def prefect_not_installed():
             """Prefect orchestration (not installed).
 
             Install with: pip install seeknal[prefect]
             """
-            typer.echo(typer.style(
-                "✗ Prefect orchestration is not available.", fg=typer.colors.RED
-            ))
+            typer.echo(
+                typer.style("✗ Prefect orchestration is not available.", fg=typer.colors.RED)
+            )
             typer.echo("")
             typer.echo("Install with:")
             typer.echo(typer.style("  pip install seeknal[prefect]", fg=typer.colors.CYAN))
@@ -587,6 +577,7 @@ _register_prefect_commands()
 
 class OutputFormat(str, Enum):
     """Output format options."""
+
     TABLE = "table"
     JSON = "json"
     YAML = "yaml"
@@ -594,6 +585,7 @@ class OutputFormat(str, Enum):
 
 class ResourceType(str, Enum):
     """Resource types for listing."""
+
     PROJECTS = "projects"
     WORKSPACES = "workspaces"
     ENTITIES = "entities"
@@ -603,11 +595,13 @@ class ResourceType(str, Enum):
 
 class DeleteResourceType(str, Enum):
     """Resource types for deletion."""
+
     FEATURE_GROUP = "feature-group"
 
 
 class ValidationModeChoice(str, Enum):
     """Validation mode options for validate-features command."""
+
     WARN = "warn"
     FAIL = "fail"
 
@@ -621,6 +615,7 @@ def _get_version() -> str:
 
     try:
         from seeknal import __version__
+
         return __version__
     except ImportError:
         return "1.0.0"
@@ -696,7 +691,9 @@ def parse_date_safely(date_str: str, param_name: str = "date") -> datetime:
         # Validate future dates (max 1 year ahead from today)
         max_future_date = datetime.now() + timedelta(days=365)
         if dt > max_future_date:
-            _echo_error(f"Invalid {param_name}: Date {dt.strftime('%Y-%m-%d')} is more than 1 year in the future")
+            _echo_error(
+                f"Invalid {param_name}: Date {dt.strftime('%Y-%m-%d')} is more than 1 year in the future"
+            )
             raise typer.Exit(1)
 
         return dt
@@ -704,7 +701,9 @@ def parse_date_safely(date_str: str, param_name: str = "date") -> datetime:
     except ValueError as e:
         # Catch parsing errors from fromisoformat
         if "invalid" in str(e).lower() or "out of range" in str(e).lower():
-            _echo_error(f"Invalid {param_name}: {date_str}. Use YYYY-MM-DD or ISO timestamp (YYYY-MM-DDTHH:MM:SS)")
+            _echo_error(
+                f"Invalid {param_name}: {date_str}. Use YYYY-MM-DD or ISO timestamp (YYYY-MM-DDTHH:MM:SS)"
+            )
         else:
             _echo_error(f"Invalid {param_name}: {e}")
         raise typer.Exit(1)
@@ -734,6 +733,7 @@ def handle_cli_error(error_message: str = "Operation failed"):
         def init(name: str):
             # Command logic here
     """
+
     def decorator(func: Callable) -> Callable:
         @wraps(func)
         def wrapper(*args, **kwargs):
@@ -744,7 +744,9 @@ def handle_cli_error(error_message: str = "Operation failed"):
             except Exception as e:
                 _echo_error(f"{error_message}: {e}")
                 raise typer.Exit(1)
+
         return wrapper
+
     return decorator
 
 
@@ -780,23 +782,27 @@ def _build_manifest_from_dag(dag_builder, project_name: str):
 
     manifest = Manifest(project=project_name)
     for node_id, node in dag_builder.nodes.items():
-        kind_str = node.kind.value if hasattr(node.kind, 'value') else str(node.kind)
+        kind_str = node.kind.value if hasattr(node.kind, "value") else str(node.kind)
         manifest_node_type = node_type_map.get(kind_str, ManifestNodeType.SOURCE)
         # Extract columns dict from YAML data
         raw_columns = {}
-        if hasattr(node, 'yaml_data'):
+        if hasattr(node, "yaml_data"):
             raw_columns = node.yaml_data.get("columns", {}) or {}
 
-        manifest.add_node(Node(
-            id=node_id,
-            name=node.name,
-            node_type=manifest_node_type,
-            description=node.yaml_data.get("description") if hasattr(node, 'yaml_data') else None,
-            tags=list(node.tags) if hasattr(node, 'tags') and node.tags else [],
-            columns=raw_columns,
-            config=node.yaml_data if hasattr(node, 'yaml_data') else {},
-            file_path=node.file_path if hasattr(node, 'file_path') else None,
-        ))
+        manifest.add_node(
+            Node(
+                id=node_id,
+                name=node.name,
+                node_type=manifest_node_type,
+                description=node.yaml_data.get("description")
+                if hasattr(node, "yaml_data")
+                else None,
+                tags=list(node.tags) if hasattr(node, "tags") and node.tags else [],
+                columns=raw_columns,
+                config=node.yaml_data if hasattr(node, "yaml_data") else {},
+                file_path=node.file_path if hasattr(node, "file_path") else None,
+            )
+        )
 
     for node_id in dag_builder.nodes:
         for downstream_id in dag_builder.get_downstream(node_id):
@@ -814,6 +820,7 @@ def info():
     typer.echo(f"Python version: {sys.version.split()[0]}")
     try:
         import pyspark
+
         pyspark_version = pyspark.__version__
     except ImportError:
         pyspark_version = "not installed (optional; install seeknal[spark])"
@@ -830,9 +837,7 @@ def _scaffold_ask_skills(project_path: Path) -> None:
     bundled ``SKILL.md`` into ``<project>/seeknal/skills/`` so users
     can edit/extend them per-project without touching the package.
     """
-    builtin_root = (
-        Path(__file__).resolve().parent.parent / "ask" / "builtin_skills"
-    )
+    builtin_root = Path(__file__).resolve().parent.parent / "ask" / "builtin_skills"
     if not builtin_root.is_dir():
         return  # No built-ins shipped (unexpected, but don't fail init)
 
@@ -1337,20 +1342,12 @@ rather than inventing one-off checks.
 @app.command()
 def init(
     name: str = typer.Option(
-        None, "--name", "-n",
-        help="Project name (defaults to current directory name)"
+        None, "--name", "-n", help="Project name (defaults to current directory name)"
     ),
-    description: str = typer.Option(
-        "", "--description", "-d",
-        help="Project description"
-    ),
-    path: Path = typer.Option(
-        Path("."), "--path", "-p",
-        help="Project path"
-    ),
+    description: str = typer.Option("", "--description", "-d", help="Project description"),
+    path: Path = typer.Option(Path("."), "--path", "-p", help="Project path"),
     force: bool = typer.Option(
-        False, "--force", "-f",
-        help="Overwrite existing project configuration"
+        False, "--force", "-f", help="Overwrite existing project configuration"
     ),
 ):
     """Initialize a new Seeknal project with dbt-style structure.
@@ -1544,6 +1541,7 @@ classifier:
 
         # Also create the legacy Project for database compatibility
         from seeknal.project import Project
+
         if description and isinstance(description, str):
             project = Project(name=name, description=description)
         else:
@@ -1582,102 +1580,93 @@ classifier:
 @app.command()
 def run(
     dry_run: bool = typer.Option(
-        False, "--dry-run",
-        help="Show what would be executed without running"
+        False, "--dry-run", help="Show what would be executed without running"
     ),
     # YAML pipeline execution flags
     full: bool = typer.Option(
-        False, "--full", "-f",
-        help="Run all nodes regardless of state (ignore incremental run cache)"
+        False,
+        "--full",
+        "-f",
+        help="Run all nodes regardless of state (ignore incremental run cache)",
     ),
     nodes: Optional[List[str]] = typer.Option(
-        None, "--nodes", "-n",
-        help="Run specific nodes only (e.g., --nodes transform.clean_data)"
+        None, "--nodes", "-n", help="Run specific nodes only (e.g., --nodes transform.clean_data)"
     ),
     types: Optional[List[str]] = typer.Option(
-        None, "--types", "-t",
-        help="Filter by node types (e.g., --types transform,feature_group)"
+        None, "--types", "-t", help="Filter by node types (e.g., --types transform,feature_group)"
     ),
     tags: Optional[List[str]] = typer.Option(
-        None, "--tags",
-        help="Run only nodes with these tags (plus upstream deps). OR logic."
+        None, "--tags", help="Run only nodes with these tags (plus upstream deps). OR logic."
     ),
     exclude_tags: Optional[List[str]] = typer.Option(
-        None, "--exclude-tags",
-        help="Skip nodes with these tags"
+        None, "--exclude-tags", help="Skip nodes with these tags"
     ),
     continue_on_error: bool = typer.Option(
-        False, "--continue-on-error",
-        help="Continue execution after failures"
+        False, "--continue-on-error", help="Continue execution after failures"
     ),
-    retry: int = typer.Option(
-        0, "--retry", "-r",
-        help="Number of retries for failed nodes"
-    ),
+    retry: int = typer.Option(0, "--retry", "-r", help="Number of retries for failed nodes"),
     show_plan: bool = typer.Option(
-        False, "--show-plan", "-p",
-        help="Show execution plan without running"
+        False, "--show-plan", "-p", help="Show execution plan without running"
     ),
     # Parallel execution flags
     parallel: bool = typer.Option(
-        False, "--parallel",
-        help="Execute independent nodes in parallel (layer-based concurrency)"
+        False, "--parallel", help="Execute independent nodes in parallel (layer-based concurrency)"
     ),
     max_workers: int = typer.Option(
-        4, "--max-workers",
-        help="Maximum parallel workers (default: 4, max recommended: CPU count)"
+        4, "--max-workers", help="Maximum parallel workers (default: 4, max recommended: CPU count)"
     ),
     # Materialization flags
     materialize: Optional[bool] = typer.Option(
-        None, "--materialize/--no-materialize",
-        help="Enable/disable Iceberg materialization (overrides node config)"
+        None,
+        "--materialize/--no-materialize",
+        help="Enable/disable Iceberg materialization (overrides node config)",
     ),
     # Environment flag
     env: Optional[str] = typer.Option(
-        None, "--env",
-        help="Run in isolated virtual environment (requires a plan: seeknal env plan <name>)"
+        None,
+        "--env",
+        help="Run in isolated virtual environment (requires a plan: seeknal env plan <name>)",
     ),
     # Parameterization flags
     param_date: Optional[str] = typer.Option(
-        None, "--date",
-        help="Override date parameter (YYYY-MM-DD format)"
+        None, "--date", help="Override date parameter (YYYY-MM-DD format)"
     ),
     param_run_id: Optional[str] = typer.Option(
-        None, "--run-id",
-        help="Custom run ID for parameterization"
+        None, "--run-id", help="Custom run ID for parameterization"
     ),
     # Interval tracking flags
     start: Optional[str] = typer.Option(
-        None, "--start",
-        help="Start timestamp for interval execution (ISO format or YYYY-MM-DD)"
+        None, "--start", help="Start timestamp for interval execution (ISO format or YYYY-MM-DD)"
     ),
     end: Optional[str] = typer.Option(
-        None, "--end",
-        help="End timestamp for interval execution (ISO format or YYYY-MM-DD)"
+        None, "--end", help="End timestamp for interval execution (ISO format or YYYY-MM-DD)"
     ),
     backfill: bool = typer.Option(
-        False, "--backfill",
-        help="Execute backfill for all missing intervals in the date range"
+        False, "--backfill", help="Execute backfill for all missing intervals in the date range"
     ),
     restate: bool = typer.Option(
-        False, "--restate",
-        help="Process restatement intervals marked for reprocessing"
+        False, "--restate", help="Process restatement intervals marked for reprocessing"
     ),
     start_date: Optional[str] = typer.Option(
-        None, "--start-date",
-        help="Start date for filtering (YYYY-MM-DD). Available as {{ start_date }} in transform SQL"
+        None,
+        "--start-date",
+        help="Start date for filtering (YYYY-MM-DD). Available as {{ start_date }} in transform SQL",
     ),
     end_date: Optional[str] = typer.Option(
-        None, "--end-date",
-        help="End date for filtering (YYYY-MM-DD). Available as {{ end_date }} in transform SQL"
+        None,
+        "--end-date",
+        help="End date for filtering (YYYY-MM-DD). Available as {{ end_date }} in transform SQL",
     ),
     profile: Optional[str] = typer.Option(
-        None, "--profile",
-        help="Path to profiles.yml for source_defaults and connections (default: ~/.seeknal/profiles.yml)"
+        None,
+        "--profile",
+        help="Path to profiles.yml for source_defaults and connections (default: ~/.seeknal/profiles.yml)",
     ),
     verbose: bool = typer.Option(
-        False, "--verbose", "-v",
-        help="Show full tracebacks and subprocess output inline on failure; write detailed log file for all nodes"
+        False,
+        "--verbose",
+        "-v",
+        help="Show full tracebacks and subprocess output inline on failure; write detailed log file for all nodes",
     ),
 ):
     """Execute YAML/Python pipeline.
@@ -1756,6 +1745,7 @@ def run(
     # Environment mode: delegate to shared helper
     if env is not None:
         from pathlib import Path
+
         project_path = Path.cwd().resolve()
         _run_in_environment(
             env_name=env,
@@ -1849,9 +1839,13 @@ def _run_yaml_pipeline(
     from pathlib import Path
     from seeknal.workflow.dag import DAGBuilder, CycleDetectedError, MissingDependencyError
     from seeknal.workflow.state import (
-        RunState, load_state, save_state,
-        calculate_node_hash, get_nodes_to_run,
-        update_node_state, NodeStatus,
+        RunState,
+        load_state,
+        save_state,
+        calculate_node_hash,
+        get_nodes_to_run,
+        update_node_state,
+        NodeStatus,
         include_upstream_sources,
     )
     from seeknal.workflow.executors import get_executor, ExecutionContext
@@ -1959,6 +1953,7 @@ def _run_yaml_pipeline(
 
             try:
                 from seeknal.workflow.iceberg_metadata import get_current_snapshot_id
+
                 current_snap, _ = get_current_snapshot_id(
                     table_ref=table_ref,
                     params=yaml_data.get("params", {}),
@@ -1994,7 +1989,8 @@ def _run_yaml_pipeline(
         # Union: tag-matched nodes (+ upstream) AND explicitly named nodes (+ downstream)
         tag_set = set(tags)
         tag_matched = {
-            node_id for node_id in dag_builder.nodes
+            node_id
+            for node_id in dag_builder.nodes
             if any(t in tag_set for t in dag_builder.nodes[node_id].tags)
         }
         if not tag_matched:
@@ -2016,7 +2012,8 @@ def _run_yaml_pipeline(
         # Run only tag-matched nodes + their upstream dependencies
         tag_set = set(tags)
         tag_matched = {
-            node_id for node_id in dag_builder.nodes
+            node_id
+            for node_id in dag_builder.nodes
             if any(t in tag_set for t in dag_builder.nodes[node_id].tags)
         }
         if not tag_matched:
@@ -2043,8 +2040,7 @@ def _run_yaml_pipeline(
         # Filter by type
         type_set = set(types)
         nodes_to_run = {
-            node_id for node_id in nodes_to_run
-            if dag_builder.nodes[node_id].kind.value in type_set
+            node_id for node_id in nodes_to_run if dag_builder.nodes[node_id].kind.value in type_set
         }
 
     # Apply type filter on top of tags (narrowing)
@@ -2053,11 +2049,13 @@ def _run_yaml_pipeline(
         # Only narrow the tag-matched nodes, keep upstream deps regardless of type
         tag_set = set(tags)
         tag_matched = {
-            node_id for node_id in dag_builder.nodes
+            node_id
+            for node_id in dag_builder.nodes
             if any(t in tag_set for t in dag_builder.nodes[node_id].tags)
         }
         nodes_to_run = {
-            node_id for node_id in nodes_to_run
+            node_id
+            for node_id in nodes_to_run
             if node_id not in tag_matched or dag_builder.nodes[node_id].kind.value in type_set
         }
 
@@ -2068,7 +2066,8 @@ def _run_yaml_pipeline(
         if tags:
             tag_set_for_warn = set(tags)
             tag_matched_for_warn = {
-                node_id for node_id in dag_builder.nodes
+                node_id
+                for node_id in dag_builder.nodes
                 if any(t in tag_set_for_warn for t in dag_builder.nodes[node_id].tags)
             }
             for node_id in list(nodes_to_run):
@@ -2082,7 +2081,8 @@ def _run_yaml_pipeline(
                             )
                             break
         nodes_to_run = {
-            node_id for node_id in nodes_to_run
+            node_id
+            for node_id in nodes_to_run
             if not any(tag in exclude_set for tag in dag_builder.nodes[node_id].tags)
         }
 
@@ -2149,9 +2149,7 @@ def _run_yaml_pipeline(
             layers[layer].append(node_id)
 
         if layers:
-            widest_layer_num, widest_layer_nodes = max(
-                layers.items(), key=lambda x: len(x[1])
-            )
+            widest_layer_num, widest_layer_nodes = max(layers.items(), key=lambda x: len(x[1]))
             if len(widest_layer_nodes) > 3:
                 _echo_info(
                     f"Tip: This pipeline has {len(widest_layer_nodes)} independent nodes "
@@ -2167,14 +2165,16 @@ def _run_yaml_pipeline(
         # Build a Manifest from dag_builder for the DAGRunner
         _manifest = _Manifest(project=project_path.name)
         for node_id, node in dag_builder.nodes.items():
-            _manifest.add_node(_Node(
-                id=node_id,
-                name=node.name,
-                node_type=_NodeType(node.kind.value),
-                tags=list(node.tags) if node.tags else [],
-                config=node.yaml_data,
-                file_path=node.file_path,
-            ))
+            _manifest.add_node(
+                _Node(
+                    id=node_id,
+                    name=node.name,
+                    node_type=_NodeType(node.kind.value),
+                    tags=list(node.tags) if node.tags else [],
+                    config=node.yaml_data,
+                    file_path=node.file_path,
+                )
+            )
         for node_id in dag_builder.nodes:
             for downstream_id in dag_builder.get_downstream(node_id):
                 _manifest.add_edge(node_id, downstream_id)
@@ -2197,9 +2197,10 @@ def _run_yaml_pipeline(
 
         # Write run log for parallel execution
         from seeknal.workflow.run_logger import RunLogger as _RunLogger
+
         _run_logger = _RunLogger(
             target_path=target_path,
-            run_id=_runner.run_state.run_id if hasattr(_runner, 'run_state') else "",
+            run_id=_runner.run_state.run_id if hasattr(_runner, "run_state") else "",
             project_name=project_path.name,
             verbose=verbose,
             flags=["--parallel", "--verbose"] if verbose else ["--parallel"],
@@ -2236,6 +2237,7 @@ def _run_yaml_pipeline(
 
     # Step 5: Execute nodes in topological order
     import time
+
     start_time = time.time()
 
     # Initialize run state
@@ -2245,6 +2247,7 @@ def _run_yaml_pipeline(
 
     # Initialize run logger
     from seeknal.workflow.run_logger import RunLogger
+
     run_flags = []
     if verbose:
         run_flags.append("--verbose")
@@ -2283,13 +2286,17 @@ def _run_yaml_pipeline(
         # Check if we should run this node
         if node_id not in nodes_to_run:
             if node_id in run_state.nodes and run_state.nodes[node_id].is_success():
-                typer.echo(f"{idx}/{len(execution_order)}: {node.name} [{typer.style('CACHED', fg=typer.colors.BLUE)}]")
+                typer.echo(
+                    f"{idx}/{len(execution_order)}: {node.name} [{typer.style('CACHED', fg=typer.colors.BLUE)}]"
+                )
                 cached += 1
                 run_logger.log_node(node_id, "CACHED")
             continue
 
         # Execute the node
-        typer.echo(f"{idx}/{len(execution_order)}: {node.name} [{typer.style('RUNNING', fg=typer.colors.YELLOW)}]")
+        typer.echo(
+            f"{idx}/{len(execution_order)}: {node.name} [{typer.style('RUNNING', fg=typer.colors.YELLOW)}]"
+        )
 
         if dry_run:
             # Dry run - just show what would happen
@@ -2303,11 +2310,7 @@ def _run_yaml_pipeline(
 
         # Inject Iceberg watermark for incremental reads
         # Skip watermark on --full refresh so executor does a full scan
-        if (
-            node.kind.value == "source"
-            and node.yaml_data.get("source") == "iceberg"
-            and not full
-        ):
+        if node.kind.value == "source" and node.yaml_data.get("source") == "iceberg" and not full:
             # Check current run_state first, then fall back to old_state
             stored = run_state.nodes.get(node_id)
             if not stored and old_state:
@@ -2366,7 +2369,8 @@ def _run_yaml_pipeline(
 
                 successful += 1
                 run_logger.log_node(
-                    node_id, "SUCCESS",
+                    node_id,
+                    "SUCCESS",
                     duration_seconds=duration,
                     row_count=result.row_count,
                 )
@@ -2391,7 +2395,8 @@ def _run_yaml_pipeline(
                 )
                 failed += 1
                 run_logger.log_node(
-                    node_id, "FAILED",
+                    node_id,
+                    "FAILED",
                     duration_seconds=duration,
                     error_message=result.error_message,
                     output_log=result.output_log,
@@ -2411,7 +2416,8 @@ def _run_yaml_pipeline(
                     total_attempts = retry + 1  # initial + retries
                     # Log the initial failure as attempt 1
                     run_logger.log_node(
-                        node_id, "FAILED",
+                        node_id,
+                        "FAILED",
                         duration_seconds=duration,
                         error_message=result.error_message,
                         output_log=result.output_log,
@@ -2442,7 +2448,8 @@ def _run_yaml_pipeline(
                                 failed -= 1
                                 successful += 1
                                 run_logger.log_node(
-                                    node_id, "SUCCESS",
+                                    node_id,
+                                    "SUCCESS",
                                     duration_seconds=duration,
                                     row_count=result.row_count,
                                     attempt=attempt + 1,
@@ -2451,7 +2458,8 @@ def _run_yaml_pipeline(
                                 break
                             else:
                                 run_logger.log_node(
-                                    node_id, "FAILED",
+                                    node_id,
+                                    "FAILED",
                                     duration_seconds=time.time() - node_start,
                                     error_message=result.error_message,
                                     output_log=result.output_log,
@@ -2461,7 +2469,8 @@ def _run_yaml_pipeline(
                         except Exception as e:
                             typer.echo(f"  Retry {attempt} failed: {e}")
                             run_logger.log_node(
-                                node_id, "FAILED",
+                                node_id,
+                                "FAILED",
                                 duration_seconds=time.time() - node_start,
                                 error_message=str(e),
                                 attempt=attempt + 1,
@@ -2482,7 +2491,8 @@ def _run_yaml_pipeline(
             )
             failed += 1
             run_logger.log_node(
-                node_id, "FAILED",
+                node_id,
+                "FAILED",
                 duration_seconds=duration,
                 error_message=str(e),
             )
@@ -2544,6 +2554,7 @@ def _run_yaml_pipeline(
                         )
         except Exception as exc:
             import logging
+
             logging.getLogger(__name__).warning("Entity consolidation failed: %s", exc)
 
     # Step 7: Print summary
@@ -2587,11 +2598,17 @@ def _run_yaml_pipeline(
         typer.echo("")
         typer.echo(f"  Data Quality:   {_rule_total} rule(s)")
         if _rule_passed > 0:
-            typer.echo(f"                  {typer.style(str(_rule_passed) + ' passed', fg=typer.colors.GREEN)}")
+            typer.echo(
+                f"                  {typer.style(str(_rule_passed) + ' passed', fg=typer.colors.GREEN)}"
+            )
         if _rule_warns > 0:
-            typer.echo(f"                  {typer.style(str(_rule_warns) + ' warning(s)', fg=typer.colors.YELLOW, bold=True)}")
+            typer.echo(
+                f"                  {typer.style(str(_rule_warns) + ' warning(s)', fg=typer.colors.YELLOW, bold=True)}"
+            )
         if _rule_errors > 0:
-            typer.echo(f"                  {typer.style(str(_rule_errors) + ' error(s)', fg=typer.colors.RED, bold=True)}")
+            typer.echo(
+                f"                  {typer.style(str(_rule_errors) + ' error(s)', fg=typer.colors.RED, bold=True)}"
+            )
 
     typer.echo("=" * 60)
 
@@ -2617,25 +2634,15 @@ def _run_yaml_pipeline(
 
 @app.command("list")
 def list_resources(
-    resource_type: ResourceType = typer.Argument(
-        ..., help="Type of resource to list"
-    ),
-    project: Optional[str] = typer.Option(
-        None, "--project", "-p",
-        help="Filter by project name"
-    ),
-    format: OutputFormat = typer.Option(
-        OutputFormat.TABLE, "--format", "-f",
-        help="Output format"
-    ),
+    resource_type: ResourceType = typer.Argument(..., help="Type of resource to list"),
+    project: Optional[str] = typer.Option(None, "--project", "-p", help="Filter by project name"),
+    format: OutputFormat = typer.Option(OutputFormat.TABLE, "--format", "-f", help="Output format"),
 ):
     """List resources (projects, entities, feature-groups, etc.)."""
     from seeknal.project import Project
     from seeknal.entity import Entity
     from seeknal.featurestore.featurestore import OfflineStore
-    from seeknal.models import (
-        WorkspaceTable, FeatureGroupTable
-    )
+    from seeknal.models import WorkspaceTable, FeatureGroupTable
     from seeknal.request import get_db_session
     from sqlmodel import select
     from tabulate import tabulate
@@ -2663,8 +2670,10 @@ def list_resources(
                     typer.echo("No feature groups found.")
                 else:
                     headers = ["Name", "Description", "Version"]
-                    data = [[fg.name, fg.description or "", getattr(fg, "version", 1) or 1]
-                            for fg in feature_groups]
+                    data = [
+                        [fg.name, fg.description or "", getattr(fg, "version", 1) or 1]
+                        for fg in feature_groups
+                    ]
                     typer.echo(tabulate(data, headers=headers, tablefmt="simple"))
             case ResourceType.OFFLINE_STORES:
                 OfflineStore.list()
@@ -2677,15 +2686,15 @@ def list_resources(
 def show(
     resource_type: str = typer.Argument(..., help="Type of resource"),
     name: str = typer.Argument(..., help="Resource name"),
-    format: OutputFormat = typer.Option(
-        OutputFormat.TABLE, "--format", "-f",
-        help="Output format"
-    ),
+    format: OutputFormat = typer.Option(OutputFormat.TABLE, "--format", "-f", help="Output format"),
 ):
     """Show detailed information about a resource."""
     from seeknal.request import (
-        ProjectRequest, EntityRequest, FlowRequest,
-        FeatureGroupRequest, WorkspaceRequest
+        ProjectRequest,
+        EntityRequest,
+        FlowRequest,
+        FeatureGroupRequest,
+        WorkspaceRequest,
     )
     import json
 
@@ -2710,14 +2719,14 @@ def show(
 
         if format == OutputFormat.JSON:
             # Convert to dict and print as JSON
-            data = {k: v for k, v in resource.__dict__.items() if not k.startswith('_')}
+            data = {k: v for k, v in resource.__dict__.items() if not k.startswith("_")}
             typer.echo(json.dumps(data, indent=2, default=str))
         else:
             # Print as table
             typer.echo(f"\n{resource_type.title()}: {name}")
             typer.echo("-" * 40)
             for key, value in resource.__dict__.items():
-                if not key.startswith('_') and value is not None:
+                if not key.startswith("_") and value is not None:
                     typer.echo(f"  {key}: {value}")
 
     except Exception as e:
@@ -2727,10 +2736,7 @@ def show(
 
 @app.command()
 def validate(
-    config_path: Optional[Path] = typer.Option(
-        None, "--config", "-c",
-        help="Path to config file"
-    ),
+    config_path: Optional[Path] = typer.Option(None, "--config", "-c", help="Path to config file"),
 ):
     """Validate configurations and connections."""
     from seeknal.context import CONFIG_BASE_URL
@@ -2766,6 +2772,7 @@ def _build_range_validator(config):
     params = config.params or {}
     column = config.columns[0] if len(config.columns) == 1 else config.columns[0]
     from seeknal.feature_validation.validators import RangeValidator
+
     return RangeValidator(
         column=column,
         min_val=params.get("min_val"),
@@ -2779,7 +2786,7 @@ def _build_freshness_validator(config):
         raise ValueError("FreshnessValidator requires a column")
     from datetime import timedelta
     from seeknal.feature_validation.validators import FreshnessValidator
-    
+
     params = config.params or {}
     max_age_seconds = params.get("max_age_seconds", 86400)  # Default 24 hours
     return FreshnessValidator(
@@ -2800,6 +2807,7 @@ _VALIDATOR_REGISTRY = {
 def _build_null_validator(config):
     """Build a NullValidator from config."""
     from seeknal.feature_validation.validators import NullValidator
+
     params = config.params or {}
     return NullValidator(
         columns=config.columns or [],
@@ -2810,6 +2818,7 @@ def _build_null_validator(config):
 def _build_uniqueness_validator(config):
     """Build a UniquenessValidator from config."""
     from seeknal.feature_validation.validators import UniquenessValidator
+
     params = config.params or {}
     return UniquenessValidator(
         columns=config.columns or [],
@@ -2929,17 +2938,14 @@ def _format_field(field, symbol: str = "") -> str:
 
 @app.command("validate-features")
 def validate_features(
-    feature_group: str = typer.Argument(
-        ..., help="Name of the feature group to validate"
-    ),
+    feature_group: str = typer.Argument(..., help="Name of the feature group to validate"),
     mode: ValidationModeChoice = typer.Option(
-        ValidationModeChoice.FAIL, "--mode", "-m",
-        help="Validation mode: 'warn' logs failures and continues, 'fail' stops on first failure"
+        ValidationModeChoice.FAIL,
+        "--mode",
+        "-m",
+        help="Validation mode: 'warn' logs failures and continues, 'fail' stops on first failure",
     ),
-    verbose: bool = typer.Option(
-        False, "--verbose", "-v",
-        help="Show detailed validation results"
-    ),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed validation results"),
 ):
     """Validate feature group data quality.
 
@@ -2989,7 +2995,9 @@ def validate_features(
             raise typer.Exit(1)
 
         # Convert CLI mode to ValidationMode enum
-        validation_mode = ValidationMode.WARN if mode == ValidationModeChoice.WARN else ValidationMode.FAIL
+        validation_mode = (
+            ValidationMode.WARN if mode == ValidationModeChoice.WARN else ValidationMode.FAIL
+        )
 
         # Show validator count
         typer.echo(f"  Validators to run: {len(validators)}")
@@ -3026,7 +3034,11 @@ def validate_features(
 
         # Summary statistics
         passed_style = typer.style(str(summary.passed_count), fg=typer.colors.GREEN, bold=True)
-        failed_style = typer.style(str(summary.failed_count), fg=typer.colors.RED if summary.failed_count > 0 else typer.colors.GREEN, bold=True)
+        failed_style = typer.style(
+            str(summary.failed_count),
+            fg=typer.colors.RED if summary.failed_count > 0 else typer.colors.GREEN,
+            bold=True,
+        )
 
         typer.echo(f"  Total validators: {summary.total_validators}")
         typer.echo(f"  Passed:           {passed_style}")
@@ -3066,19 +3078,15 @@ def validate_features(
         _echo_error(f"Validation failed: {e}")
         if verbose:
             import traceback
+
             typer.echo(typer.style(traceback.format_exc(), dim=True))
         raise typer.Exit(1)
 
 
 @app.command()
 def debug(
-    feature_group: str = typer.Argument(
-        ..., help="Feature group name to debug"
-    ),
-    limit: int = typer.Option(
-        10, "--limit", "-l",
-        help="Number of rows to show"
-    ),
+    feature_group: str = typer.Argument(..., help="Feature group name to debug"),
+    limit: int = typer.Option(10, "--limit", "-l", help="Number of rows to show"),
 ):
     """Show sample data from a feature group for debugging."""
     from seeknal.featurestore.feature_group import FeatureGroup, HistoricalFeatures, FeatureLookup
@@ -3113,20 +3121,13 @@ def debug(
 
 @app.command()
 def clean(
-    feature_group: str = typer.Argument(
-        ..., help="Feature group name to clean"
-    ),
+    feature_group: str = typer.Argument(..., help="Feature group name to clean"),
     before_date: Optional[str] = typer.Option(
-        None, "--before", "-b",
-        help="Delete data before this date (YYYY-MM-DD)"
+        None, "--before", "-b", help="Delete data before this date (YYYY-MM-DD)"
     ),
-    ttl_days: Optional[int] = typer.Option(
-        None, "--ttl",
-        help="Delete data older than TTL days"
-    ),
+    ttl_days: Optional[int] = typer.Option(None, "--ttl", help="Delete data older than TTL days"),
     dry_run: bool = typer.Option(
-        False, "--dry-run",
-        help="Show what would be deleted without deleting"
+        False, "--dry-run", help="Show what would be deleted without deleting"
     ),
 ):
     """Clean old feature data based on TTL or date."""
@@ -3140,6 +3141,7 @@ def clean(
         cutoff = parse_date_safely(before_date, "before date")
     else:
         from datetime import timedelta
+
         cutoff = datetime.now() - timedelta(days=ttl_days)
 
     typer.echo(f"Cleaning feature group: {feature_group}")
@@ -3163,13 +3165,8 @@ def delete(
     resource_type: DeleteResourceType = typer.Argument(
         ..., help="Type of resource to delete (feature-group)"
     ),
-    name: str = typer.Argument(
-        ..., help="Name of the resource to delete"
-    ),
-    force: bool = typer.Option(
-        False, "--force", "-f",
-        help="Skip confirmation prompt"
-    ),
+    name: str = typer.Argument(..., help="Name of the resource to delete"),
+    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation prompt"),
 ):
     """Delete a resource (feature group) including storage and metadata."""
     from seeknal.featurestore.feature_group import FeatureGroup
@@ -3209,12 +3206,12 @@ def delete(
 
 @app.command("delete-table")
 def delete_table(
-    table_name: str = typer.Argument(
-        ..., help="Name of the online table to delete"
-    ),
+    table_name: str = typer.Argument(..., help="Name of the online table to delete"),
     force: bool = typer.Option(
-        False, "--force", "-f",
-        help="Force deletion without confirmation (bypass dependency warnings)"
+        False,
+        "--force",
+        "-f",
+        help="Force deletion without confirmation (bypass dependency warnings)",
     ),
 ):
     """Delete an online table and all associated data files.
@@ -3258,15 +3255,16 @@ def delete_table(
 
         # Step 3: Show warnings if dependencies exist
         if dependent_feature_groups:
-            _echo_warning(f"Table '{table_name}' has {len(dependent_feature_groups)} dependent feature group(s):")
+            _echo_warning(
+                f"Table '{table_name}' has {len(dependent_feature_groups)} dependent feature group(s):"
+            )
             for fg_name in dependent_feature_groups:
                 typer.echo(f"  - {fg_name}")
 
             if not force:
                 _echo_warning("Deleting this table may affect these feature groups.")
                 confirm = typer.confirm(
-                    "Are you sure you want to delete this table?",
-                    default=False
+                    "Are you sure you want to delete this table?", default=False
                 )
                 if not confirm:
                     _echo_info("Deletion cancelled")
@@ -3275,8 +3273,7 @@ def delete_table(
             # No dependencies, but still confirm unless --force
             if not force:
                 confirm = typer.confirm(
-                    f"Are you sure you want to delete table '{table_name}'?",
-                    default=False
+                    f"Are you sure you want to delete table '{table_name}'?", default=False
                 )
                 if not confirm:
                     _echo_info("Deletion cancelled")
@@ -3296,7 +3293,7 @@ def delete_table(
             lookup_key=entity_obj,
             online_store=OnlineStoreDuckDB(),
             project="default",  # TODO: Get from online_table.project_id if needed
-            id=online_table.id
+            id=online_table.id,
         )
 
         success = online_table_obj.delete()
@@ -3312,6 +3309,7 @@ def delete_table(
         _echo_error(f"Failed to delete table: {e}")
         raise typer.Exit(1)
 
+
 # Version subcommands
 @version_app.command("list")
 def version_list(
@@ -3319,12 +3317,10 @@ def version_list(
         ..., help="Name of the feature group to query versions for"
     ),
     format: OutputFormat = typer.Option(
-        OutputFormat.TABLE, "--format", "-f",
-        help="Output format: table (default), json, or yaml"
+        OutputFormat.TABLE, "--format", "-f", help="Output format: table (default), json, or yaml"
     ),
     limit: Optional[int] = typer.Option(
-        None, "--limit", "-l",
-        help="Maximum number of versions to display (most recent first)"
+        None, "--limit", "-l", help="Maximum number of versions to display (most recent first)"
     ),
 ):
     """
@@ -3381,16 +3377,12 @@ def version_list(
 
 @version_app.command("show")
 def version_show(
-    feature_group: str = typer.Argument(
-        ..., help="Name of the feature group to inspect"
-    ),
+    feature_group: str = typer.Argument(..., help="Name of the feature group to inspect"),
     version: Optional[int] = typer.Option(
-        None, "--version", "-v",
-        help="Specific version number to show (defaults to latest version)"
+        None, "--version", "-v", help="Specific version number to show (defaults to latest version)"
     ),
     format: OutputFormat = typer.Option(
-        OutputFormat.TABLE, "--format", "-f",
-        help="Output format: table (default), json, or yaml"
+        OutputFormat.TABLE, "--format", "-f", help="Output format: table (default), json, or yaml"
     ),
 ):
     """
@@ -3493,16 +3485,13 @@ def version_diff(
         ..., help="Name of the feature group to compare versions for"
     ),
     from_version: int = typer.Option(
-        ..., "--from", "-f",
-        help="Base version number to compare from (older version)"
+        ..., "--from", "-f", help="Base version number to compare from (older version)"
     ),
     to_version: int = typer.Option(
-        ..., "--to", "-t",
-        help="Target version number to compare to (newer version)"
+        ..., "--to", "-t", help="Target version number to compare to (newer version)"
     ),
     format: OutputFormat = typer.Option(
-        OutputFormat.TABLE, "--format",
-        help="Output format: table (default) or json"
+        OutputFormat.TABLE, "--format", help="Output format: table (default) or json"
     ),
 ):
     """
@@ -3564,19 +3553,28 @@ def version_diff(
 
                 # Display modified features
                 if modified:
-                    typer.echo("\n" + typer.style("Modified (~):", fg=typer.colors.YELLOW, bold=True))
+                    typer.echo(
+                        "\n" + typer.style("Modified (~):", fg=typer.colors.YELLOW, bold=True)
+                    )
                     for change in modified:
                         if isinstance(change, dict):
                             field_name = change.get("field", "unknown")
                             old_type = _format_field_type(change.get("old_type", "unknown"))
                             new_type = _format_field_type(change.get("new_type", "unknown"))
-                            typer.echo(typer.style(f"  ~ {field_name}: {old_type} → {new_type}", fg=typer.colors.YELLOW))
+                            typer.echo(
+                                typer.style(
+                                    f"  ~ {field_name}: {old_type} → {new_type}",
+                                    fg=typer.colors.YELLOW,
+                                )
+                            )
                         else:
                             typer.echo(typer.style(f"  ~ {change}", fg=typer.colors.YELLOW))
 
                 # Summary
                 typer.echo("\n" + "-" * 60)
-                typer.echo(f"Summary: {len(added)} added, {len(removed)} removed, {len(modified)} modified")
+                typer.echo(
+                    f"Summary: {len(added)} added, {len(removed)} removed, {len(modified)} modified"
+                )
 
     except ValueError as e:
         _echo_error(str(e))
@@ -3589,25 +3587,16 @@ def version_diff(
 @app.command()
 def parse(
     project: str = typer.Option(
-        None, "--project", "-p",
-        help="Project name (defaults to current directory name)"
+        None, "--project", "-p", help="Project name (defaults to current directory name)"
     ),
-    path: Path = typer.Option(
-        Path("."), "--path",
-        help="Project path to parse"
-    ),
+    path: Path = typer.Option(Path("."), "--path", help="Project path to parse"),
     target_path: Optional[Path] = typer.Option(
-        None, "--target", "-t",
-        help="Target directory for manifest (defaults to <path>/target)"
+        None, "--target", "-t", help="Target directory for manifest (defaults to <path>/target)"
     ),
     format: OutputFormat = typer.Option(
-        OutputFormat.TABLE, "--format", "-f",
-        help="Output format: table (default) or json"
+        OutputFormat.TABLE, "--format", "-f", help="Output format: table (default) or json"
     ),
-    no_diff: bool = typer.Option(
-        False, "--no-diff",
-        help="Skip comparison with previous manifest"
-    ),
+    no_diff: bool = typer.Option(False, "--no-diff", help="Skip comparison with previous manifest"),
 ):
     """
     Parse project and generate manifest.json.
@@ -3717,34 +3706,65 @@ def parse(
 
                     # Show added nodes
                     if diff.added_nodes:
-                        typer.echo(typer.style(f"  Added ({len(diff.added_nodes)}):", fg=typer.colors.GREEN))
+                        typer.echo(
+                            typer.style(
+                                f"  Added ({len(diff.added_nodes)}):", fg=typer.colors.GREEN
+                            )
+                        )
                         for node_id in sorted(diff.added_nodes.keys()):
                             typer.echo(typer.style(f"    + {node_id}", fg=typer.colors.GREEN))
 
                     # Show removed nodes
                     if diff.removed_nodes:
-                        typer.echo(typer.style(f"  Removed ({len(diff.removed_nodes)}):", fg=typer.colors.RED))
+                        typer.echo(
+                            typer.style(
+                                f"  Removed ({len(diff.removed_nodes)}):", fg=typer.colors.RED
+                            )
+                        )
                         for node_id in sorted(diff.removed_nodes.keys()):
                             typer.echo(typer.style(f"    - {node_id}", fg=typer.colors.RED))
 
                     # Show modified nodes
                     if diff.modified_nodes:
-                        typer.echo(typer.style(f"  Modified ({len(diff.modified_nodes)}):", fg=typer.colors.YELLOW))
+                        typer.echo(
+                            typer.style(
+                                f"  Modified ({len(diff.modified_nodes)}):", fg=typer.colors.YELLOW
+                            )
+                        )
                         for node_id in sorted(diff.modified_nodes.keys()):
                             change = diff.modified_nodes[node_id]
                             fields = ", ".join(change.changed_fields)
-                            typer.echo(typer.style(f"    ~ {node_id} ({fields})", fg=typer.colors.YELLOW))
+                            typer.echo(
+                                typer.style(f"    ~ {node_id} ({fields})", fg=typer.colors.YELLOW)
+                            )
 
                     # Show edge changes
                     if diff.added_edges:
-                        typer.echo(typer.style(f"  Added edges ({len(diff.added_edges)}):", fg=typer.colors.GREEN))
+                        typer.echo(
+                            typer.style(
+                                f"  Added edges ({len(diff.added_edges)}):", fg=typer.colors.GREEN
+                            )
+                        )
                         for edge in diff.added_edges:
-                            typer.echo(typer.style(f"    + {edge.from_node} -> {edge.to_node}", fg=typer.colors.GREEN))
+                            typer.echo(
+                                typer.style(
+                                    f"    + {edge.from_node} -> {edge.to_node}",
+                                    fg=typer.colors.GREEN,
+                                )
+                            )
 
                     if diff.removed_edges:
-                        typer.echo(typer.style(f"  Removed edges ({len(diff.removed_edges)}):", fg=typer.colors.RED))
+                        typer.echo(
+                            typer.style(
+                                f"  Removed edges ({len(diff.removed_edges)}):", fg=typer.colors.RED
+                            )
+                        )
                         for edge in diff.removed_edges:
-                            typer.echo(typer.style(f"    - {edge.from_node} -> {edge.to_node}", fg=typer.colors.RED))
+                            typer.echo(
+                                typer.style(
+                                    f"    - {edge.from_node} -> {edge.to_node}", fg=typer.colors.RED
+                                )
+                            )
 
                     typer.echo("")
                     typer.echo(f"Summary: {diff.summary()}")
@@ -3761,16 +3781,16 @@ def parse(
 def plan(
     env_name: Optional[str] = typer.Argument(
         None,
-        help="Environment name (optional). Without: show changes vs last run. With: create environment plan."
+        help="Environment name (optional). Without: show changes vs last run. With: create environment plan.",
     ),
     project_path: Path = typer.Option(".", help="Project directory"),
     tags: Optional[List[str]] = typer.Option(
-        None, "--tags",
-        help="Show only nodes with these tags (plus upstream deps). OR logic. Production mode only."
+        None,
+        "--tags",
+        help="Show only nodes with these tags (plus upstream deps). OR logic. Production mode only.",
     ),
     exclude_tags: Optional[List[str]] = typer.Option(
-        None, "--exclude-tags",
-        help="Hide nodes with these tags from the plan."
+        None, "--exclude-tags", help="Hide nodes with these tags from the plan."
     ),
 ):
     """Analyze changes and show execution plan.
@@ -3916,30 +3936,40 @@ def plan(
 
                 # Show edge changes
                 if diff.added_edges:
-                    typer.echo(typer.style(
-                        f"  Added edges ({len(diff.added_edges)}):", fg=typer.colors.GREEN
-                    ))
+                    typer.echo(
+                        typer.style(
+                            f"  Added edges ({len(diff.added_edges)}):", fg=typer.colors.GREEN
+                        )
+                    )
                     for edge in diff.added_edges:
-                        typer.echo(typer.style(
-                            f"    + {edge.from_node} -> {edge.to_node}", fg=typer.colors.GREEN
-                        ))
+                        typer.echo(
+                            typer.style(
+                                f"    + {edge.from_node} -> {edge.to_node}", fg=typer.colors.GREEN
+                            )
+                        )
 
                 if diff.removed_edges:
-                    typer.echo(typer.style(
-                        f"  Removed edges ({len(diff.removed_edges)}):", fg=typer.colors.RED
-                    ))
+                    typer.echo(
+                        typer.style(
+                            f"  Removed edges ({len(diff.removed_edges)}):", fg=typer.colors.RED
+                        )
+                    )
                     for edge in diff.removed_edges:
-                        typer.echo(typer.style(
-                            f"    - {edge.from_node} -> {edge.to_node}", fg=typer.colors.RED
-                        ))
+                        typer.echo(
+                            typer.style(
+                                f"    - {edge.from_node} -> {edge.to_node}", fg=typer.colors.RED
+                            )
+                        )
 
                 # Hint for detailed diff
                 if diff.modified_nodes:
                     typer.echo("")
-                    typer.echo(typer.style(
-                        "  Tip: Run 'seeknal diff <type>/<name>' for detailed YAML diff",
-                        fg=typer.colors.RESET,
-                    ))
+                    typer.echo(
+                        typer.style(
+                            "  Tip: Run 'seeknal diff <type>/<name>' for detailed YAML diff",
+                            fg=typer.colors.RESET,
+                        )
+                    )
             else:
                 _echo_info("No changes detected since last parse")
         else:
@@ -3982,14 +4012,12 @@ def plan(
         if tags and env_name is None:
             tag_set = set(tags)
             tag_matched = {
-                node_id for node_id in dag_builder.nodes
+                node_id
+                for node_id in dag_builder.nodes
                 if any(t in tag_set for t in dag_builder.nodes[node_id].tags)
             }
             if not tag_matched:
-                _echo_warning(
-                    f"No nodes found with tags: {', '.join(tags)}. "
-                    "Showing full plan."
-                )
+                _echo_warning(f"No nodes found with tags: {', '.join(tags)}. " "Showing full plan.")
             else:
                 # Auto-include all transitive upstream deps
                 with_upstream = set(tag_matched)
@@ -4001,12 +4029,14 @@ def plan(
             exclude_set = set(exclude_tags)
             if plan_filter_set is not None:
                 plan_filter_set = {
-                    node_id for node_id in plan_filter_set
+                    node_id
+                    for node_id in plan_filter_set
                     if not any(t in exclude_set for t in dag_builder.nodes[node_id].tags)
                 }
             else:
                 plan_filter_set = {
-                    node_id for node_id in dag_builder.nodes
+                    node_id
+                    for node_id in dag_builder.nodes
                     if not any(t in exclude_set for t in dag_builder.nodes[node_id].tags)
                 }
 
@@ -4113,20 +4143,27 @@ def diff_command(
         typer.echo("")
         if result.category:
             cat_labels = {
-                ChangeCategory.BREAKING: ("BREAKING (downstream rebuild required)", typer.colors.RED),
-                ChangeCategory.NON_BREAKING: ("NON_BREAKING (rebuild this node)", typer.colors.YELLOW),
+                ChangeCategory.BREAKING: (
+                    "BREAKING (downstream rebuild required)",
+                    typer.colors.RED,
+                ),
+                ChangeCategory.NON_BREAKING: (
+                    "NON_BREAKING (rebuild this node)",
+                    typer.colors.YELLOW,
+                ),
                 ChangeCategory.METADATA: ("METADATA (no rebuild needed)", typer.colors.BLUE),
             }
-            label, color = cat_labels.get(
-                result.category, ("UNKNOWN", typer.colors.RESET)
-            )
+            label, color = cat_labels.get(result.category, ("UNKNOWN", typer.colors.RESET))
             typer.echo(typer.style(f"  Category: {label}", fg=color, bold=True))
 
         if result.downstream_count > 0 and result.category == ChangeCategory.BREAKING:
-            typer.echo(typer.style(
-                f"  Impact: {result.downstream_count} downstream node(s) affected",
-                fg=typer.colors.YELLOW, bold=True,
-            ))
+            typer.echo(
+                typer.style(
+                    f"  Impact: {result.downstream_count} downstream node(s) affected",
+                    fg=typer.colors.YELLOW,
+                    bold=True,
+                )
+            )
             downstream = engine.get_downstream_nodes(result.node_id)
             for ds_id in downstream[:5]:
                 typer.echo(typer.style(f"    -> {ds_id}", fg=typer.colors.RED))
@@ -4159,7 +4196,9 @@ def diff_command(
             total_files = len(modified) + len(new) + len(deleted)
             total_ins = sum(r.insertions for r in modified)
             total_del = sum(r.deletions for r in modified)
-            typer.echo(f"  {total_files} file(s) changed, {total_ins} insertion(s), {total_del} deletion(s)")
+            typer.echo(
+                f"  {total_files} file(s) changed, {total_ins} insertion(s), {total_del} deletion(s)"
+            )
         else:
             # Summary mode
             typer.echo(typer.style("Changes since last apply:", bold=True))
@@ -4208,7 +4247,9 @@ def diff_command(
             py_files = list(py_dir.glob("*.py"))
             if py_files:
                 typer.echo("")
-                _echo_info(f"Note: {len(py_files)} Python pipeline file(s) found. Diff not yet supported for .py files.")
+                _echo_info(
+                    f"Note: {len(py_files)} Python pipeline file(s) found. Diff not yet supported for .py files."
+                )
 
 
 @app.command()
@@ -4230,28 +4271,30 @@ def promote(
 @app.command()
 def repl(
     profile: Optional[str] = typer.Option(
-        None, "--profile",
-        help="Path to profiles.yml for connections (default: ~/.seeknal/profiles.yml)"
+        None,
+        "--profile",
+        help="Path to profiles.yml for connections (default: ~/.seeknal/profiles.yml)",
     ),
     env: Optional[str] = typer.Option(
-        None, "--env",
-        help="Load data from a virtual environment (e.g., dev) instead of production"
+        None, "--env", help="Load data from a virtual environment (e.g., dev) instead of production"
     ),
     exec_sql: Optional[str] = typer.Option(
-        None, "--exec", "-e",
-        help="Execute SQL query and exit (non-interactive). Use '-' to read from stdin."
+        None,
+        "--exec",
+        "-e",
+        help="Execute SQL query and exit (non-interactive). Use '-' to read from stdin.",
     ),
     format: str = typer.Option(
-        "table", "--format", "-f",
-        help="Output format for --exec: table, json, csv"
+        "table", "--format", "-f", help="Output format for --exec: table, json, csv"
     ),
     output: Optional[str] = typer.Option(
-        None, "--output", "-o",
-        help="Export --exec results to file (format inferred from .csv, .json, .parquet)"
+        None,
+        "--output",
+        "-o",
+        help="Export --exec results to file (format inferred from .csv, .json, .parquet)",
     ),
     limit: Optional[int] = typer.Option(
-        None, "--limit",
-        help="Limit number of result rows for --exec"
+        None, "--limit", help="Limit number of result rows for --exec"
     ),
 ):
     """Start interactive SQL REPL or execute a one-shot query.
@@ -4302,8 +4345,7 @@ def repl(
         env_dir = project_path / "target" / "environments" / env
         if not env_dir.exists():
             _echo_error(
-                f"Environment '{env}' not found. "
-                f"Run 'seeknal env plan {env}' to create it."
+                f"Environment '{env}' not found. " f"Run 'seeknal env plan {env}' to create it."
             )
             raise typer.Exit(1)
 
@@ -4329,6 +4371,7 @@ def repl(
             raise typer.Exit(code=1)
         except Exception as e:
             from seeknal.db_utils import sanitize_error_message
+
             print(f"Error: {sanitize_error_message(str(e))}", file=sys.stderr)
             raise typer.Exit(code=1)
 
@@ -4414,12 +4457,19 @@ def _exec_export_to_file(columns: list, rows: list, output_path: str) -> None:
 
 @app.command()
 def draft(
-    node_type: str = typer.Argument(..., help="Node type (source, transform, feature-group, semantic-model, model, aggregation, rule, exposure)"),
+    node_type: str = typer.Argument(
+        ...,
+        help="Node type (source, transform, feature-group, semantic-model, model, aggregation, rule, exposure)",
+    ),
     name: str = typer.Argument(..., help="Node name"),
     description: Optional[str] = typer.Option(None, "--description", "-d", help="Node description"),
     force: bool = typer.Option(False, "--force", "-f", help="Overwrite existing draft file"),
-    python: bool = typer.Option(False, "--python", "-py", help="Generate Python file instead of YAML"),
-    deps: str = typer.Option("", "--deps", help="Comma-separated Python dependencies for PEP 723 header"),
+    python: bool = typer.Option(
+        False, "--python", "-py", help="Generate Python file instead of YAML"
+    ),
+    deps: str = typer.Option(
+        "", "--deps", help="Comma-separated Python dependencies for PEP 723 header"
+    ),
 ):
     """Generate template from Jinja2 template.
 
@@ -4457,8 +4507,12 @@ def draft(
 def dry_run(
     file_path: str = typer.Argument(..., help="Path to YAML or Python pipeline file"),
     limit: int = typer.Option(10, "--limit", "-l", help="Row limit for preview (default: 10)"),
-    timeout: int = typer.Option(30, "--timeout", "-t", help="Query timeout in seconds (default: 30)"),
-    schema_only: bool = typer.Option(False, "--schema-only", "-s", help="Validate schema only, skip execution"),
+    timeout: int = typer.Option(
+        30, "--timeout", "-t", help="Query timeout in seconds (default: 30)"
+    ),
+    schema_only: bool = typer.Option(
+        False, "--schema-only", "-s", help="Validate schema only, skip execution"
+    ),
 ):
     """Validate YAML/Python and preview execution.
 
@@ -4493,7 +4547,9 @@ def inspect(
         help="Node ID to inspect (e.g., 'source.products', 'transform.sales_enriched')",
     ),
     limit: int = typer.Option(10, "--limit", "-l", help="Row limit for preview"),
-    schema_only: bool = typer.Option(False, "--schema", "-s", help="Show schema (columns + types) only"),
+    schema_only: bool = typer.Option(
+        False, "--schema", "-s", help="Show schema (columns + types) only"
+    ),
     list_all: bool = typer.Option(False, "--list", help="List all available intermediate outputs"),
     project_path: Path = typer.Option(".", help="Project directory"),
 ):
@@ -4537,9 +4593,7 @@ def inspect(
         # Suggest available nodes
         intermediate_dir = target_path / "intermediate"
         if intermediate_dir.exists():
-            available = [
-                f.stem.replace("_", ".", 1) for f in intermediate_dir.glob("*.parquet")
-            ]
+            available = [f.stem.replace("_", ".", 1) for f in intermediate_dir.glob("*.parquet")]
             if available:
                 _echo_info(f"\n  Available nodes:")
                 for node in sorted(available):
@@ -4613,7 +4667,9 @@ def _inspect_list(target_path: Path):
 @app.command()
 def apply(
     file_path: str = typer.Argument(..., help="Path to YAML or Python pipeline file"),
-    force: bool = typer.Option(False, "--force", "-f", help="Overwrite existing file without prompt"),
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Overwrite existing file without prompt"
+    ),
     no_parse: bool = typer.Option(False, "--no-parse", help="Skip manifest regeneration"),
 ):
     """Apply file to production.
@@ -4686,6 +4742,7 @@ def apply(
         if target_path.resolve() != path.resolve():
             _echo_info(f"Moving file to {target_path}...")
             import shutil
+
             target_path.parent.mkdir(parents=True, exist_ok=True)
             shutil.move(str(path), str(target_path))
 
@@ -4695,6 +4752,7 @@ def apply(
 
         # Convert to list format for dry_run_command
         import sys
+
         sys.argv = ["seeknal", "dry-run", str(target_path)]
 
         # Run dry-run with schema-only mode
@@ -4818,7 +4876,7 @@ def audit(
         if node and view_name != node:
             continue
         try:
-            conn.execute(f'CREATE VIEW "{view_name}" AS SELECT * FROM read_parquet(\'{pf}\')')
+            conn.execute(f"CREATE VIEW \"{view_name}\" AS SELECT * FROM read_parquet('{pf}')")
         except Exception as e:
             _echo_warning(f"Could not load {view_name}: {e}")
 
@@ -4829,9 +4887,11 @@ def audit(
         raise typer.Exit(code=1)
 
     from seeknal.dag.manifest import Manifest
+
     manifest = Manifest.load(str(manifest_path))
 
     from seeknal.workflow.audits import parse_audits, AuditRunner
+
     runner = AuditRunner(conn)
     total_passed = 0
     total_failed = 0
@@ -4868,13 +4928,24 @@ def audit(
 @app.command()
 def query(
     metrics: str = typer.Option(..., help="Comma-separated metric names"),
-    dimensions: Optional[str] = typer.Option(None, help="Comma-separated dimensions (e.g. region,ordered_at__month)"),
+    dimensions: Optional[str] = typer.Option(
+        None, help="Comma-separated dimensions (e.g. region,ordered_at__month)"
+    ),
     filter: Optional[str] = typer.Option(None, "--filter", help="SQL filter expression"),
-    order_by: Optional[str] = typer.Option(None, "--order-by", help="Order by columns (prefix - for DESC)"),
+    order_by: Optional[str] = typer.Option(
+        None, "--order-by", help="Order by columns (prefix - for DESC)"
+    ),
     limit: int = typer.Option(100, help="Maximum rows to return"),
-    compile_only: bool = typer.Option(False, "--compile", help="Show generated SQL without executing"),
+    compile_only: bool = typer.Option(
+        False, "--compile", help="Show generated SQL without executing"
+    ),
     format: str = typer.Option("table", help="Output format: table, json, csv"),
-    output: Optional[str] = typer.Option(None, "--output", "-o", help="Export results to file (format inferred from extension: .csv, .json, .parquet)"),
+    output: Optional[str] = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Export results to file (format inferred from extension: .csv, .json, .parquet)",
+    ),
     project_path: str = typer.Option(".", help="Path to project directory"),
 ):
     """
@@ -4944,16 +5015,20 @@ def query(
     for sm in semantic_models:
         for measure in sm.measures:
             if measure.name not in seen_names:
-                metric_list.append(MetricModel(
-                    name=measure.name,
-                    type=MetricType.SIMPLE,
-                    description=measure.description,
-                    measure=measure.name,
-                ))
+                metric_list.append(
+                    MetricModel(
+                        name=measure.name,
+                        type=MetricType.SIMPLE,
+                        description=measure.description,
+                        measure=measure.name,
+                    )
+                )
                 seen_names.add(measure.name)
 
     if not metric_list:
-        _echo_error("No metrics or measures found. Define measures in seeknal/semantic_models/ or metrics in seeknal/metrics/")
+        _echo_error(
+            "No metrics or measures found. Define measures in seeknal/semantic_models/ or metrics in seeknal/metrics/"
+        )
         raise typer.Exit(code=1)
 
     # Build compiler
@@ -4985,6 +5060,7 @@ def query(
 
     # Execute on DuckDB
     import duckdb
+
     conn = duckdb.connect(":memory:")
 
     # Register tables from cached parquet files (target/cache/{kind}/{name}.parquet)
@@ -5006,7 +5082,9 @@ def query(
             parts = stem.split("_", 1)
             table_name = parts[1] if len(parts) > 1 else stem
             try:
-                conn.execute(f"CREATE OR REPLACE VIEW \"{table_name}\" AS SELECT * FROM read_parquet('{pf}')")
+                conn.execute(
+                    f"CREATE OR REPLACE VIEW \"{table_name}\" AS SELECT * FROM read_parquet('{pf}')"
+                )
             except Exception:
                 pass
 
@@ -5021,6 +5099,7 @@ def query(
     # Export to file if --output is specified
     if output:
         import pandas as pd
+
         df = pd.DataFrame(rows, columns=columns)
         out_path = P(output)
         ext = out_path.suffix.lower()
@@ -5043,6 +5122,7 @@ def query(
     elif format == "csv":
         import csv
         import io
+
         buf = io.StringIO()
         writer = csv.writer(buf)
         writer.writerow(columns)
@@ -5051,6 +5131,7 @@ def query(
     else:
         try:
             from tabulate import tabulate as tabfmt
+
             typer.echo(tabfmt(rows, headers=columns, tablefmt="simple"))
         except ImportError:
             # Fallback to simple formatting
@@ -5064,9 +5145,15 @@ def query(
 @app.command("deploy-metrics")
 def deploy_metrics(
     connection: str = typer.Option(..., help="StarRocks connection name or URL"),
-    dimensions: Optional[str] = typer.Option(None, help="Comma-separated dimensions to include in MVs"),
-    refresh_interval: str = typer.Option("1 DAY", help="MV refresh interval (e.g. '1 HOUR', '1 DAY')"),
-    drop_existing: bool = typer.Option(False, "--drop-existing", help="Drop and recreate existing MVs"),
+    dimensions: Optional[str] = typer.Option(
+        None, help="Comma-separated dimensions to include in MVs"
+    ),
+    refresh_interval: str = typer.Option(
+        "1 DAY", help="MV refresh interval (e.g. '1 HOUR', '1 DAY')"
+    ),
+    drop_existing: bool = typer.Option(
+        False, "--drop-existing", help="Drop and recreate existing MVs"
+    ),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show DDL without executing"),
     project_path: str = typer.Option(".", help="Path to project directory"),
 ):
@@ -5136,12 +5223,14 @@ def deploy_metrics(
     for sm in semantic_models:
         for measure in sm.measures:
             if measure.name not in seen_names:
-                metric_list.append(MetricModel(
-                    name=measure.name,
-                    type=MetricTypeModel.SIMPLE,
-                    description=measure.description,
-                    measure=measure.name,
-                ))
+                metric_list.append(
+                    MetricModel(
+                        name=measure.name,
+                        type=MetricTypeModel.SIMPLE,
+                        description=measure.description,
+                        measure=measure.name,
+                    )
+                )
                 seen_names.add(measure.name)
 
     if not metric_list:
@@ -5151,12 +5240,14 @@ def deploy_metrics(
     # Resolve connection config
     if connection.startswith("starrocks://"):
         from seeknal.connections.starrocks import parse_starrocks_url
+
         sr_config = parse_starrocks_url(connection)
         conn_config = sr_config.to_pymysql_kwargs()
     else:
         # Try loading from profiles
         try:
             from seeknal.workflow.materialization.profile_loader import ProfileLoader
+
             loader = ProfileLoader()
             conn_config = loader.load_starrocks_profile(connection)
         except Exception as e:
@@ -5178,7 +5269,9 @@ def deploy_metrics(
         for sm in semantic_models:
             if sm.default_time_dimension:
                 dim_list = [sm.default_time_dimension]
-                _echo_info(f"Auto-including dimension '{sm.default_time_dimension}' (required for StarRocks MV keys)")
+                _echo_info(
+                    f"Auto-including dimension '{sm.default_time_dimension}' (required for StarRocks MV keys)"
+                )
                 break
 
     deployer = MetricDeployer(compiler, conn_config)
@@ -5223,8 +5316,7 @@ def env_plan(
     env_name: str = typer.Argument(..., help="Environment name (e.g., dev, staging)"),
     project_path: Path = typer.Option(".", help="Project directory"),
     profile: Optional[str] = typer.Option(
-        None, "--profile",
-        help="Path to profiles.yml for source_defaults and connections"
+        None, "--profile", help="Path to profiles.yml for source_defaults and connections"
     ),
 ):
     """Preview changes in a virtual environment."""
@@ -5309,6 +5401,7 @@ def _resolve_env_profile(
 
     # Convention: ~/.seeknal/profiles-{env}.yml
     from seeknal.context import CONFIG_BASE_URL
+
     home_env_profile = Path(CONFIG_BASE_URL) / f"profiles-{env_name}.yml"
     if home_env_profile.exists():
         return home_env_profile
@@ -5392,6 +5485,7 @@ def _run_in_environment(
     copied_refs: set[str] = set()
     if refs_data:
         import shutil
+
         env_intermediate = env_dir / "intermediate"
         env_intermediate.mkdir(parents=True, exist_ok=True)
         for ref in refs_data.get("refs", []):
@@ -5417,7 +5511,11 @@ def _run_in_environment(
         while queue:
             nid = queue.pop()
             for up in manifest.get_upstream_nodes(nid):
-                if up not in nodes_to_execute and up not in copied_refs and up not in missing_upstream:
+                if (
+                    up not in nodes_to_execute
+                    and up not in copied_refs
+                    and up not in missing_upstream
+                ):
                     missing_upstream.add(up)
                     queue.append(up)
         nodes_to_execute = nodes_to_execute | missing_upstream
@@ -5454,6 +5552,7 @@ def _run_in_environment(
     else:
         # Sequential execution
         import time as _time
+
         successful = 0
         failed = 0
         order = runner._get_topological_order()
@@ -5488,17 +5587,14 @@ def _run_in_environment(
     env_state_path = env_dir / "run_state.json"
     if not env_state_path.exists():
         import json
+
         with open(env_state_path, "w") as f:
             json.dump({"applied": True, "env_name": env_name}, f)
 
     if failed > 0:
-        _echo_warning(
-            f"Environment '{env_name}' applied with {failed} failure(s)."
-        )
+        _echo_warning(f"Environment '{env_name}' applied with {failed} failure(s).")
     else:
-        _echo_success(
-            f"Environment '{env_name}' applied successfully."
-        )
+        _echo_success(f"Environment '{env_name}' applied successfully.")
 
 
 @env_app.command("apply")
@@ -5508,12 +5604,15 @@ def env_apply(
     force: bool = typer.Option(False, help="Apply even if plan is stale"),
     parallel: bool = typer.Option(False, "--parallel", help="Run nodes in parallel"),
     max_workers: int = typer.Option(4, "--max-workers", help="Max parallel workers"),
-    continue_on_error: bool = typer.Option(False, "--continue-on-error", help="Continue past failures"),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Show what would execute without running"),
+    continue_on_error: bool = typer.Option(
+        False, "--continue-on-error", help="Continue past failures"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Show what would execute without running"
+    ),
     project_path: Path = typer.Option(".", help="Project directory"),
     profile: Optional[str] = typer.Option(
-        None, "--profile",
-        help="Path to profiles.yml for source_defaults and connections"
+        None, "--profile", help="Path to profiles.yml for source_defaults and connections"
     ),
 ):
     """Execute a plan in a virtual environment.
@@ -5558,7 +5657,8 @@ def _promote_environment(
 
     # Run dry_run first to get diff analysis (warnings, changed files)
     preview = manager.promote(
-        from_env, to_env,
+        from_env,
+        to_env,
         rematerialize=rematerialize,
         profile_path=profile_path,
         dry_run=True,
@@ -5617,7 +5717,8 @@ def _promote_environment(
     )
 
     result = manager.promote(
-        from_env, to_env,
+        from_env,
+        to_env,
         rematerialize=rematerialize,
         profile_path=profile_path,
     )
@@ -5669,19 +5770,23 @@ def env_promote(
     from_env: str = typer.Argument(..., help="Source environment"),
     to_env: str = typer.Argument("prod", help="Target (default: prod)"),
     project_path: Path = typer.Option(".", help="Project directory"),
-    dry_run: bool = typer.Option(False, "--dry-run", help="Show what would be promoted without executing"),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Show what would be promoted without executing"
+    ),
     profile: Optional[str] = typer.Option(
-        None, "--profile",
-        help="Path to profiles.yml for re-materialization connections"
+        None, "--profile", help="Path to profiles.yml for re-materialization connections"
     ),
     rematerialize: bool = typer.Option(
-        False, "--rematerialize",
-        help="Re-execute materialization targets with production credentials after promotion"
+        False,
+        "--rematerialize",
+        help="Re-execute materialization targets with production credentials after promotion",
     ),
 ):
     """Promote environment to production."""
     _promote_environment(
-        from_env, to_env, project_path,
+        from_env,
+        to_env,
+        project_path,
         dry_run=dry_run,
         profile=profile,
         rematerialize=rematerialize,
@@ -5716,7 +5821,8 @@ def env_list(
 
         status = "applied" if applied else ("planned" if plan_exists else "created")
         status_color = (
-            typer.colors.GREEN if applied
+            typer.colors.GREEN
+            if applied
             else (typer.colors.BLUE if plan_exists else typer.colors.YELLOW)
         )
 
@@ -5757,13 +5863,9 @@ def env_delete(
 @app.command("download-sample-data")
 def download_sample_data(
     output_dir: Path = typer.Option(
-        Path("data/sample"), "--output-dir", "-o",
-        help="Output directory for sample data files"
+        Path("data/sample"), "--output-dir", "-o", help="Output directory for sample data files"
     ),
-    force: bool = typer.Option(
-        False, "--force", "-f",
-        help="Overwrite existing sample data files"
-    ),
+    force: bool = typer.Option(False, "--force", "-f", help="Overwrite existing sample data files"),
 ):
     """Download sample e-commerce datasets for tutorials and testing.
 
@@ -5796,17 +5898,19 @@ def download_sample_data(
 
     # Get the package data directory
     from importlib.resources import files
+
     try:
         # Try Python 3.9+ style first
-        sample_data_dir = files('seeknal.docs.data.sample')
+        sample_data_dir = files("seeknal.docs.data.sample")
     except (TypeError, AttributeError):
         # Fallback for older Python versions
         import os
+
         package_dir = Path(__file__).parent.parent
-        sample_data_dir = package_dir / 'docs' / 'data' / 'sample'
+        sample_data_dir = package_dir / "docs" / "data" / "sample"
 
     # Check if source sample data exists
-    source_files = ['customers.csv', 'products.csv', 'orders.csv', 'sales.csv']
+    source_files = ["customers.csv", "products.csv", "orders.csv", "sales.csv"]
     missing_files = [f for f in source_files if not (sample_data_dir / f).exists()]
 
     if missing_files:
@@ -5865,16 +5969,14 @@ def download_sample_data(
 # Interval Management Commands
 # =============================================================================
 
+
 @intervals_app.command("list")
 def intervals_list(
     node_id: str = typer.Argument(
-        ...,
-        help="Node identifier (e.g., transform.clean_data, feature_group.user_features)"
+        ..., help="Node identifier (e.g., transform.clean_data, feature_group.user_features)"
     ),
     output_format: OutputFormat = typer.Option(
-        OutputFormat.TABLE,
-        "--output", "-o",
-        help="Output format"
+        OutputFormat.TABLE, "--output", "-o", help="Output format"
     ),
 ):
     """List completed intervals for a node.
@@ -5920,6 +6022,7 @@ def intervals_list(
 
     elif output_format == OutputFormat.JSON:
         import json
+
         data = {
             "node_id": node_id,
             "completed_intervals": node_state.completed_intervals,
@@ -5931,17 +6034,18 @@ def intervals_list(
 @intervals_app.command("pending")
 def intervals_pending(
     node_id: str = typer.Argument(
-        ...,
-        help="Node identifier (e.g., transform.clean_data, feature_group.user_features)"
+        ..., help="Node identifier (e.g., transform.clean_data, feature_group.user_features)"
     ),
     start: str = typer.Option(
         ...,
-        "--start", "-s",
+        "--start",
+        "-s",
         help="Start date (YYYY-MM-DD or ISO timestamp)",
     ),
     end: Optional[str] = typer.Option(
         None,
-        "--end", "-e",
+        "--end",
+        "-e",
         help="End date (YYYY-MM-DD or ISO timestamp). Defaults to next scheduled run.",
     ),
     schedule: str = typer.Option(
@@ -6004,18 +6108,17 @@ def intervals_pending(
 # Restatement subcommands - use add subcommand pattern
 @intervals_app.command("restatement-add")
 def restatement_add(
-    node_id: str = typer.Argument(
-        ...,
-        help="Node identifier"
-    ),
+    node_id: str = typer.Argument(..., help="Node identifier"),
     start: str = typer.Option(
         ...,
-        "--start", "-s",
+        "--start",
+        "-s",
         help="Start date (YYYY-MM-DD or ISO timestamp)",
     ),
     end: str = typer.Option(
         ...,
-        "--end", "-e",
+        "--end",
+        "-e",
         help="End date (YYYY-MM-DD or ISO timestamp)",
     ),
 ):
@@ -6058,10 +6161,7 @@ def restatement_add(
 
 @intervals_app.command("restatement-list")
 def restatement_list(
-    node_id: str = typer.Argument(
-        ...,
-        help="Node identifier"
-    ),
+    node_id: str = typer.Argument(..., help="Node identifier"),
 ):
     """List restatement intervals for a node.
 
@@ -6101,10 +6201,7 @@ def restatement_list(
 
 @intervals_app.command("restatement-clear")
 def restatement_clear(
-    node_id: str = typer.Argument(
-        ...,
-        help="Node identifier"
-    ),
+    node_id: str = typer.Argument(..., help="Node identifier"),
 ):
     """Clear all restatement intervals for a node.
 
@@ -6138,18 +6235,17 @@ def restatement_clear(
 
 @intervals_app.command("backfill")
 def intervals_backfill(
-    node_id: str = typer.Argument(
-        ...,
-        help="Node identifier to backfill"
-    ),
+    node_id: str = typer.Argument(..., help="Node identifier to backfill"),
     start: str = typer.Option(
         ...,
-        "--start", "-s",
+        "--start",
+        "-s",
         help="Start date (YYYY-MM-DD or ISO timestamp)",
     ),
     end: str = typer.Option(
         ...,
-        "--end", "-e",
+        "--end",
+        "-e",
         help="End date (YYYY-MM-DD or ISO timestamp)",
     ),
     schedule: str = typer.Option(
@@ -6221,7 +6317,9 @@ def intervals_backfill(
 
 @app.command()
 def migrate_state(
-    backend: str = typer.Option(..., "--backend", "-b", help="Target backend type (file, database)"),
+    backend: str = typer.Option(
+        ..., "--backend", "-b", help="Target backend type (file, database)"
+    ),
     project_path: Path = typer.Option(".", help="Project directory"),
     dry_run: bool = typer.Option(True, help="Preview changes without executing"),
 ):
@@ -6295,7 +6393,7 @@ def migrate_state(
                 status=run_info.status,
                 started_at=run_info.started_at,
                 finished_at=run_info.finished_at,
-                metadata=run_info.metadata or {}
+                metadata=run_info.metadata or {},
             )
 
         # Migrate all node states
@@ -6331,6 +6429,7 @@ def migrate_state(
         project_file = project_path / "seeknal_project.yml"
         if project_file.exists():
             import yaml
+
             with open(project_file) as f:
                 config = yaml.safe_load(f)
             config["state_backend"] = "database"
@@ -6356,32 +6455,22 @@ def lineage(
         None, help="Node to focus on (e.g., transform.clean_orders)"
     ),
     column: Optional[str] = typer.Option(
-        None, "--column", "-c",
-        help="Column to trace lineage for (requires node argument)"
+        None, "--column", "-c", help="Column to trace lineage for (requires node argument)"
     ),
-    project: str = typer.Option(
-        None, "--project", "-p", help="Project name"
-    ),
-    path: Path = typer.Option(
-        Path("."), "--path", help="Project path"
-    ),
+    project: str = typer.Option(None, "--project", "-p", help="Project name"),
+    path: Path = typer.Option(Path("."), "--path", help="Project path"),
     output: Path = typer.Option(
-        None, "--output", "-o",
-        help="Output HTML file path (default: target/lineage.html)"
+        None, "--output", "-o", help="Output HTML file path (default: target/lineage.html)"
     ),
-    no_open: bool = typer.Option(
-        False, "--no-open", help="Don't auto-open browser"
-    ),
+    no_open: bool = typer.Option(False, "--no-open", help="Don't auto-open browser"),
     ascii_output: bool = typer.Option(
         False, "--ascii", help="Print DAG as ASCII tree to stdout instead of HTML"
     ),
     tags: Optional[List[str]] = typer.Option(
-        None, "--tags",
-        help="Show only nodes with these tags (plus upstream deps). OR logic."
+        None, "--tags", help="Show only nodes with these tags (plus upstream deps). OR logic."
     ),
     exclude_tags: Optional[List[str]] = typer.Option(
-        None, "--exclude-tags",
-        help="Hide nodes with these tags from the lineage."
+        None, "--exclude-tags", help="Hide nodes with these tags from the lineage."
     ),
 ):
     """Generate interactive lineage visualization.
@@ -6428,7 +6517,8 @@ def lineage(
             if tags:
                 tag_set = set(tags)
                 tag_matched = {
-                    nid for nid, node in manifest.nodes.items()
+                    nid
+                    for nid, node in manifest.nodes.items()
                     if any(t in tag_set for t in node.tags)
                 }
                 if not tag_matched:
@@ -6438,6 +6528,7 @@ def lineage(
                 # Auto-include all transitive upstream deps via BFS
                 keep_ids = set(tag_matched)
                 from collections import deque
+
                 queue = deque(tag_matched)
                 while queue:
                     current = queue.popleft()
@@ -6450,12 +6541,14 @@ def lineage(
                 exclude_set = set(exclude_tags)
                 if keep_ids is not None:
                     keep_ids = {
-                        nid for nid in keep_ids
+                        nid
+                        for nid in keep_ids
                         if not any(t in exclude_set for t in manifest.nodes[nid].tags)
                     }
                 else:
                     keep_ids = {
-                        nid for nid, node in manifest.nodes.items()
+                        nid
+                        for nid, node in manifest.nodes.items()
                         if not any(t in exclude_set for t in node.tags)
                     }
 
@@ -6472,6 +6565,7 @@ def lineage(
 
         if ascii_output:
             from seeknal.dag.visualize import render_ascii_tree  # ty: ignore[unresolved-import]
+
             tree_text = render_ascii_tree(manifest, focus_node=node_id)
             typer.echo(tree_text)
             return
@@ -6492,26 +6586,15 @@ def lineage(
         raise typer.Exit(code=1)
 
 
-
-
 @app.command()
 def dq(
-    node_id: Optional[str] = typer.Argument(
-        None, help="Focus on a specific profile or rule node"
-    ),
-    project: str = typer.Option(
-        None, "--project", "-p", help="Project name"
-    ),
-    path: Path = typer.Option(
-        Path("."), "--path", help="Project path"
-    ),
+    node_id: Optional[str] = typer.Argument(None, help="Focus on a specific profile or rule node"),
+    project: str = typer.Option(None, "--project", "-p", help="Project name"),
+    path: Path = typer.Option(Path("."), "--path", help="Project path"),
     output: Path = typer.Option(
-        None, "--output", "-o",
-        help="Output HTML file path (default: target/dq_report.html)"
+        None, "--output", "-o", help="Output HTML file path (default: target/dq_report.html)"
     ),
-    no_open: bool = typer.Option(
-        False, "--no-open", help="Don't auto-open browser"
-    ),
+    no_open: bool = typer.Option(False, "--no-open", help="Don't auto-open browser"),
     ascii_output: bool = typer.Option(
         False, "--ascii", help="Print ASCII report to stdout instead of HTML"
     ),
@@ -6527,7 +6610,8 @@ def dq(
     """
     from seeknal.workflow.dag import DAGBuilder, CycleDetectedError, MissingDependencyError
     from seeknal.dag.dq import (
-        DQDataBuilder, DQVisualizationError,
+        DQDataBuilder,
+        DQVisualizationError,
         render_dq_ascii as _render_dq_ascii,
         generate_dq_html as _generate_dq_html,
     )
@@ -6555,6 +6639,7 @@ def dq(
         state = load_state(state_path)
         if state is None:
             from seeknal.workflow.state import RunState
+
             state = RunState()
             _echo_warning("No run state found. Run 'seeknal run' first for DQ data.")
 
@@ -6587,12 +6672,8 @@ def dq(
 
 @entity_app.command("list")
 def entity_list(
-    project: str = typer.Option(
-        None, "--project", "-p", help="Project name"
-    ),
-    path: Path = typer.Option(
-        Path("."), "--path", help="Project path"
-    ),
+    project: str = typer.Option(None, "--project", "-p", help="Project name"),
+    path: Path = typer.Option(Path("."), "--path", help="Project path"),
 ):
     """List all consolidated entities in the feature store.
 
@@ -6607,7 +6688,9 @@ def entity_list(
 
     feature_store_path = path / "target" / "feature_store"
     if not feature_store_path.exists():
-        _echo_info("No consolidated entities found. Run 'seeknal run' with feature group nodes first.")
+        _echo_info(
+            "No consolidated entities found. Run 'seeknal run' with feature group nodes first."
+        )
         return
 
     entities_found = False
@@ -6621,9 +6704,7 @@ def entity_list(
 
         entities_found = True
         fg_count = len(catalog.feature_groups)
-        total_features = sum(
-            len(fg.features) for fg in catalog.feature_groups.values()
-        )
+        total_features = sum(len(fg.features) for fg in catalog.feature_groups.values())
         parquet_exists = (entity_dir / "features.parquet").exists()
         status = "ready" if parquet_exists else "stale"
 
@@ -6635,18 +6716,16 @@ def entity_list(
         )
 
     if not entities_found:
-        _echo_info("No consolidated entities found. Run 'seeknal run' with feature group nodes first.")
+        _echo_info(
+            "No consolidated entities found. Run 'seeknal run' with feature group nodes first."
+        )
 
 
 @entity_app.command("show")
 def entity_show(
     name: str = typer.Argument(..., help="Entity name to inspect"),
-    project: str = typer.Option(
-        None, "--project", "-p", help="Project name"
-    ),
-    path: Path = typer.Option(
-        Path("."), "--path", help="Project path"
-    ),
+    project: str = typer.Option(None, "--project", "-p", help="Project name"),
+    path: Path = typer.Option(Path("."), "--path", help="Project path"),
 ):
     """Display detailed catalog for a consolidated entity.
 
@@ -6691,12 +6770,8 @@ def entity_show(
 
 @app.command()
 def consolidate(
-    project: str = typer.Option(
-        None, "--project", "-p", help="Project name"
-    ),
-    path: Path = typer.Option(
-        Path("."), "--path", help="Project path"
-    ),
+    project: str = typer.Option(None, "--project", "-p", help="Project name"),
+    path: Path = typer.Option(Path("."), "--path", help="Project path"),
     prune: bool = typer.Option(
         False, "--prune", help="Remove stale FG columns not in current manifest"
     ),

--- a/src/seeknal/cli/repl.py
+++ b/src/seeknal/cli/repl.py
@@ -101,6 +101,7 @@ class REPL:
         self._registered_parquets: int = 0
         self._registered_pg: int = 0
         self._registered_iceberg: int = 0
+        self._registered_atlas: int = 0
         self._node_count: int = 0
         self._last_run: Optional[str] = None
         self._load_extensions()
@@ -195,6 +196,12 @@ class REPL:
             self._register_iceberg_catalogs()
         except Exception as e:
             warnings.warn(f"REPL: Failed to attach Iceberg catalogs: {e}")
+
+        # Phase 3b: Attach the Atlas governed catalog (config-gated, best-effort)
+        try:
+            self._register_atlas_catalog()
+        except Exception as e:
+            warnings.warn(f"REPL: Failed to attach Atlas catalog: {e}")
 
         # Phase 1c: Register ask-ingested parquets
         try:
@@ -508,6 +515,61 @@ class REPL:
         )
         self.attached.add("iceberg")
         self._registered_iceberg += 1
+
+    def _register_atlas_catalog(self) -> None:
+        """Phase 3b: Surface the Atlas governed catalog when Atlas is connected.
+
+        When ``ATLAS_API_URL`` is set, count the governed datasets Atlas exposes and —
+        if the Lakekeeper catalog env (``LAKEKEEPER_URL``) is configured — ATTACH the
+        warehouse so the datasets are queryable in the REPL as
+        ``atlas.<namespace>.<table>`` (mirrors the iceberg-source read path). The
+        governance gate still enforces access on every read. Best-effort: any failure
+        leaves the rest of the REPL catalog intact.
+        """
+        import os
+        import warnings
+
+        from seeknal.integrations.atlas_catalog import create_catalog_client_from_env
+
+        client = create_catalog_client_from_env()
+        if client is None:
+            return  # Atlas not configured → nothing to surface
+
+        uri = os.getenv("LAKEKEEPER_URL", "").strip()
+        warehouse = os.getenv("LAKEKEEPER_WAREHOUSE", "").strip()
+        if uri and "atlas" not in self.attached:
+            try:
+                from seeknal.workflow.materialization.operations import (
+                    DuckDBIcebergExtension,
+                )
+
+                DuckDBIcebergExtension.load_extension(self.conn)
+                DuckDBIcebergExtension.configure_s3(self.conn)
+                bearer_token = None
+                try:
+                    bearer_token = DuckDBIcebergExtension.get_oauth2_token()
+                except Exception:
+                    pass  # no OAuth2 configured → try without
+                catalog_uri = uri.rstrip("/")
+                if "/catalog" not in catalog_uri:
+                    catalog_uri = f"{catalog_uri}/catalog"
+                DuckDBIcebergExtension.attach_rest_catalog(
+                    con=self.conn,
+                    catalog_name="atlas",
+                    uri=catalog_uri,
+                    warehouse_path=warehouse,
+                    bearer_token=bearer_token,
+                )
+                self.attached.add("atlas")
+            except Exception as e:
+                warnings.warn(f"REPL: Atlas catalog attach skipped: {e}")
+
+        # Record how many governed datasets Atlas exposes (visibility), regardless of
+        # whether the warehouse could be attached.
+        try:
+            self._registered_atlas = len(client.list_datasets(limit=200))
+        except Exception as e:
+            warnings.warn(f"REPL: Atlas dataset listing failed: {e}")
 
     def execute_oneshot(
         self, sql: str, limit: Optional[int] = None

--- a/src/seeknal/heartbeat/__init__.py
+++ b/src/seeknal/heartbeat/__init__.py
@@ -1,0 +1,8 @@
+"""Heartbeat — polling daemon + smart inbox layer for seeknal.
+
+See `docs/cli/heartbeat.md` for the user-facing reference.
+"""
+
+from seeknal.heartbeat.config import HeartbeatConfig
+
+__all__ = ["HeartbeatConfig"]

--- a/src/seeknal/heartbeat/classifier/__init__.py
+++ b/src/seeknal/heartbeat/classifier/__init__.py
@@ -1,0 +1,27 @@
+"""Smart classifier for the heartbeat (v0.5).
+
+Phase A.5 of the tick loop: each new file is fingerprinted, matched against
+``.seeknal/source_catalog.yml``, and either auto-routed (high-confidence
+catalog match) or quarantined for operator review (low confidence).
+
+The classifier is opt-in via ``classifier.enabled: true`` in HEARTBEAT.md.
+When disabled, the loop falls back to filename-stem routing (v0.4 behavior).
+"""
+
+from seeknal.heartbeat.classifier.models import (
+    ClassificationDecision,
+    ColumnMapping,
+    Fingerprint,
+)
+from seeknal.heartbeat.classifier.fingerprint import compute_fingerprint, similarity
+from seeknal.heartbeat.classifier.catalog import Catalog, CatalogMatch
+
+__all__ = [
+    "ClassificationDecision",
+    "ColumnMapping",
+    "Fingerprint",
+    "compute_fingerprint",
+    "similarity",
+    "Catalog",
+    "CatalogMatch",
+]

--- a/src/seeknal/heartbeat/classifier/catalog.py
+++ b/src/seeknal/heartbeat/classifier/catalog.py
@@ -1,0 +1,223 @@
+"""Source catalog — persistent memory of known source tables.
+
+Stored at ``.seeknal/source_catalog.yml``. Comments preserved on round-trip
+via ruamel.yaml's round-trip parser. Atomic writes via tempfile + os.replace.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+from seeknal.heartbeat.classifier.fingerprint import similarity
+from seeknal.heartbeat.classifier.models import Fingerprint
+from seeknal.utils.path_security import is_insecure_path
+
+logger = logging.getLogger("seeknal.heartbeat.classifier.catalog")
+
+
+@dataclass
+class CatalogEntry:
+    source_table: str
+    fingerprint: Fingerprint
+    canonical_columns: dict[str, dict[str, Any]] = field(default_factory=dict)
+    write_mode: str = "append"
+    business_key: list[str] = field(default_factory=list)
+    last_seen: str = ""
+    confirmed_by: str = ""
+    sample_path: str = ""
+    stale_schema: bool = False
+    confidence_threshold_override: Optional[float] = None
+
+
+@dataclass
+class CatalogMatch:
+    source_table: str
+    confidence: float
+    entry: CatalogEntry
+
+
+def _load_yaml(path: Path) -> Any:
+    """Use ruamel.yaml round-trip if available, else safe_load."""
+    try:
+        from ruamel.yaml import YAML
+
+        yaml_rt = YAML(typ="rt")
+        with open(path, "r") as fh:
+            return yaml_rt.load(fh)
+    except ImportError:
+        import yaml
+
+        with open(path, "r") as fh:
+            return yaml.safe_load(fh)
+
+
+def _dump_yaml(data: Any, fh) -> None:
+    try:
+        from ruamel.yaml import YAML
+
+        yaml_rt = YAML(typ="rt")
+        yaml_rt.dump(data, fh)
+    except ImportError:
+        import yaml
+
+        yaml.safe_dump(data, fh, sort_keys=False)
+
+
+@dataclass
+class Catalog:
+    schema_version: int = 1
+    entries: dict[str, CatalogEntry] = field(default_factory=dict)
+    source_path: Optional[Path] = None
+
+    @classmethod
+    def load(cls, project_root: Path) -> "Catalog":
+        """Load catalog from ``<project_root>/.seeknal/source_catalog.yml``."""
+        path = Path(project_root) / ".seeknal" / "source_catalog.yml"
+        if is_insecure_path(str(path)):
+            raise ValueError(
+                f"Insecure catalog path: {path!s}. "
+                "Use a project-local .seeknal/ directory."
+            )
+        if not path.exists():
+            return cls(source_path=path)
+
+        try:
+            raw = _load_yaml(path)
+        except Exception as exc:  # noqa: BLE001
+            logger.critical(
+                "source_catalog.yml at %s is corrupt (%s); "
+                "renaming to .corrupt and starting empty.",
+                path,
+                exc,
+            )
+            from datetime import datetime, timezone
+
+            ts = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+            try:
+                path.rename(path.with_suffix(f".yml.corrupt.{ts}"))
+            except OSError:
+                pass
+            return cls(source_path=path)
+
+        if raw is None:
+            return cls(source_path=path)
+        if not isinstance(raw, dict):
+            raise ValueError(
+                f"source_catalog.yml at {path} did not parse to a mapping."
+            )
+
+        catalog = cls(source_path=path)
+        catalog.schema_version = int(raw.get("schema_version", 1))
+        for name, body in (raw.get("sources") or {}).items():
+            if not isinstance(body, dict):
+                continue
+            fp_raw = body.get("fingerprint") or {}
+            fp = Fingerprint(
+                column_names=list(fp_raw.get("column_names", []) or []),
+                column_types=list(fp_raw.get("column_types", []) or []),
+                value_regexes=list(fp_raw.get("value_regexes", []) or []),
+                row_count_sample=int(fp_raw.get("row_count_sample", 0) or 0),
+                column_count=int(
+                    fp_raw.get("column_count", len(fp_raw.get("column_names", []) or []))
+                    or 0
+                ),
+            )
+            catalog.entries[name] = CatalogEntry(
+                source_table=name,
+                fingerprint=fp,
+                canonical_columns=dict(body.get("canonical_columns") or {}),
+                write_mode=str(body.get("write_mode", "append")),
+                business_key=list(body.get("business_key") or []),
+                last_seen=str(body.get("last_seen", "") or ""),
+                confirmed_by=str(body.get("confirmed_by", "") or ""),
+                sample_path=str(body.get("sample_path", "") or ""),
+                stale_schema=bool(body.get("stale_schema", False)),
+                confidence_threshold_override=body.get(
+                    "confidence_threshold_override"
+                ),
+            )
+        return catalog
+
+    def save(self, path: Optional[Path] = None) -> Path:
+        target = Path(path or self.source_path)
+        if is_insecure_path(str(target)):
+            raise ValueError(
+                f"Insecure catalog save path: {target!s}. "
+                "Use a project-local .seeknal/ directory."
+            )
+        target.parent.mkdir(parents=True, exist_ok=True)
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "sources": {},
+        }
+        for name, entry in self.entries.items():
+            body: dict[str, Any] = {
+                "fingerprint": {
+                    "column_names": list(entry.fingerprint.column_names),
+                    "column_types": list(entry.fingerprint.column_types),
+                    "value_regexes": list(entry.fingerprint.value_regexes),
+                    "row_count_sample": entry.fingerprint.row_count_sample,
+                    "column_count": entry.fingerprint.column_count,
+                },
+                "canonical_columns": dict(entry.canonical_columns),
+                "write_mode": entry.write_mode,
+                "business_key": list(entry.business_key),
+            }
+            if entry.last_seen:
+                body["last_seen"] = entry.last_seen
+            if entry.confirmed_by:
+                body["confirmed_by"] = entry.confirmed_by
+            if entry.sample_path:
+                body["sample_path"] = entry.sample_path
+            if entry.stale_schema:
+                body["stale_schema"] = True
+            if entry.confidence_threshold_override is not None:
+                body["confidence_threshold_override"] = (
+                    entry.confidence_threshold_override
+                )
+            payload["sources"][name] = body
+
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=".source_catalog.",
+            suffix=".yml.tmp",
+            dir=str(target.parent),
+        )
+        try:
+            with os.fdopen(fd, "w") as fh:
+                _dump_yaml(payload, fh)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp_path, target)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+            raise
+        self.source_path = target
+        return target
+
+    def find_best_match(
+        self, fp: Fingerprint, threshold: float = 0.85
+    ) -> Optional[CatalogMatch]:
+        best: Optional[CatalogMatch] = None
+        for name, entry in self.entries.items():
+            score = similarity(fp, entry.fingerprint)
+            override = entry.confidence_threshold_override or threshold
+            if score >= override:
+                if best is None or score > best.confidence:
+                    best = CatalogMatch(
+                        source_table=name, confidence=score, entry=entry
+                    )
+        return best
+
+    def upsert(self, entry: CatalogEntry) -> None:
+        self.entries[entry.source_table] = entry
+
+
+__all__ = ["Catalog", "CatalogEntry", "CatalogMatch"]

--- a/src/seeknal/heartbeat/classifier/fingerprint.py
+++ b/src/seeknal/heartbeat/classifier/fingerprint.py
@@ -1,0 +1,179 @@
+"""Deterministic fingerprint extraction for a tabular file.
+
+Reads up to the first 1000 rows + the header (no LLM call) and produces a
+:class:`Fingerprint`. Heavy imports are local so the base seeknal install
+doesn't pay the cost when the classifier is disabled.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+from seeknal.heartbeat.classifier.models import Fingerprint
+
+logger = logging.getLogger("seeknal.heartbeat.classifier.fingerprint")
+
+_SAMPLE_ROW_LIMIT = 1000
+
+_VALUE_REGEX_PROBES: list[tuple[str, re.Pattern[str]]] = [
+    ("email", re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")),
+    ("uuid", re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")),
+    ("iso_date", re.compile(r"^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2})?)?$")),
+    ("currency_usd", re.compile(r"^\$?\d+(\.\d{2})?$")),
+    ("phone_e164", re.compile(r"^\+\d{6,15}$")),
+    ("phone_us", re.compile(r"^\(?\d{3}\)?[ -.]?\d{3}[ -.]?\d{4}$")),
+    ("integer", re.compile(r"^-?\d+$")),
+    ("float", re.compile(r"^-?\d+\.\d+$")),
+    ("region_code", re.compile(r"^[A-Z]{2,3}$")),
+]
+
+
+def _normalize_name(name: str) -> str:
+    """Lowercase snake_case."""
+    stripped = name.strip()
+    # camelCase → snake_case
+    snake = re.sub(r"(?<!^)(?=[A-Z])", "_", stripped).lower()
+    # non-word → underscore
+    snake = re.sub(r"[^a-z0-9]+", "_", snake)
+    return snake.strip("_")
+
+
+def _infer_type(values: list[str]) -> str:
+    """Cheap type sniffing from a column's sample values."""
+    if not values:
+        return "string"
+    ints = floats = dates = bools = 0
+    for v in values:
+        v = v.strip()
+        if not v:
+            continue
+        if v.lower() in {"true", "false"}:
+            bools += 1
+        elif _VALUE_REGEX_PROBES[2][1].match(v):  # iso_date
+            dates += 1
+        elif _VALUE_REGEX_PROBES[6][1].match(v):  # integer
+            ints += 1
+        elif _VALUE_REGEX_PROBES[7][1].match(v):  # float
+            floats += 1
+    nonempty = sum(1 for v in values if v.strip())
+    if nonempty == 0:
+        return "string"
+    if dates / nonempty > 0.6:
+        return "date"
+    if bools / nonempty > 0.6:
+        return "bool"
+    if floats / nonempty > 0.6:
+        return "float"
+    if (ints + floats) / nonempty > 0.6:
+        return "int"
+    return "string"
+
+
+def _dominant_regex(values: list[str]) -> str:
+    """Return the regex-probe name matched by the majority of values."""
+    if not values:
+        return ""
+    scores: dict[str, int] = {}
+    nonempty = 0
+    for v in values:
+        s = v.strip()
+        if not s:
+            continue
+        nonempty += 1
+        for name, pat in _VALUE_REGEX_PROBES:
+            if pat.match(s):
+                scores[name] = scores.get(name, 0) + 1
+                break
+    if nonempty == 0:
+        return ""
+    for name, count in sorted(scores.items(), key=lambda kv: -kv[1]):
+        if count / nonempty > 0.6:
+            return name
+    return ""
+
+
+def _read_sample(path: Path) -> tuple[list[str], list[list[str]]]:
+    """Return (header, rows[≤_SAMPLE_ROW_LIMIT]) as strings using DuckDB."""
+    suffix = path.suffix.lower()
+    safe = str(path.resolve()).replace("'", "''")
+    import duckdb  # local
+
+    if suffix in (".csv", ".tsv"):
+        delim = "\\t" if suffix == ".tsv" else ","
+        reader = f"read_csv_auto('{safe}', delim='{delim}', sample_size=-1)"
+    elif suffix in (".json", ".jsonl"):
+        reader = f"read_json_auto('{safe}')"
+    elif suffix == ".parquet":
+        reader = f"read_parquet('{safe}')"
+    else:
+        raise ValueError(f"Unsupported suffix for fingerprint: {suffix}")
+
+    con = duckdb.connect(":memory:")
+    try:
+        desc = con.execute(f"DESCRIBE SELECT * FROM {reader}").fetchall()
+        header = [r[0] for r in desc]
+        rows = con.execute(
+            f"SELECT * FROM {reader} LIMIT {_SAMPLE_ROW_LIMIT}"
+        ).fetchall()
+    finally:
+        con.close()
+
+    string_rows: list[list[str]] = []
+    for row in rows:
+        string_rows.append(["" if v is None else str(v) for v in row])
+    return header, string_rows
+
+
+def compute_fingerprint(path: Path) -> Fingerprint:
+    header, rows = _read_sample(path)
+    column_names = [_normalize_name(h) for h in header]
+    cols: list[list[str]] = [[] for _ in column_names]
+    for row in rows:
+        for i, val in enumerate(row[: len(column_names)]):
+            cols[i].append(val)
+    column_types = [_infer_type(col) for col in cols]
+    value_regexes = [_dominant_regex(col) for col in cols]
+    return Fingerprint(
+        column_names=column_names,
+        column_types=column_types,
+        value_regexes=value_regexes,
+        row_count_sample=len(rows),
+        column_count=len(column_names),
+    )
+
+
+def _jaccard(a: list[str], b: list[str]) -> float:
+    sa, sb = set(filter(None, a)), set(filter(None, b))
+    if not sa and not sb:
+        return 1.0
+    union = sa | sb
+    if not union:
+        return 0.0
+    return len(sa & sb) / len(union)
+
+
+def similarity(a: Fingerprint, b: Fingerprint) -> float:
+    """Weighted similarity ∈ [0, 1].
+
+    Components: column-name Jaccard (50%) + type-overlap (25%) +
+    regex-Jaccard (25%). Embedding-based scoring is a soft upgrade that
+    activates if sentence-transformers is installed.
+    """
+    name_jaccard = _jaccard(a.column_names, b.column_names)
+
+    type_overlap = 0.0
+    common = set(a.column_names) & set(b.column_names)
+    if common:
+        a_types = dict(zip(a.column_names, a.column_types))
+        b_types = dict(zip(b.column_names, b.column_types))
+        matches = sum(1 for c in common if a_types.get(c) == b_types.get(c))
+        type_overlap = matches / len(common)
+    regex_jaccard = _jaccard(a.value_regexes, b.value_regexes)
+
+    base = 0.5 * name_jaccard + 0.25 * type_overlap + 0.25 * regex_jaccard
+    return max(0.0, min(1.0, base))
+
+
+__all__ = ["compute_fingerprint", "similarity", "_normalize_name", "_infer_type"]

--- a/src/seeknal/heartbeat/classifier/llm_classifier.py
+++ b/src/seeknal/heartbeat/classifier/llm_classifier.py
@@ -1,0 +1,161 @@
+"""LLM-backed classifier (optional, requires ``pip install seeknal[classifier]``)."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Optional, Protocol
+
+from seeknal.heartbeat.classifier.models import Fingerprint
+
+logger = logging.getLogger("seeknal.heartbeat.classifier.llm")
+
+
+@dataclass
+class LLMProposal:
+    target_table: str
+    confidence: float
+    column_mapping: dict[str, str] = field(default_factory=dict)
+    reasoning: str = ""
+    concerns: list[str] = field(default_factory=list)
+    call_id: str = ""
+
+
+class LLMClassifier(Protocol):
+    """Provider-pluggable classifier."""
+
+    def classify(
+        self,
+        fp: Fingerprint,
+        catalog_summary: str,
+        file_sample_preview: str,
+    ) -> LLMProposal:
+        ...
+
+
+class NullLLMClassifier:
+    """No-op classifier — returns a zero-confidence proposal."""
+
+    def classify(
+        self,
+        fp: Fingerprint,
+        catalog_summary: str,
+        file_sample_preview: str,
+    ) -> LLMProposal:  # pragma: no cover — trivial
+        del fp, catalog_summary, file_sample_preview
+        return LLMProposal(
+            target_table="",
+            confidence=0.0,
+            concerns=["LLM classifier disabled"],
+        )
+
+
+def _require_anthropic():
+    try:
+        import anthropic  # type: ignore  # noqa: F401
+    except ImportError as exc:
+        raise RuntimeError(
+            "Classifier requires `pip install seeknal[classifier]` "
+            "(anthropic SDK not found). "
+            "Disable the classifier in HEARTBEAT.md (classifier.enabled: false) "
+            "to run without it."
+        ) from exc
+
+
+class AnthropicLLMClassifier:
+    """Anthropic Claude Haiku wrapper. Lazy SDK import for soft dependency.
+
+    Behavior on outage/timeout: raises RuntimeError; the router catches and
+    falls back to the deterministic default.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: Optional[str] = None,
+        model: str = "claude-haiku-4-5",
+        timeout_s: float = 30.0,
+    ):
+        self.api_key = api_key
+        self.model = model
+        self.timeout_s = timeout_s
+
+    def classify(
+        self,
+        fp: Fingerprint,
+        catalog_summary: str,
+        file_sample_preview: str,
+    ) -> LLMProposal:
+        _require_anthropic()
+        import anthropic  # type: ignore
+
+        client = anthropic.Anthropic(api_key=self.api_key, timeout=self.timeout_s)
+        prompt = self._build_prompt(fp, catalog_summary, file_sample_preview)
+        try:
+            response = client.messages.create(
+                model=self.model,
+                max_tokens=1024,
+                messages=[{"role": "user", "content": prompt}],
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Anthropic call failed: %s", exc)
+            raise RuntimeError(f"LLM provider error: {exc}") from exc
+
+        call_id = getattr(response, "id", "") or ""
+        text = ""
+        for block in getattr(response, "content", []) or []:
+            text += getattr(block, "text", "")
+        proposal = self._parse_response(text, call_id)
+        return proposal
+
+    def _build_prompt(
+        self,
+        fp: Fingerprint,
+        catalog_summary: str,
+        file_sample_preview: str,
+    ) -> str:
+        return (
+            "You are a strict data-routing classifier. Decide whether the file "
+            "matches one of the known source tables in the catalog, or whether "
+            "it should be quarantined for human review.\n\n"
+            f"FILE FINGERPRINT:\n"
+            f"  columns: {fp.column_names}\n"
+            f"  types:   {fp.column_types}\n"
+            f"  regexes: {fp.value_regexes}\n"
+            f"  rows_in_sample: {fp.row_count_sample}\n\n"
+            f"FILE PREVIEW (first rows):\n{file_sample_preview}\n\n"
+            f"CATALOG SUMMARY:\n{catalog_summary}\n\n"
+            "Respond ONLY with a JSON object: "
+            '{"target_table": "<name or empty>", "confidence": <0..1>, '
+            '"column_mapping": {"<file_col>": "<target_col>"}, '
+            '"reasoning": "<short>", "concerns": ["..."]}'
+        )
+
+    def _parse_response(self, text: str, call_id: str) -> LLMProposal:
+        import json
+        import re
+
+        json_match = re.search(r"\{.*\}", text, re.DOTALL)
+        if not json_match:
+            raise RuntimeError("LLM response did not contain JSON")
+        try:
+            payload = json.loads(json_match.group(0))
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"LLM response JSON parse failed: {exc}") from exc
+
+        return LLMProposal(
+            target_table=str(payload.get("target_table", "") or ""),
+            confidence=float(payload.get("confidence", 0.0)),
+            column_mapping=dict(payload.get("column_mapping") or {}),
+            reasoning=str(payload.get("reasoning", "") or ""),
+            concerns=list(payload.get("concerns", []) or []),
+            call_id=call_id,
+        )
+
+
+__all__ = [
+    "AnthropicLLMClassifier",
+    "LLMClassifier",
+    "LLMProposal",
+    "NullLLMClassifier",
+]

--- a/src/seeknal/heartbeat/classifier/mapper.py
+++ b/src/seeknal/heartbeat/classifier/mapper.py
@@ -1,0 +1,131 @@
+"""Column mapper — Pass 1 deterministic, Pass 2 LLM-assisted (optional).
+
+Pass 1 is always run and covers:
+- Exact match.
+- Snake_case / camelCase normalization.
+- Catalog alias lookup.
+- Levenshtein distance ≤ 2 (cheap stdlib fallback).
+
+Pass 2 (LLM) is invoked only when Pass 1 leaves >10% of the target schema
+unmapped AND ``classifier.enabled`` is true. Unit-sensitive numeric columns
+are never auto-mapped regardless of confidence — they force a quarantine.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Iterable, Optional
+
+from seeknal.heartbeat.classifier.models import ColumnMapping
+
+DEFAULT_UNIT_SENSITIVE_KEYWORDS = [
+    # English
+    "amount", "total", "revenue", "price", "cost", "weight", "duration",
+    "tax", "fee", "discount",
+    # Indonesian
+    "jumlah", "harga", "biaya", "pendapatan", "berat", "durasi", "pajak", "diskon",
+]
+
+
+def _normalize(name: str) -> str:
+    snake = re.sub(r"(?<!^)(?=[A-Z])", "_", name.strip()).lower()
+    return re.sub(r"[^a-z0-9]+", "_", snake).strip("_")
+
+
+def _levenshtein(a: str, b: str) -> int:
+    if a == b:
+        return 0
+    if len(a) > len(b):
+        a, b = b, a
+    if not a:
+        return len(b)
+    previous = list(range(len(a) + 1))
+    for j, bc in enumerate(b, 1):
+        current = [j]
+        for i, ac in enumerate(a, 1):
+            cost = 0 if ac == bc else 1
+            current.append(min(
+                current[-1] + 1,
+                previous[i] + 1,
+                previous[i - 1] + cost,
+            ))
+        previous = current
+    return previous[-1]
+
+
+@dataclass
+class Mapper:
+    """Maps file column names to target schema column names."""
+
+    unit_sensitive_keywords: list[str] = field(
+        default_factory=lambda: list(DEFAULT_UNIT_SENSITIVE_KEYWORDS)
+    )
+
+    def map_columns(
+        self,
+        file_columns: Iterable[str],
+        target_columns: Iterable[str],
+        *,
+        aliases: Optional[dict[str, list[str]]] = None,
+    ) -> ColumnMapping:
+        """Run Pass 1 deterministic mapping."""
+        aliases = aliases or {}
+        alias_lookup: dict[str, str] = {}
+        for canonical, alts in aliases.items():
+            for alt in alts:
+                alias_lookup[_normalize(alt)] = canonical
+
+        target_norm = {_normalize(c): c for c in target_columns}
+
+        mapping: dict[str, str] = {}
+        claimed: set[str] = set()
+        unmapped: list[str] = []
+        for col in file_columns:
+            norm = _normalize(col)
+            if norm in target_norm and target_norm[norm] not in claimed:
+                mapping[col] = target_norm[norm]
+                claimed.add(target_norm[norm])
+                continue
+            if norm in alias_lookup and alias_lookup[norm] not in claimed:
+                mapping[col] = alias_lookup[norm]
+                claimed.add(alias_lookup[norm])
+                continue
+            # Fuzzy: Levenshtein ≤ 2
+            best: Optional[str] = None
+            best_dist = 3
+            for tnorm, tcol in target_norm.items():
+                if tcol in claimed:
+                    continue
+                dist = _levenshtein(norm, tnorm)
+                if dist < best_dist:
+                    best_dist = dist
+                    best = tcol
+            if best is not None and best_dist <= 2:
+                mapping[col] = best
+                claimed.add(best)
+                continue
+            unmapped.append(col)
+
+        unmapped_target = [
+            t for t in target_columns if t not in set(mapping.values())
+        ]
+
+        unit_uncertain = any(
+            any(kw in _normalize(target_col) for kw in self.unit_sensitive_keywords)
+            for target_col in mapping.values()
+        )
+
+        return ColumnMapping(
+            mapping=mapping,
+            unmapped_file_cols=unmapped,
+            unmapped_target_cols=unmapped_target,
+            has_unit_uncertainty=unit_uncertain,
+        )
+
+    def has_unit_sensitive(self, target_col: str) -> bool:
+        norm = _normalize(target_col)
+        return any(kw in norm for kw in self.unit_sensitive_keywords)
+
+
+__all__ = ["Mapper", "DEFAULT_UNIT_SENSITIVE_KEYWORDS"]

--- a/src/seeknal/heartbeat/classifier/models.py
+++ b/src/seeknal/heartbeat/classifier/models.py
@@ -1,0 +1,107 @@
+"""Classifier dataclasses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal, Optional
+
+
+@dataclass
+class Fingerprint:
+    column_names: list[str]
+    column_types: list[str]
+    value_regexes: list[str]
+    row_count_sample: int = 0
+    column_count: int = 0
+
+
+@dataclass
+class ColumnMapping:
+    mapping: dict[str, str] = field(default_factory=dict)  # file_col -> target_col
+    unmapped_file_cols: list[str] = field(default_factory=list)
+    unmapped_target_cols: list[str] = field(default_factory=list)
+    has_unit_uncertainty: bool = False
+
+    @property
+    def coverage(self) -> float:
+        total = len(self.mapping) + len(self.unmapped_file_cols)
+        if total == 0:
+            return 1.0
+        return len(self.mapping) / total
+
+
+@dataclass
+class ClassificationDecision:
+    file: Path
+    outcome: Literal["routed", "quarantined", "default_fallback"]
+    target_table: str
+    source: Literal["fingerprint", "llm", "fallback"] = "fallback"
+    confidence: float = 0.0
+    mapping: ColumnMapping = field(default_factory=ColumnMapping)
+    write_mode: Literal["append", "upsert", "overwrite"] = "append"
+    business_key: list[str] = field(default_factory=list)
+    llm_call_id: Optional[str] = None
+    reason: Optional[str] = None  # populated for quarantine
+
+    @classmethod
+    def default_for(cls, path: Path) -> "ClassificationDecision":
+        """v0.4 fallback: filename-stem → ``ingested.<stem>``."""
+        stem = path.stem.lower()
+        return cls(
+            file=path,
+            outcome="default_fallback",
+            target_table=f"ingested.{stem}",
+            source="fallback",
+            confidence=0.0,
+        )
+
+    @classmethod
+    def routed(
+        cls,
+        *,
+        file: Path,
+        target_table: str,
+        mapping: ColumnMapping,
+        source: Literal["fingerprint", "llm"],
+        confidence: float,
+        write_mode: Literal["append", "upsert", "overwrite"] = "append",
+        business_key: Optional[list[str]] = None,
+        llm_call_id: Optional[str] = None,
+    ) -> "ClassificationDecision":
+        return cls(
+            file=file,
+            outcome="routed",
+            target_table=target_table,
+            mapping=mapping,
+            source=source,
+            confidence=confidence,
+            write_mode=write_mode,
+            business_key=business_key or [],
+            llm_call_id=llm_call_id,
+        )
+
+    @classmethod
+    def quarantined(
+        cls,
+        *,
+        file: Path,
+        reason: str,
+        proposed_table: str = "",
+        confidence: float = 0.0,
+        llm_call_id: Optional[str] = None,
+        mapping: Optional[ColumnMapping] = None,
+    ) -> "ClassificationDecision":
+        return cls(
+            file=file,
+            outcome="quarantined",
+            target_table=proposed_table,
+            source="llm" if llm_call_id else "fingerprint",
+            confidence=confidence,
+            mapping=mapping or ColumnMapping(),
+            llm_call_id=llm_call_id,
+            reason=reason,
+        )
+
+
+__all__ = ["ClassificationDecision", "ColumnMapping", "Fingerprint"]

--- a/src/seeknal/heartbeat/classifier/router.py
+++ b/src/seeknal/heartbeat/classifier/router.py
@@ -1,0 +1,200 @@
+"""ClassificationRouter — Phase A.5 orchestrator.
+
+Inputs: a freshly-discovered file path.
+Outputs: a :class:`ClassificationDecision` (routed / quarantined / fallback).
+
+The router runs:
+1. Fingerprint extraction (always; deterministic).
+2. Catalog fuzzy match (deterministic).
+3. Pass 1 column mapping (deterministic; uses catalog aliases).
+4. If catalog match is high-confidence AND mapping covers ≥95% AND no
+   unit-sensitive uncertainty → ROUTED.
+5. Else if classifier disabled or LLM unavailable → DEFAULT_FALLBACK.
+6. Else LLM proposal; high-confidence + no concerns → ROUTED.
+7. Otherwise QUARANTINED.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from seeknal.heartbeat.classifier.catalog import Catalog, CatalogEntry
+from seeknal.heartbeat.classifier.fingerprint import compute_fingerprint
+from seeknal.heartbeat.classifier.llm_classifier import (
+    LLMClassifier,
+    LLMProposal,
+    NullLLMClassifier,
+)
+from seeknal.heartbeat.classifier.mapper import Mapper
+from seeknal.heartbeat.classifier.models import (
+    ClassificationDecision,
+    ColumnMapping,
+    Fingerprint,
+)
+
+logger = logging.getLogger("seeknal.heartbeat.classifier.router")
+
+
+@dataclass
+class ClassifierConfig:
+    enabled: bool = False
+    provider: str = "anthropic"
+    model: str = "claude-haiku-4-5"
+    api_key_env: str = "ANTHROPIC_API_KEY"
+    confidence_threshold: float = 0.85
+    catalog_path: Optional[Path] = None
+    unit_sensitive_keywords: Optional[list[str]] = None
+
+
+class ClassificationRouter:
+    def __init__(
+        self,
+        *,
+        config: ClassifierConfig,
+        catalog: Catalog,
+        llm: Optional[LLMClassifier] = None,
+        mapper: Optional[Mapper] = None,
+    ):
+        self._config = config
+        self._catalog = catalog
+        self._llm = llm or NullLLMClassifier()
+        keywords = (
+            config.unit_sensitive_keywords
+            if config.unit_sensitive_keywords is not None
+            else None
+        )
+        if keywords is None:
+            self._mapper = mapper or Mapper()
+        else:
+            self._mapper = mapper or Mapper(unit_sensitive_keywords=list(keywords))
+
+    def classify(self, path: Path) -> ClassificationDecision:
+        if not self._config.enabled:
+            return ClassificationDecision.default_for(path)
+        try:
+            fp = compute_fingerprint(path)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Fingerprint failed for %s: %s", path, exc)
+            return ClassificationDecision.default_for(path)
+
+        match = self._catalog.find_best_match(
+            fp, threshold=self._config.confidence_threshold
+        )
+        if match is not None:
+            mapping = self._build_mapping(fp, match.entry)
+            if (
+                mapping.coverage >= 0.95
+                and not mapping.has_unit_uncertainty
+            ):
+                return ClassificationDecision.routed(
+                    file=path,
+                    target_table=match.source_table,
+                    mapping=mapping,
+                    source="fingerprint",
+                    confidence=match.confidence,
+                    write_mode=_to_write_mode(match.entry.write_mode),
+                    business_key=list(match.entry.business_key),
+                )
+
+        # Below catalog threshold (or unit-sensitive uncertainty) → LLM
+        try:
+            proposal = self._llm.classify(
+                fp,
+                catalog_summary=self._summarize_catalog(),
+                file_sample_preview="",
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("LLM classify failed (%s); falling back.", exc)
+            return ClassificationDecision.default_for(path)
+
+        return self._decide_from_proposal(path, fp, proposal)
+
+    def _build_mapping(
+        self, fp: Fingerprint, entry: CatalogEntry
+    ) -> ColumnMapping:
+        target_columns = list(entry.canonical_columns.keys()) or list(
+            entry.fingerprint.column_names
+        )
+        aliases: dict[str, list[str]] = {}
+        for canonical, body in entry.canonical_columns.items():
+            if isinstance(body, dict):
+                aliases[canonical] = list(body.get("aliases") or [])
+        return self._mapper.map_columns(
+            file_columns=fp.column_names,
+            target_columns=target_columns,
+            aliases=aliases,
+        )
+
+    def _summarize_catalog(self) -> str:
+        lines: list[str] = []
+        for name, entry in self._catalog.entries.items():
+            lines.append(
+                f"- {name}: cols={entry.fingerprint.column_names[:8]}"
+            )
+        return "\n".join(lines) or "(empty)"
+
+    def _decide_from_proposal(
+        self,
+        path: Path,
+        fp: Fingerprint,
+        proposal: LLMProposal,
+    ) -> ClassificationDecision:
+        if not proposal.target_table:
+            return ClassificationDecision.quarantined(
+                file=path,
+                reason="LLM did not propose a target table",
+                confidence=proposal.confidence,
+                llm_call_id=proposal.call_id,
+            )
+
+        # Unit-sensitive check on the proposed mapping.
+        unit_keywords = self._mapper.unit_sensitive_keywords
+        unit_concern = any(
+            any(kw in tgt.lower() for kw in unit_keywords)
+            for tgt in proposal.column_mapping.values()
+        )
+
+        threshold = self._config.confidence_threshold
+        if (
+            proposal.confidence < threshold
+            or proposal.concerns
+            or unit_concern
+        ):
+            reason_parts: list[str] = []
+            if proposal.confidence < threshold:
+                reason_parts.append("below_threshold")
+            if proposal.concerns:
+                reason_parts.append("has_concerns")
+            if unit_concern:
+                reason_parts.append("unit_sensitive_columns")
+            return ClassificationDecision.quarantined(
+                file=path,
+                reason=";".join(reason_parts),
+                proposed_table=proposal.target_table,
+                confidence=proposal.confidence,
+                llm_call_id=proposal.call_id,
+                mapping=ColumnMapping(mapping=dict(proposal.column_mapping)),
+            )
+
+        mapping = ColumnMapping(mapping=dict(proposal.column_mapping))
+        return ClassificationDecision.routed(
+            file=path,
+            target_table=proposal.target_table,
+            mapping=mapping,
+            source="llm",
+            confidence=proposal.confidence,
+            llm_call_id=proposal.call_id,
+        )
+
+
+def _to_write_mode(value: str):
+    v = (value or "append").lower()
+    if v in {"append", "upsert", "overwrite"}:
+        return v  # type: ignore[return-value]
+    return "append"
+
+
+__all__ = ["ClassificationRouter", "ClassifierConfig"]

--- a/src/seeknal/heartbeat/config.py
+++ b/src/seeknal/heartbeat/config.py
@@ -1,0 +1,232 @@
+"""HeartbeatConfig — loads HEARTBEAT.md project-level daemon config.
+
+The config file lives at ``<project_root>/HEARTBEAT.md``. The body is either
+pure YAML, or contains exactly one fenced ``` ```yaml ... ``` `` block.
+Front-matter is not supported (keeps the parser simple).
+
+Resolution rules:
+- Missing file → defaults + log warning.
+- ``ingested_target`` falls back to ``profiles.yml`` source_defaults.ingested.target,
+  then ``"parquet"``.
+- ``project_name`` priority: explicit key → ``seeknal_project.yml`` name → directory name.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+from seeknal.utils.path_security import is_insecure_path
+
+logger = logging.getLogger("seeknal.heartbeat.config")
+
+DEFAULT_INTERVAL_SECONDS = 60
+DEFAULT_INBOX_FOLDERS = ("inbox",)
+DEFAULT_QUARANTINE_DIR = "target/heartbeat/quarantine"
+SUPPORTED_INGESTED_TARGETS = ("parquet", "iceberg")
+
+_INTERVAL_RE = re.compile(r"^\s*(\d+)\s*([smh]?)\s*$", re.IGNORECASE)
+_FENCED_YAML_RE = re.compile(r"```yaml\s*\n(.*?)\n```", re.DOTALL)
+
+
+def _parse_interval(value: Any) -> int:
+    """Parse "30s"/"2m"/"1h"/"0s" or a raw int → seconds. Reject negatives."""
+    if isinstance(value, bool):
+        raise ValueError(f"Invalid interval (bool): {value!r}")
+    if isinstance(value, int):
+        if value < 0:
+            raise ValueError(f"Interval must be >= 0, got {value}")
+        return value
+    if isinstance(value, str):
+        match = _INTERVAL_RE.match(value)
+        if not match:
+            raise ValueError(
+                f"Invalid interval '{value}'. Expected e.g. '30s', '2m', '1h', '0s'."
+            )
+        num = int(match.group(1))
+        suffix = match.group(2).lower()
+        if suffix in ("", "s"):
+            return num
+        if suffix == "m":
+            return num * 60
+        if suffix == "h":
+            return num * 3600
+        raise ValueError(f"Invalid interval suffix '{suffix}'")
+    raise ValueError(f"Interval must be int or str, got {type(value).__name__}")
+
+
+def _parse_heartbeat_body(text: str) -> dict[str, Any]:
+    """Parse HEARTBEAT.md body. Pure YAML, or single fenced ```yaml block."""
+    stripped = text.strip()
+    if not stripped:
+        return {}
+    fenced_match = _FENCED_YAML_RE.search(stripped)
+    if fenced_match:
+        yaml_text = fenced_match.group(1)
+    else:
+        yaml_text = stripped
+    try:
+        data = yaml.safe_load(yaml_text)
+    except yaml.YAMLError as exc:
+        raise yaml.YAMLError(f"HEARTBEAT.md parse error: {exc}") from exc
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"HEARTBEAT.md must parse to a mapping, got {type(data).__name__}"
+        )
+    return data
+
+
+def _resolve_project_name(
+    project_root: Path,
+    explicit: Optional[str],
+) -> str:
+    if explicit:
+        return str(explicit)
+    project_yml = project_root / "seeknal_project.yml"
+    if project_yml.exists():
+        try:
+            with open(project_yml, "r") as fh:
+                pdata = yaml.safe_load(fh) or {}
+            name = pdata.get("name") if isinstance(pdata, dict) else None
+            if name:
+                return str(name)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Failed to read project name from %s: %s", project_yml, exc
+            )
+    return project_root.name
+
+
+@dataclass
+class HeartbeatConfig:
+    """Parsed HEARTBEAT.md daemon config.
+
+    Attributes:
+        interval_seconds: Loop interval. ``0`` disables ``start`` (tick still works).
+        inbox_folders: List of folders (relative to project root or absolute).
+        ingested_target: ``"parquet"`` | ``"iceberg"`` | ``None`` (use profile fallback).
+        enabled: Master toggle. ``False`` → ``start`` exits with a message.
+        quarantine_dir: Where bad files go (Path).
+        project_name: Resolved at load time.
+        profile_path: Path to profiles.yml override (None → ProfileLoader default).
+    """
+
+    interval_seconds: int = DEFAULT_INTERVAL_SECONDS
+    inbox_folders: list[Path] = field(
+        default_factory=lambda: [Path(p) for p in DEFAULT_INBOX_FOLDERS]
+    )
+    ingested_target: Optional[str] = None
+    enabled: bool = True
+    quarantine_dir: Path = field(default_factory=lambda: Path(DEFAULT_QUARANTINE_DIR))
+    project_name: str = ""
+    profile_path: Optional[Path] = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def load(
+        cls,
+        project_root: Path,
+        profile_loader: Optional[Any] = None,
+    ) -> "HeartbeatConfig":
+        """Load HEARTBEAT.md from ``project_root`` and resolve fallbacks.
+
+        Args:
+            project_root: Directory containing HEARTBEAT.md.
+            profile_loader: ProfileLoader instance used for ``ingested_target``
+                fallback via ``load_source_defaults("ingested")``.
+        """
+        project_root = Path(project_root).expanduser().resolve()
+        config_path = project_root / "HEARTBEAT.md"
+        data: dict[str, Any]
+        if not config_path.exists():
+            logger.warning(
+                "HEARTBEAT.md not found at %s; using defaults", config_path
+            )
+            data = {}
+        else:
+            with open(config_path, "r") as fh:
+                data = _parse_heartbeat_body(fh.read())
+
+        interval_raw = data.get("interval", DEFAULT_INTERVAL_SECONDS)
+        interval_seconds = _parse_interval(interval_raw)
+
+        enabled = bool(data.get("enabled", True))
+
+        inbox_raw = data.get("inbox_folders") or list(DEFAULT_INBOX_FOLDERS)
+        if isinstance(inbox_raw, str):
+            inbox_raw = [inbox_raw]
+        if not isinstance(inbox_raw, list):
+            raise ValueError("`inbox_folders` must be a list of paths")
+        inbox_folders = [Path(p) for p in inbox_raw]
+        # Security check on each folder
+        for folder in inbox_folders:
+            folder_abs = folder if folder.is_absolute() else (project_root / folder)
+            if is_insecure_path(str(folder_abs)):
+                raise ValueError(
+                    f"Insecure inbox folder: {folder_abs!s}. "
+                    "Use a secure location (e.g. project-local inbox/)."
+                )
+
+        target = data.get("ingested_target")
+        if target is not None and target not in SUPPORTED_INGESTED_TARGETS:
+            raise ValueError(
+                f"Unknown ingested_target '{target}'. "
+                f"Accepted: {', '.join(SUPPORTED_INGESTED_TARGETS)}"
+            )
+
+        if target is None and profile_loader is not None:
+            try:
+                defaults = profile_loader.load_source_defaults("ingested") or {}
+                target = defaults.get("target")
+                if target is not None and target not in SUPPORTED_INGESTED_TARGETS:
+                    raise ValueError(
+                        f"Unknown ingested_target '{target}' in profile. "
+                        f"Accepted: {', '.join(SUPPORTED_INGESTED_TARGETS)}"
+                    )
+            except ValueError:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Could not read source_defaults.ingested.target from profile: %s",
+                    exc,
+                )
+                target = None
+
+        if target is None:
+            target = "parquet"
+
+        quarantine_raw = data.get("quarantine_dir", DEFAULT_QUARANTINE_DIR)
+        quarantine_dir = Path(quarantine_raw)
+        quarantine_abs = (
+            quarantine_dir
+            if quarantine_dir.is_absolute()
+            else (project_root / quarantine_dir)
+        )
+        if is_insecure_path(str(quarantine_abs)):
+            raise ValueError(
+                f"Insecure quarantine_dir: {quarantine_abs!s}. "
+                "Use a project-local path (e.g. target/heartbeat/quarantine)."
+            )
+
+        project_name = _resolve_project_name(project_root, data.get("project_name"))
+
+        profile_raw = data.get("profile_path")
+        profile_path = Path(profile_raw) if profile_raw else None
+
+        return cls(
+            interval_seconds=interval_seconds,
+            inbox_folders=inbox_folders,
+            ingested_target=target,
+            enabled=enabled,
+            quarantine_dir=quarantine_dir,
+            project_name=project_name,
+            profile_path=profile_path,
+            raw=data,
+        )

--- a/src/seeknal/heartbeat/inbox_state.py
+++ b/src/seeknal/heartbeat/inbox_state.py
@@ -1,0 +1,219 @@
+"""InboxState — change detection for the heartbeat polling daemon.
+
+Persists per-file checksum + status at ``target/heartbeat/inbox_state.json``.
+Atomic writes via tempfile + os.replace.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Optional
+
+from seeknal.utils.path_security import is_insecure_path
+
+logger = logging.getLogger("seeknal.heartbeat.inbox_state")
+
+_CHUNK_SIZE = 1024 * 1024  # 1 MiB
+_LARGE_FILE_BYTES = 100 * 1024 * 1024  # 100 MiB log threshold
+_VALID_STATUSES = {"ok", "quarantined", "failed"}
+
+
+@dataclass
+class InboxFileRecord:
+    """Per-file state snapshot keyed by absolute path."""
+
+    path: str
+    checksum_sha256: str
+    size_bytes: int
+    mtime: float
+    ingested_at: str
+    target_table: str
+    last_status: str = "ok"
+
+    def __post_init__(self) -> None:
+        if self.last_status not in _VALID_STATUSES:
+            raise ValueError(
+                f"Invalid last_status '{self.last_status}'. "
+                f"Expected one of {sorted(_VALID_STATUSES)}."
+            )
+
+
+def _compute_sha256(path: Path) -> tuple[str, int]:
+    """SHA-256 + byte count, streaming the file."""
+    hasher = hashlib.sha256()
+    size = 0
+    with open(path, "rb") as fh:
+        while True:
+            chunk = fh.read(_CHUNK_SIZE)
+            if not chunk:
+                break
+            hasher.update(chunk)
+            size += len(chunk)
+    if size > _LARGE_FILE_BYTES:
+        logger.info(
+            "Hashed large file %s (%.1f MB)",
+            path,
+            size / (1024 * 1024),
+        )
+    return hasher.hexdigest(), size
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class InboxState:
+    """Persistent record of which inbox files have been seen / ingested."""
+
+    def __init__(self, state_path: Path):
+        state_path = Path(state_path).expanduser()
+        # Path security check on the state file location
+        if is_insecure_path(str(state_path)):
+            raise ValueError(
+                f"Insecure InboxState path: {state_path!s}. "
+                "Use a project-local target/heartbeat/inbox_state.json."
+            )
+        self._state_path = state_path
+        self._records: dict[str, InboxFileRecord] = {}
+
+    @property
+    def state_path(self) -> Path:
+        return self._state_path
+
+    @classmethod
+    def load(cls, state_path: Path) -> "InboxState":
+        state = cls(state_path)
+        if state._state_path.exists():
+            try:
+                with open(state._state_path, "r") as fh:
+                    raw = json.load(fh)
+            except json.JSONDecodeError as exc:
+                logger.warning(
+                    "InboxState file %s is corrupt (%s); starting empty.",
+                    state._state_path,
+                    exc,
+                )
+                return state
+            if not isinstance(raw, dict):
+                logger.warning(
+                    "InboxState file %s did not contain a JSON object; starting empty.",
+                    state._state_path,
+                )
+                return state
+            for key, entry in raw.items():
+                if not isinstance(entry, dict):
+                    continue
+                try:
+                    state._records[key] = InboxFileRecord(**entry)
+                except (TypeError, ValueError) as exc:
+                    logger.warning(
+                        "Skipping malformed inbox_state entry %s: %s", key, exc
+                    )
+        return state
+
+    def save(self) -> None:
+        """Atomic write: serialize to a temp file in the same dir then os.replace."""
+        self._state_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {key: asdict(rec) for key, rec in self._records.items()}
+        directory = str(self._state_path.parent)
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=".inbox_state.", suffix=".json.tmp", dir=directory
+        )
+        try:
+            with os.fdopen(fd, "w") as fh:
+                json.dump(payload, fh, indent=2, sort_keys=True)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp_path, self._state_path)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+            raise
+
+    def get(self, path: Path) -> Optional[InboxFileRecord]:
+        return self._records.get(str(path.resolve()))
+
+    def all_records(self) -> list[InboxFileRecord]:
+        return list(self._records.values())
+
+    def scan(self, folders: Iterable[Path]) -> list[Path]:
+        """Return paths in ``folders`` whose checksum is new or changed.
+
+        Quarantined entries (``last_status == 'quarantined'``) are not re-emitted
+        unless their checksum changes (the file was replaced).
+        """
+        candidates: list[Path] = []
+        for folder in folders:
+            folder = Path(folder).expanduser()
+            if not folder.exists() or not folder.is_dir():
+                continue
+            for entry in sorted(folder.iterdir()):
+                if not entry.is_file():
+                    continue
+                if entry.name.startswith("."):
+                    continue
+                candidates.append(entry.resolve())
+
+        new_or_changed: list[Path] = []
+        for path in candidates:
+            try:
+                checksum, size = _compute_sha256(path)
+            except OSError as exc:
+                logger.warning("Skipping unreadable inbox file %s: %s", path, exc)
+                continue
+            key = str(path)
+            existing = self._records.get(key)
+            if existing is None or existing.checksum_sha256 != checksum:
+                new_or_changed.append(path)
+                # remember size for the change handler so it doesn't re-hash
+                self._pending_meta = getattr(self, "_pending_meta", {})
+                self._pending_meta[key] = (checksum, size, path.stat().st_mtime)
+        return new_or_changed
+
+    def _meta(self, path: Path) -> tuple[str, int, float]:
+        key = str(path)
+        pending = getattr(self, "_pending_meta", {})
+        if key in pending:
+            return pending[key]
+        checksum, size = _compute_sha256(path)
+        return checksum, size, path.stat().st_mtime
+
+    def mark_ingested(
+        self,
+        path: Path,
+        target_table: str,
+        status: str = "ok",
+    ) -> InboxFileRecord:
+        checksum, size, mtime = self._meta(path)
+        record = InboxFileRecord(
+            path=str(path),
+            checksum_sha256=checksum,
+            size_bytes=size,
+            mtime=mtime,
+            ingested_at=_utcnow_iso(),
+            target_table=target_table,
+            last_status=status,
+        )
+        self._records[str(path)] = record
+        return record
+
+    def mark_quarantined(
+        self,
+        path: Path,
+        reason: str,
+        target_table: str = "",
+    ) -> InboxFileRecord:
+        del reason  # captured by RunRecorder; InboxFileRecord just tracks status
+        return self.mark_ingested(path, target_table=target_table, status="quarantined")
+
+    def mark_failed(self, path: Path, target_table: str = "") -> InboxFileRecord:
+        return self.mark_ingested(path, target_table=target_table, status="failed")

--- a/src/seeknal/heartbeat/ingest.py
+++ b/src/seeknal/heartbeat/ingest.py
@@ -1,0 +1,306 @@
+"""Heartbeat IngestWriter — Parquet or Iceberg backend selected per config.
+
+ParquetWriter is the default: uses DuckDB to read CSV/JSON/Parquet and writes
+``target/ingested/<table>/data.parquet`` with a companion ``_meta.json``.
+
+IcebergWriter delegates to :func:`seeknal.iceberg.ingest_writer.write_iceberg_ingested_table`,
+resolving ``catalog_uri`` + ``warehouse`` from ``profiles.yml`` source_defaults.
+
+Any backend exception → ``IngestResult(status='quarantined', error=...)``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from seeknal.heartbeat.recorder import IngestResult
+
+logger = logging.getLogger("seeknal.heartbeat.ingest")
+
+TABLE_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+SUPPORTED_SUFFIXES = {".csv", ".tsv", ".json", ".jsonl", ".parquet"}
+RESERVED_KEYWORDS = {
+    "select",
+    "from",
+    "where",
+    "join",
+    "group",
+    "order",
+    "by",
+    "at",
+    "in",
+    "on",
+    "as",
+    "to",
+    "with",
+    "having",
+    "union",
+    "table",
+    "and",
+    "or",
+    "not",
+    "is",
+    "null",
+    "limit",
+    "offset",
+    "case",
+    "when",
+    "then",
+    "else",
+    "end",
+}
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(tz=timezone.utc).isoformat(timespec="seconds")
+
+
+def derive_table_name(path: Path) -> str:
+    """Lowercased stem with non-word chars replaced by ``_``. Validates."""
+    stem = path.stem
+    candidate = re.sub(r"[^a-zA-Z0-9_]+", "_", stem).strip("_").lower()
+    if not candidate or not TABLE_NAME_RE.match(candidate):
+        raise ValueError(
+            f"Cannot derive valid table name from filename '{path.name}'. "
+            "Must yield ^[a-z][a-z0-9_]*$."
+        )
+    if candidate in RESERVED_KEYWORDS:
+        raise ValueError(
+            f"Filename '{path.name}' would map to reserved SQL keyword "
+            f"'{candidate}'. Rename the file."
+        )
+    return candidate
+
+
+class ParquetWriter:
+    """Writes ``target/ingested/<table>/data.parquet`` using DuckDB."""
+
+    def __init__(self, project_root: Path):
+        self._project_root = Path(project_root)
+        self._base = self._project_root / "target" / "ingested"
+
+    def write(
+        self,
+        *,
+        source_path: Path,
+        table_name: str,
+        checksum: Optional[str] = None,
+    ) -> IngestResult:
+        try:
+            import duckdb  # type: ignore
+        except ImportError as exc:
+            return IngestResult(
+                file=str(source_path),
+                table=table_name,
+                target="parquet",
+                status="failed",
+                error=f"DuckDB not installed: {exc}",
+            )
+
+        suffix = source_path.suffix.lower()
+        if suffix not in SUPPORTED_SUFFIXES:
+            return IngestResult(
+                file=str(source_path),
+                table=table_name,
+                target="parquet",
+                status="quarantined",
+                error=f"Unsupported source suffix: {suffix}",
+            )
+
+        out_dir = self._base / table_name
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_parquet = out_dir / "data.parquet"
+        meta_path = out_dir / "_meta.json"
+
+        safe_in = str(source_path.resolve()).replace("'", "''")
+        safe_out = str(out_parquet.resolve()).replace("'", "''")
+
+        if suffix == ".csv":
+            reader = f"read_csv_auto('{safe_in}')"
+        elif suffix == ".tsv":
+            reader = f"read_csv_auto('{safe_in}', delim='\\t')"
+        elif suffix in (".json", ".jsonl"):
+            reader = f"read_json_auto('{safe_in}')"
+        elif suffix == ".parquet":
+            reader = f"read_parquet('{safe_in}')"
+        else:  # pragma: no cover — guarded above
+            reader = ""
+
+        con = duckdb.connect(":memory:")
+        try:
+            row = con.execute(f"SELECT COUNT(*) FROM {reader}").fetchone()
+            row_count = int(row[0]) if row else 0
+            con.execute(
+                f"COPY (SELECT * FROM {reader}) TO '{safe_out}' (FORMAT PARQUET)"
+            )
+        except Exception as exc:  # noqa: BLE001
+            return IngestResult(
+                file=str(source_path),
+                table=table_name,
+                target="parquet",
+                status="quarantined",
+                error=str(exc),
+            )
+        finally:
+            con.close()
+
+        try:
+            size_bytes = out_parquet.stat().st_size
+        except OSError:
+            size_bytes = 0
+
+        meta: dict[str, Any] = {
+            "source_file": str(source_path),
+            "rows": row_count,
+            "bytes": size_bytes,
+            "ingested_at": _utcnow_iso(),
+            "checksum_sha256": checksum,
+            "table": table_name,
+        }
+        meta_path.write_text(json.dumps(meta, indent=2, sort_keys=True))
+
+        return IngestResult(
+            file=str(source_path),
+            table=table_name,
+            rows=row_count,
+            bytes=size_bytes,
+            target="parquet",
+            status="ok",
+        )
+
+
+class IcebergWriter:
+    """Writes via :mod:`seeknal.iceberg.ingest_writer`."""
+
+    def __init__(
+        self,
+        *,
+        catalog_uri: str,
+        warehouse: str,
+        namespace: str = "ingested",
+        existing_tables: Optional[set[str]] = None,
+    ):
+        self._catalog_uri = catalog_uri
+        self._warehouse = warehouse
+        self._namespace = namespace
+        self._existing: set[str] = existing_tables or set()
+
+    def write(
+        self,
+        *,
+        source_path: Path,
+        table_name: str,
+        checksum: Optional[str] = None,
+    ) -> IngestResult:
+        del checksum  # forward-compat; not yet used in Iceberg sidecar
+        from seeknal.iceberg.ingest_writer import (
+            IcebergWriteError,
+            write_iceberg_ingested_table,
+        )
+
+        mode = "append" if table_name in self._existing else "create"
+        try:
+            res = write_iceberg_ingested_table(
+                source_path=source_path,
+                table_name=table_name,
+                catalog_uri=self._catalog_uri,
+                warehouse=self._warehouse,
+                namespace=self._namespace,
+                mode=mode,
+            )
+        except IcebergWriteError as exc:
+            return IngestResult(
+                file=str(source_path),
+                table=table_name,
+                target="iceberg",
+                status="quarantined",
+                error=str(exc),
+            )
+
+        self._existing.add(table_name)
+        return IngestResult(
+            file=str(source_path),
+            table=table_name,
+            rows=res.rows,
+            bytes=res.bytes,
+            target="iceberg",
+            status="ok",
+        )
+
+
+def quarantine_file(path: Path, quarantine_dir: Path) -> Path:
+    """Move ``path`` into ``quarantine_dir`` with a timestamp suffix on collision."""
+    quarantine_dir = Path(quarantine_dir)
+    quarantine_dir.mkdir(parents=True, exist_ok=True)
+    dest = quarantine_dir / path.name
+    if dest.exists():
+        ts = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+        dest = quarantine_dir / f"{path.stem}.{ts}{path.suffix}"
+    shutil.move(str(path), str(dest))
+    return dest
+
+
+class IngestWriter:
+    """Backend dispatcher selected by ``HeartbeatConfig.ingested_target``."""
+
+    def __init__(
+        self,
+        project_root: Path,
+        *,
+        target: str = "parquet",
+        iceberg_catalog_uri: Optional[str] = None,
+        iceberg_warehouse: Optional[str] = None,
+        iceberg_namespace: str = "ingested",
+    ):
+        self._project_root = Path(project_root)
+        self._target = target
+        if target == "parquet":
+            self._backend = ParquetWriter(self._project_root)
+        elif target == "iceberg":
+            if not iceberg_catalog_uri or not iceberg_warehouse:
+                raise ValueError(
+                    "Iceberg target requires catalog_uri and warehouse "
+                    "(set source_defaults.iceberg in profiles.yml)."
+                )
+            self._backend = IcebergWriter(
+                catalog_uri=iceberg_catalog_uri,
+                warehouse=iceberg_warehouse,
+                namespace=iceberg_namespace,
+            )
+        else:
+            raise ValueError(
+                f"Unknown target '{target}'. Accepted: parquet, iceberg."
+            )
+
+    @property
+    def target(self) -> str:
+        return self._target
+
+    def write(
+        self,
+        source_path: Path,
+        *,
+        table_name: Optional[str] = None,
+        checksum: Optional[str] = None,
+    ) -> IngestResult:
+        try:
+            resolved_table = table_name or derive_table_name(source_path)
+        except ValueError as exc:
+            return IngestResult(
+                file=str(source_path),
+                table="",
+                target=self._target,  # type: ignore[arg-type]
+                status="quarantined",
+                error=str(exc),
+            )
+        return self._backend.write(
+            source_path=source_path,
+            table_name=resolved_table,
+            checksum=checksum,
+        )

--- a/src/seeknal/heartbeat/quarantine/__init__.py
+++ b/src/seeknal/heartbeat/quarantine/__init__.py
@@ -1,0 +1,21 @@
+"""Heartbeat quarantine subsystem (v0.5).
+
+Manages the ``target/heartbeat/quarantine/needs_review/<run_id>/`` queue:
+- ``QuarantineSidecar``: dataclass for the YAML metadata next to each pending file.
+- ``apply_review_decision``: applies operator Confirm/Reject/Edit decisions.
+- ``CallbackMap``: monotonic base36 token → run_id mapping for Telegram callbacks.
+"""
+
+from seeknal.heartbeat.quarantine.review import (
+    QuarantineSidecar,
+    apply_review_decision,
+    list_pending_reviews,
+)
+from seeknal.heartbeat.quarantine.callback_map import CallbackMap
+
+__all__ = [
+    "QuarantineSidecar",
+    "apply_review_decision",
+    "list_pending_reviews",
+    "CallbackMap",
+]

--- a/src/seeknal/heartbeat/quarantine/callback_map.py
+++ b/src/seeknal/heartbeat/quarantine/callback_map.py
@@ -1,0 +1,103 @@
+"""Monotonic base36 token map for Telegram inline-keyboard callback_data.
+
+Telegram limits ``callback_data`` to 64 bytes. The natural approach (UUID
+prefix) is collision-prone over months; we use a monotonic 4-char base36
+counter that resumes from the persisted max on daemon restart.
+
+Stored at ``target/heartbeat/quarantine/_callback_map.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import threading
+from pathlib import Path
+from typing import Optional
+
+
+def _to_base36(num: int, width: int = 4) -> str:
+    digits = "0123456789abcdefghijklmnopqrstuvwxyz"
+    if num < 0:
+        raise ValueError("counter must be non-negative")
+    if num == 0:
+        return "0".zfill(width)
+    parts: list[str] = []
+    while num > 0:
+        num, rem = divmod(num, 36)
+        parts.append(digits[rem])
+    return "".join(reversed(parts)).rjust(width, "0")
+
+
+def _from_base36(value: str) -> int:
+    return int(value, 36)
+
+
+class CallbackMap:
+    """Per-project mapping token ↔ run_id, persisted atomically."""
+
+    def __init__(self, path: Path):
+        self._path = Path(path)
+        self._lock = threading.Lock()
+        self._token_to_run: dict[str, str] = {}
+        self._counter = 0
+        self._load()
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            return
+        try:
+            raw = json.loads(self._path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return
+        if not isinstance(raw, dict):
+            return
+        self._token_to_run = {str(k): str(v) for k, v in raw.items()}
+        if self._token_to_run:
+            try:
+                self._counter = max(_from_base36(t) for t in self._token_to_run)
+            except ValueError:
+                self._counter = len(self._token_to_run)
+
+    def _save(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(
+            prefix=".callback_map.", suffix=".json.tmp", dir=str(self._path.parent)
+        )
+        try:
+            with os.fdopen(fd, "w") as fh:
+                json.dump(self._token_to_run, fh, indent=2, sort_keys=True)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp, self._path)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except FileNotFoundError:
+                pass
+            raise
+
+    def allocate(self, run_id: str) -> str:
+        with self._lock:
+            self._counter += 1
+            token = _to_base36(self._counter)
+            self._token_to_run[token] = run_id
+            self._save()
+            return token
+
+    def lookup(self, token: str) -> Optional[str]:
+        return self._token_to_run.get(token)
+
+    def remove(self, token: str) -> None:
+        with self._lock:
+            if token in self._token_to_run:
+                del self._token_to_run[token]
+                self._save()
+
+
+__all__ = ["CallbackMap"]

--- a/src/seeknal/heartbeat/quarantine/notifier.py
+++ b/src/seeknal/heartbeat/quarantine/notifier.py
@@ -1,0 +1,79 @@
+"""QuarantineNotifier — formatter for operator-facing review messages.
+
+The notifier produces the *content* of the notification (title, summary,
+preview, inline-keyboard button payloads). Actual delivery is the Telegram
+channel's job; this module is delivery-agnostic so it can also drive the
+``seeknal heartbeat review`` CLI.
+
+Per the file-as-boundary principle, the heartbeat does not import telegram.
+The telegram channel reads ``QuarantineNotice`` from this module instead.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+from seeknal.heartbeat.quarantine.review import QuarantineSidecar
+
+
+@dataclass
+class QuarantineNotice:
+    sidecar_path: Path
+    run_id: str
+    file: str
+    target_table: str
+    confidence: float
+    concerns: list[str] = field(default_factory=list)
+    preview_text: str = ""
+    callback_tokens: dict[str, str] = field(default_factory=dict)
+
+    def summary(self) -> str:
+        concerns = ", ".join(self.concerns) if self.concerns else "—"
+        return (
+            f"📨 New file needs review: {Path(self.file).name}\n"
+            f"Best guess: {self.target_table or '?'} "
+            f"({self.confidence * 100:.0f}% confidence)\n"
+            f"Concerns: {concerns}\n"
+        )
+
+
+def build_notice(
+    sidecar_path: Path,
+    *,
+    preview_text: str = "",
+    confirm_token: str = "",
+    reject_token: str = "",
+    edit_token: str = "",
+) -> QuarantineNotice:
+    sidecar = QuarantineSidecar.load(sidecar_path)
+    notice = QuarantineNotice(
+        sidecar_path=sidecar_path,
+        run_id=sidecar.run_id,
+        file=sidecar.file,
+        target_table=sidecar.target_table,
+        confidence=sidecar.confidence,
+        concerns=list(sidecar.concerns),
+        preview_text=preview_text,
+        callback_tokens={
+            "confirm": confirm_token,
+            "reject": reject_token,
+            "edit": edit_token,
+        },
+    )
+    return notice
+
+
+def render_callback(action: str, token: str, idx: int = 0) -> str:
+    """Build a base36 callback payload — 9 bytes max (well under Telegram's 64)."""
+    short = {"confirm": "c", "reject": "r", "edit": "e"}.get(action, action[0])
+    return f"q:{short}:{token}:{idx}"
+
+
+def iter_pending(project_root: Path) -> Iterable[Path]:
+    from seeknal.heartbeat.quarantine.review import list_pending_reviews
+    yield from list_pending_reviews(project_root)
+
+
+__all__ = ["QuarantineNotice", "build_notice", "render_callback", "iter_pending"]

--- a/src/seeknal/heartbeat/quarantine/review.py
+++ b/src/seeknal/heartbeat/quarantine/review.py
@@ -1,0 +1,268 @@
+"""Quarantine review primitives — read sidecar, apply Confirm/Reject/Edit decisions."""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+import yaml
+
+logger = logging.getLogger("seeknal.heartbeat.quarantine.review")
+
+_REVIEW_SUFFIX = ".review.yml"
+
+
+@dataclass
+class QuarantineSidecar:
+    """The ``*.review.yml`` next to each quarantined file."""
+
+    schema_version: int = 1
+    run_id: str = ""
+    file: str = ""
+    classified_at: str = ""
+    target_table: str = ""
+    confidence: float = 0.0
+    source: str = "llm"
+    llm_call_id: Optional[str] = None
+    reasoning: str = ""
+    column_mapping: dict[str, str] = field(default_factory=dict)
+    concerns: list[str] = field(default_factory=list)
+    status: Literal[
+        "pending_review", "confirmed", "rejected", "edited"
+    ] = "pending_review"
+    notified_at: str = ""
+    notified_chats: list[int] = field(default_factory=list)
+    resolution: Optional[str] = None
+    resolved_by: Optional[str] = None
+    resolved_at: Optional[str] = None
+    write_mode: str = "append"
+    business_key: list[str] = field(default_factory=list)
+    source_path: Optional[Path] = None
+
+    @classmethod
+    def load(cls, path: Path) -> "QuarantineSidecar":
+        with open(path, "r") as fh:
+            raw = yaml.safe_load(fh) or {}
+        if not isinstance(raw, dict):
+            raise ValueError(f"Sidecar at {path} is not a mapping")
+        decision = raw.get("classifier_decision") or {}
+        sidecar = cls(
+            schema_version=int(raw.get("schema_version", 1)),
+            run_id=str(raw.get("run_id", "") or ""),
+            file=str(raw.get("file", "") or ""),
+            classified_at=str(raw.get("classified_at", "") or ""),
+            target_table=str(decision.get("target_table", "") or ""),
+            confidence=float(decision.get("confidence", 0.0) or 0.0),
+            source=str(decision.get("source", "llm") or "llm"),
+            llm_call_id=decision.get("llm_call_id"),
+            reasoning=str(decision.get("reasoning", "") or ""),
+            column_mapping=dict(decision.get("column_mapping") or {}),
+            concerns=list(decision.get("concerns") or []),
+            status=str(raw.get("status", "pending_review") or "pending_review"),
+            notified_at=str(raw.get("notified_at", "") or ""),
+            notified_chats=list(raw.get("notified_chats") or []),
+            resolution=raw.get("resolution"),
+            resolved_by=raw.get("resolved_by"),
+            resolved_at=raw.get("resolved_at"),
+            write_mode=str(raw.get("write_mode", "append") or "append"),
+            business_key=list(raw.get("business_key") or []),
+        )
+        sidecar.source_path = path
+        return sidecar
+
+    def save(self, path: Optional[Path] = None) -> Path:
+        target = Path(path or self.source_path)
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "run_id": self.run_id,
+            "file": self.file,
+            "classified_at": self.classified_at,
+            "classifier_decision": {
+                "target_table": self.target_table,
+                "confidence": self.confidence,
+                "source": self.source,
+                "llm_call_id": self.llm_call_id,
+                "reasoning": self.reasoning,
+                "column_mapping": dict(self.column_mapping),
+                "concerns": list(self.concerns),
+            },
+            "status": self.status,
+            "write_mode": self.write_mode,
+            "business_key": list(self.business_key),
+        }
+        if self.notified_at:
+            payload["notified_at"] = self.notified_at
+        if self.notified_chats:
+            payload["notified_chats"] = list(self.notified_chats)
+        if self.resolution is not None:
+            payload["resolution"] = self.resolution
+        if self.resolved_by is not None:
+            payload["resolved_by"] = self.resolved_by
+        if self.resolved_at is not None:
+            payload["resolved_at"] = self.resolved_at
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(yaml.safe_dump(payload, sort_keys=False))
+        self.source_path = target
+        return target
+
+
+def list_pending_reviews(project_root: Path) -> list[Path]:
+    """Return sidecar files in needs_review/ that are still pending."""
+    needs = project_root / "target" / "heartbeat" / "quarantine" / "needs_review"
+    if not needs.exists():
+        return []
+    out: list[Path] = []
+    for sidecar in sorted(needs.rglob(f"*{_REVIEW_SUFFIX}")):
+        try:
+            doc = yaml.safe_load(sidecar.read_text()) or {}
+        except yaml.YAMLError:
+            continue
+        if isinstance(doc, dict) and doc.get("status", "pending_review") == "pending_review":
+            out.append(sidecar)
+    return out
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+_EDIT_LINE_RE = re.compile(r"^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*(.+)$")
+
+
+def parse_edit_input(text: str) -> tuple[dict[str, str], dict[str, Any], list[str]]:
+    """Parse operator free-text edit input — mechanical, no LLM fallback.
+
+    Supported keys:
+    - ``target=<table>`` → override target_table.
+    - ``mode=upsert|append|overwrite`` → override write_mode.
+    - ``key=col`` or ``key=col1,col2`` → override business_key.
+    - ``<file_col>=<target_col>`` → column mapping.
+
+    Returns: (column_mapping_overrides, metadata_overrides, errors)
+    """
+    column_mapping: dict[str, str] = {}
+    metadata: dict[str, Any] = {}
+    errors: list[str] = []
+    for lineno, raw_line in enumerate(text.splitlines(), 1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.lower() == "cancel":
+            return {}, {"cancelled": True}, []
+        match = _EDIT_LINE_RE.match(line)
+        if not match:
+            errors.append(
+                f"line {lineno}: expected `key=value` (alphanumeric+underscores), got: {raw_line!r}"
+            )
+            continue
+        key = match.group(1).strip()
+        value = match.group(2).strip()
+        if key.lower() == "target":
+            metadata["target_table"] = value
+        elif key.lower() == "mode":
+            if value.lower() not in {"append", "upsert", "overwrite"}:
+                errors.append(
+                    f"line {lineno}: unknown mode {value!r}. "
+                    "Use append, upsert, or overwrite."
+                )
+            else:
+                metadata["write_mode"] = value.lower()
+        elif key.lower() == "key":
+            cols = [c.strip() for c in value.split(",") if c.strip()]
+            if not cols:
+                errors.append(f"line {lineno}: empty key list")
+            else:
+                metadata["business_key"] = cols
+        else:
+            column_mapping[key] = value
+    return column_mapping, metadata, errors
+
+
+def apply_review_decision(
+    sidecar_path: Path,
+    *,
+    decision: Literal["confirm", "reject", "edit"],
+    resolved_by: str = "",
+    edit_text: Optional[str] = None,
+    rejected_dir: Optional[Path] = None,
+) -> dict[str, Any]:
+    """Apply an operator decision to the sidecar. Returns a result summary.
+
+    The classifier-confirmation effect (catalog update + IngestWriter call) is
+    intentionally NOT wired in here — that lives in the heartbeat runner, which
+    knows about the IngestWriter and Catalog. This helper is the deterministic
+    state-transition primitive.
+    """
+    sidecar = QuarantineSidecar.load(sidecar_path)
+    if sidecar.status != "pending_review":
+        return {
+            "ok": False,
+            "error": f"Sidecar already {sidecar.status!r}; skipping.",
+        }
+
+    if decision == "confirm":
+        sidecar.status = "confirmed"
+        sidecar.resolution = "confirm"
+        sidecar.resolved_by = resolved_by or "operator"
+        sidecar.resolved_at = _utcnow_iso()
+        sidecar.save()
+        return {"ok": True, "decision": "confirm", "sidecar": sidecar}
+
+    if decision == "reject":
+        sidecar.status = "rejected"
+        sidecar.resolution = "reject"
+        sidecar.resolved_by = resolved_by or "operator"
+        sidecar.resolved_at = _utcnow_iso()
+        sidecar.save()
+        # Move the data file aside.
+        data_file = Path(sidecar.file)
+        if not data_file.is_absolute():
+            data_file = sidecar_path.parent / data_file.name
+        rejected = rejected_dir or (
+            sidecar_path.parents[3] / "rejected" / sidecar.run_id
+        )
+        if data_file.exists():
+            rejected.mkdir(parents=True, exist_ok=True)
+            try:
+                shutil.move(str(data_file), str(rejected / data_file.name))
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Failed to move rejected file: %s", exc)
+        return {"ok": True, "decision": "reject", "sidecar": sidecar}
+
+    if decision == "edit":
+        if edit_text is None:
+            return {"ok": False, "error": "edit requires edit_text"}
+        column_overrides, meta_overrides, errors = parse_edit_input(edit_text)
+        if errors:
+            return {"ok": False, "errors": errors}
+        if meta_overrides.get("cancelled"):
+            return {"ok": False, "cancelled": True}
+        if column_overrides:
+            sidecar.column_mapping.update(column_overrides)
+        if "target_table" in meta_overrides:
+            sidecar.target_table = str(meta_overrides["target_table"])
+        if "write_mode" in meta_overrides:
+            sidecar.write_mode = str(meta_overrides["write_mode"])
+        if "business_key" in meta_overrides:
+            sidecar.business_key = list(meta_overrides["business_key"])
+        sidecar.status = "edited"
+        sidecar.resolution = "edit"
+        sidecar.resolved_by = resolved_by or "operator"
+        sidecar.resolved_at = _utcnow_iso()
+        sidecar.save()
+        return {"ok": True, "decision": "edit", "sidecar": sidecar}
+
+    raise ValueError(f"Unknown decision {decision!r}")
+
+
+__all__ = [
+    "QuarantineSidecar",
+    "apply_review_decision",
+    "list_pending_reviews",
+    "parse_edit_input",
+]

--- a/src/seeknal/heartbeat/recorder.py
+++ b/src/seeknal/heartbeat/recorder.py
@@ -1,0 +1,232 @@
+"""RunRecorder — append run records to ``target/heartbeat/runs.jsonl``.
+
+Each tick writes a single summary JSON line. A pretty-printed sidecar is
+written to ``target/heartbeat/runs/<run_id>.json`` for human inspection.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import logging
+import os
+import tempfile
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+logger = logging.getLogger("seeknal.heartbeat.recorder")
+
+
+@dataclass
+class IngestResult:
+    file: str
+    table: str
+    rows: int = 0
+    bytes: int = 0
+    target: Literal["parquet", "iceberg"] = "parquet"
+    status: Literal[
+        "ok", "quarantined", "quarantined_for_review", "failed"
+    ] = "ok"
+    error: Optional[str] = None
+    confidence: Optional[float] = None
+    reason: Optional[str] = None
+
+
+@dataclass
+class DagResult:
+    nodes_attempted: int = 0
+    nodes_skipped: int = 0
+    nodes_failed: int = 0
+    fingerprints: dict[str, str] = field(default_factory=dict)
+    per_node: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class ExposureResult:
+    node: str
+    target: str
+    status: Literal["ok", "failed", "skipped"]
+    error: Optional[str] = None
+
+
+@dataclass
+class ClassifierEntry:
+    """Per-file classifier decision logged into the run record (AC21)."""
+
+    file: str
+    source_used: Literal["catalog", "llm", "default", "fallback"] = "default"
+    target_table: str = ""
+    confidence: float = 0.0
+    llm_call_id: Optional[str] = None
+    decision: Literal["routed", "quarantined"] = "routed"
+
+
+@dataclass
+class HeartbeatRun:
+    run_id: str
+    started_at: str
+    finished_at: str
+    duration_ms: int
+    status: Literal["ok", "skipped", "partial", "failed"]
+    reason: Optional[str] = None
+    ingested: list[IngestResult] = field(default_factory=list)
+    dag: DagResult = field(default_factory=DagResult)
+    exposure: list[ExposureResult] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    classifier: list[ClassifierEntry] = field(default_factory=list)
+    llm_prompt_truncated: Optional[str] = None
+    llm_response_truncated: Optional[str] = None
+
+    @classmethod
+    def compute_status(
+        cls,
+        ingested: list[IngestResult],
+        dag: DagResult,
+        exposure: list[ExposureResult],
+        errors: list[str],
+    ) -> Literal["ok", "partial", "failed"]:
+        ok_ingest = [r for r in ingested if r.status == "ok"]
+        bad_ingest = [r for r in ingested if r.status not in {"ok"}]
+        ingest_failed = ingested and not ok_ingest
+        dag_failed = dag.nodes_failed > 0
+        bad_exposure = any(r.status == "failed" for r in exposure)
+        all_failed = ingest_failed and dag_failed and (bad_exposure or not exposure)
+        if all_failed:
+            return "failed"
+        any_failure = bool(errors) or bool(bad_ingest) or dag_failed or bad_exposure
+        if any_failure:
+            return "partial"
+        return "ok"
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _to_jsonable(value: Any) -> Any:
+    if isinstance(value, Path):
+        return str(value)
+    if hasattr(value, "__dataclass_fields__"):
+        return asdict(value)
+    return value
+
+
+class RunRecorder:
+    """Append-only writer for ``runs.jsonl`` + sidecar JSON files."""
+
+    def __init__(self, runs_dir: Path):
+        runs_dir = Path(runs_dir)
+        self._runs_dir = runs_dir
+        self._runs_jsonl = runs_dir / "runs.jsonl"
+        self._sidecar_dir = runs_dir / "runs"
+
+    @property
+    def runs_dir(self) -> Path:
+        return self._runs_dir
+
+    @property
+    def jsonl_path(self) -> Path:
+        return self._runs_jsonl
+
+    @property
+    def sidecar_dir(self) -> Path:
+        return self._sidecar_dir
+
+    def append(self, run: HeartbeatRun) -> None:
+        self._runs_dir.mkdir(parents=True, exist_ok=True)
+        self._sidecar_dir.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(asdict(run), default=_to_jsonable, sort_keys=True)
+        # Use fcntl.flock to serialize concurrent appends.
+        with open(self._runs_jsonl, "a") as fh:
+            try:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+                fh.write(line + "\n")
+                fh.flush()
+                os.fsync(fh.fileno())
+            finally:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+        sidecar_path = self._sidecar_dir / f"{run.run_id}.json"
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=".heartbeat-run.", suffix=".json.tmp", dir=str(self._sidecar_dir)
+        )
+        try:
+            with os.fdopen(fd, "w") as fh:
+                json.dump(
+                    asdict(run),
+                    fh,
+                    default=_to_jsonable,
+                    indent=2,
+                    sort_keys=True,
+                )
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp_path, sidecar_path)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+            raise
+
+    def tail(self, limit: int = 10) -> list[dict[str, Any]]:
+        if not self._runs_jsonl.exists():
+            return []
+        with open(self._runs_jsonl, "r") as fh:
+            lines = fh.readlines()
+        out: list[dict[str, Any]] = []
+        for line in lines[-limit:]:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                logger.warning("Skipping malformed runs.jsonl line: %s", exc)
+        return out
+
+
+def make_run(
+    run_id: str,
+    started_at: str,
+    finished_at: str,
+    duration_ms: int,
+    ingested: list[IngestResult],
+    dag: DagResult,
+    exposure: list[ExposureResult],
+    errors: list[str],
+    *,
+    reason: Optional[str] = None,
+    status: Optional[Literal["ok", "skipped", "partial", "failed"]] = None,
+    classifier: Optional[list[ClassifierEntry]] = None,
+) -> HeartbeatRun:
+    resolved_status = status or HeartbeatRun.compute_status(
+        ingested, dag, exposure, errors
+    )
+    return HeartbeatRun(
+        run_id=run_id,
+        started_at=started_at,
+        finished_at=finished_at,
+        duration_ms=duration_ms,
+        status=resolved_status,
+        reason=reason,
+        ingested=ingested,
+        dag=dag,
+        exposure=exposure,
+        errors=errors,
+        classifier=classifier or [],
+    )
+
+
+__all__ = [
+    "ClassifierEntry",
+    "DagResult",
+    "ExposureResult",
+    "HeartbeatRun",
+    "IngestResult",
+    "RunRecorder",
+    "make_run",
+    "_utcnow_iso",
+]

--- a/src/seeknal/iceberg/__init__.py
+++ b/src/seeknal/iceberg/__init__.py
@@ -1,0 +1,5 @@
+"""Top-level seeknal.iceberg package — context-free Iceberg helpers.
+
+These functions are used by the heartbeat daemon and the Ask-agent
+tool wrappers; they do not require a ToolContext.
+"""

--- a/src/seeknal/iceberg/ingest_writer.py
+++ b/src/seeknal/iceberg/ingest_writer.py
@@ -1,0 +1,157 @@
+"""Context-free Iceberg writer used by the heartbeat daemon.
+
+The function accepts a source file (CSV / JSON / Parquet) and writes it to an
+Iceberg table via PyIceberg. Catalog connectivity is supplied through
+``catalog_uri`` + ``warehouse`` — both resolved upstream from ``profiles.yml``.
+
+If PyIceberg or the catalog are unreachable, ``write_iceberg_ingested_table``
+raises an ``IcebergWriteError`` so the caller (the heartbeat IngestWriter) can
+record a quarantine event without crashing the daemon.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Optional
+
+logger = logging.getLogger("seeknal.iceberg.ingest_writer")
+
+_TABLE_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+class IcebergWriteError(Exception):
+    """Raised when the Iceberg write cannot complete (no pyiceberg, catalog
+    unreachable, schema rejected, etc.)."""
+
+
+@dataclass
+class IcebergWriteResult:
+    rows: int
+    bytes: int
+    snapshot_id: Optional[str] = None
+
+
+def _read_source_to_arrow(source_path: Path):
+    """Load a source file into a pyarrow Table. Lazy imports so the base
+    install doesn't need duckdb/pyarrow until Iceberg is actually used."""
+    suffix = source_path.suffix.lower()
+    import duckdb  # local — heavy import
+
+    safe = str(source_path.resolve()).replace("'", "''")
+    if suffix == ".csv":
+        reader = f"read_csv_auto('{safe}')"
+    elif suffix == ".tsv":
+        reader = f"read_csv_auto('{safe}', delim='\\t')"
+    elif suffix in (".json", ".jsonl"):
+        reader = f"read_json_auto('{safe}')"
+    elif suffix == ".parquet":
+        reader = f"read_parquet('{safe}')"
+    else:
+        raise IcebergWriteError(f"Unsupported suffix for Iceberg ingest: {suffix}")
+
+    con = duckdb.connect(":memory:")
+    try:
+        return con.execute(f"SELECT * FROM {reader}").arrow()
+    finally:
+        con.close()
+
+
+def write_iceberg_ingested_table(
+    *,
+    source_path: Path,
+    table_name: str,
+    catalog_uri: str,
+    warehouse: str,
+    namespace: str = "ingested",
+    mode: Literal["create", "append"] = "create",
+    business_key: Optional[str] = None,
+) -> IcebergWriteResult:
+    """Write ``source_path`` to ``namespace.table_name`` in the Iceberg catalog.
+
+    Args:
+        source_path: Local file (CSV/JSON/Parquet).
+        table_name: Lowercase alphanumeric + underscores.
+        catalog_uri: REST catalog URI (e.g. http://lakekeeper:8181).
+        warehouse: Warehouse name configured on the catalog.
+        namespace: Iceberg namespace (default ``ingested``).
+        mode: ``create`` (first write) or ``append`` (subsequent).
+        business_key: Reserved for future upsert support. Currently unused.
+
+    Raises:
+        IcebergWriteError: if PyIceberg is unavailable, the catalog can't be
+            reached, or the write fails.
+    """
+    del business_key  # accepted for forward-compat; ignored in create/append modes.
+
+    if not _TABLE_NAME_RE.match(table_name):
+        raise IcebergWriteError(
+            f"Invalid Iceberg table name '{table_name}'. "
+            "Must match ^[a-z][a-z0-9_]*$."
+        )
+
+    try:
+        from pyiceberg.catalog import load_catalog  # type: ignore
+    except ImportError as exc:
+        raise IcebergWriteError(
+            "PyIceberg is not installed. Configure ingested_target=parquet "
+            "in HEARTBEAT.md or install pyiceberg."
+        ) from exc
+
+    arrow_table = _read_source_to_arrow(source_path)
+    rows = arrow_table.num_rows
+    nbytes = arrow_table.nbytes
+
+    try:
+        catalog = load_catalog(
+            "heartbeat",
+            **{
+                "type": "rest",
+                "uri": catalog_uri,
+                "warehouse": warehouse,
+            },
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise IcebergWriteError(
+            f"Failed to connect to Iceberg catalog at {catalog_uri}: {exc}"
+        ) from exc
+
+    full_name = f"{namespace}.{table_name}"
+
+    try:
+        try:
+            catalog.create_namespace(namespace)
+        except Exception:  # namespace already exists
+            pass
+
+        try:
+            table = catalog.load_table(full_name)
+            if mode == "create":
+                raise IcebergWriteError(
+                    f"Iceberg table {full_name} already exists; use mode='append'"
+                )
+            table.append(arrow_table)
+        except Exception as load_exc:
+            if mode == "append" and "does not exist" not in str(load_exc).lower():
+                raise IcebergWriteError(
+                    f"Failed loading Iceberg table {full_name}: {load_exc}"
+                ) from load_exc
+            table = catalog.create_table(full_name, schema=arrow_table.schema)
+            table.append(arrow_table)
+
+        snapshot_id = None
+        try:
+            snapshot = table.current_snapshot()
+            snapshot_id = str(snapshot.snapshot_id) if snapshot else None
+        except Exception:  # noqa: BLE001
+            snapshot_id = None
+
+        return IcebergWriteResult(rows=rows, bytes=nbytes, snapshot_id=snapshot_id)
+    except IcebergWriteError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise IcebergWriteError(
+            f"Iceberg write failed for {full_name}: {exc}"
+        ) from exc

--- a/src/seeknal/integrations/atlas_catalog.py
+++ b/src/seeknal/integrations/atlas_catalog.py
@@ -42,6 +42,33 @@ from seeknal.integrations.atlas_governance import (
 __all__ = ["Dataset", "AtlasCatalogClient", "create_catalog_client_from_env"]
 
 
+def _columns_from_schema_fields(raw: Any) -> tuple[tuple[str, str], ...]:
+    """Normalise a catalog ``schemaFields`` list into ``(name, type)`` pairs.
+
+    Tolerant of the shapes the catalog surfaces: ``{name, type}`` (portal/iceberg),
+    ``{fieldPath, nativeDataType}`` (DataHub), or ``{name, dataType}``. Entries
+    without a usable name are dropped; a non-list input yields ``()``.
+    """
+
+    if not isinstance(raw, list):
+        return ()
+    columns: list[tuple[str, str]] = []
+    for field_def in raw:
+        if not isinstance(field_def, dict):
+            continue
+        name = field_def.get("name") or field_def.get("fieldPath")
+        if not name:
+            continue
+        col_type = (
+            field_def.get("type")
+            or field_def.get("nativeDataType")
+            or field_def.get("dataType")
+            or ""
+        )
+        columns.append((str(name), str(col_type)))
+    return tuple(columns)
+
+
 @dataclass(frozen=True)
 class Dataset:
     """Typed projection of a unified-catalog asset.
@@ -60,6 +87,11 @@ class Dataset:
     tags: tuple[str, ...] = ()
     canonical_id: str = ""
     metadata: dict[str, Any] = field(default_factory=dict)
+    #: ``(name, type)`` column pairs when the catalog exposes a schema for the
+    #: dataset (Lakekeeper/iceberg tables and cubes via the portal). Empty when the
+    #: source carries no schema. Lets ``seeknal dataset show`` render the columns the
+    #: web detail view shows, without reading any data.
+    columns: tuple[tuple[str, str], ...] = ()
 
     @classmethod
     def from_api(cls, d: dict[str, Any]) -> "Dataset":
@@ -83,6 +115,9 @@ class Dataset:
             tags=tags,
             canonical_id=str(metadata.get("canonical_asset_id", "")),
             metadata=dict(metadata),
+            columns=_columns_from_schema_fields(
+                metadata.get("schemaFields") or metadata.get("columns")
+            ),
         )
 
     @classmethod
@@ -125,6 +160,7 @@ class Dataset:
                 "displayName": display,
                 "platform": d.get("platform"),
             },
+            columns=_columns_from_schema_fields(d.get("schemaFields")),
         )
 
     @property

--- a/src/seeknal/integrations/atlas_catalog.py
+++ b/src/seeknal/integrations/atlas_catalog.py
@@ -24,12 +24,20 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
-from typing import Any, Sequence
+from typing import Any, Callable, Sequence
 
 import httpx
 
-from seeknal.integrations.atlas_client import AtlasContractConfig, AtlasContractError
-from seeknal.integrations.atlas_governance import user_token_from_credentials
+from seeknal.integrations.atlas_client import (
+    AtlasAuthError,
+    AtlasContractConfig,
+    AtlasContractError,
+    SESSION_EXPIRED_HINT,
+)
+from seeknal.integrations.atlas_governance import (
+    refresh_access_token,
+    user_token_from_credentials,
+)
 
 __all__ = ["Dataset", "AtlasCatalogClient", "create_catalog_client_from_env"]
 
@@ -105,68 +113,101 @@ class AtlasCatalogClient:
         config: AtlasContractConfig,
         *,
         client: httpx.Client | None = None,
+        token_refresher: Callable[[], str | None] | None = None,
     ) -> None:
         self.config = config
         self._client = client
+        # ``config.token`` is the initial bearer; keep a mutable copy so a 401-driven
+        # refresh can swap in a new access token without rebuilding the frozen config.
+        self._token = config.token
+        self._token_refresher = token_refresher or refresh_access_token
 
     # -- HTTP plumbing -------------------------------------------------------
 
     def _headers(self) -> dict[str, str]:
         headers = {"Content-Type": "application/json"}
-        if self.config.token:
-            headers["Authorization"] = f"Bearer {self.config.token}"
+        if self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
         return headers
 
-    def _get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+    def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        """Issue a single HTTP request via the injected client or a one-shot call."""
+
+        if self._client is not None:
+            if method == "GET":
+                return self._client.get(url, params=params, headers=self._headers())
+            return self._client.post(url, json=json_body, headers=self._headers())
+        if method == "GET":
+            return httpx.get(
+                url,
+                params=params,
+                headers=self._headers(),
+                timeout=self.config.timeout_seconds,
+            )
+        return httpx.post(
+            url,
+            json=json_body,
+            headers=self._headers(),
+            timeout=self.config.timeout_seconds,
+        )
+
+    def _send(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+    ) -> Any:
+        """Send a request, transparently refreshing the token once on HTTP 401.
+
+        On a 401 the stored refresh token is used to mint a new access token and the
+        request is retried exactly once. When no refresh is possible (or the retry is
+        still 401), an :class:`AtlasAuthError` carrying a re-authentication hint is
+        raised — never a raw traceback. Other HTTP/transport failures map to
+        :class:`AtlasContractError` as before.
+        """
+
         url = f"{self.config.base_url}{path}"
+        refreshed = False
+        while True:
+            try:
+                response = self._request(method, url, params=params, json_body=json_body)
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code == 401:
+                    if not refreshed:
+                        refreshed = True
+                        new_token = self._token_refresher()
+                        if new_token:
+                            self._token = new_token
+                            continue
+                    raise AtlasAuthError(SESSION_EXPIRED_HINT) from exc
+                message = exc.response.text.strip() or str(exc)
+                raise AtlasContractError(
+                    f"Atlas catalog request failed for {path}: {message}"
+                ) from exc
+            except httpx.HTTPError as exc:
+                raise AtlasContractError(
+                    f"Atlas catalog request failed for {path}: {exc}"
+                ) from exc
+
+    def _get(self, path: str, params: dict[str, Any] | None = None) -> Any:
         clean = {
             key: value for key, value in (params or {}).items() if value is not None
         }
-        try:
-            if self._client is not None:
-                response = self._client.get(url, params=clean, headers=self._headers())
-            else:
-                response = httpx.get(
-                    url,
-                    params=clean,
-                    headers=self._headers(),
-                    timeout=self.config.timeout_seconds,
-                )
-            response.raise_for_status()
-            return response.json()
-        except httpx.HTTPStatusError as exc:
-            message = exc.response.text.strip() or str(exc)
-            raise AtlasContractError(
-                f"Atlas catalog request failed for {path}: {message}"
-            ) from exc
-        except httpx.HTTPError as exc:
-            raise AtlasContractError(
-                f"Atlas catalog request failed for {path}: {exc}"
-            ) from exc
+        return self._send("GET", path, params=clean)
 
     def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
-        url = f"{self.config.base_url}{path}"
-        try:
-            if self._client is not None:
-                response = self._client.post(url, json=payload, headers=self._headers())
-            else:
-                response = httpx.post(
-                    url,
-                    json=payload,
-                    headers=self._headers(),
-                    timeout=self.config.timeout_seconds,
-                )
-            response.raise_for_status()
-            return response.json()
-        except httpx.HTTPStatusError as exc:
-            message = exc.response.text.strip() or str(exc)
-            raise AtlasContractError(
-                f"Atlas catalog request failed for {path}: {message}"
-            ) from exc
-        except httpx.HTTPError as exc:
-            raise AtlasContractError(
-                f"Atlas catalog request failed for {path}: {exc}"
-            ) from exc
+        return self._send("POST", path, json_body=payload)
 
     # -- Public API ----------------------------------------------------------
 

--- a/src/seeknal/integrations/atlas_catalog.py
+++ b/src/seeknal/integrations/atlas_catalog.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from typing import Any, Callable, Sequence
+from urllib.parse import quote
 
 import httpx
 
@@ -429,6 +430,23 @@ class AtlasCatalogClient:
             "/api/sample",
             {"identifier": identifier, "limit": limit, "offset": offset},
         )
+
+    def lineage(self, urn: str) -> dict[str, Any]:
+        """Fetch a dataset's upstream/downstream lineage, returning the JSON verbatim.
+
+        When the portal is configured, reads its DataHub-backed lineage route
+        (``GET /api/datasets/{urn}/lineage`` → ``{dataset, upstreamLineage,
+        downstreamLineage}``, empty arrays when DataHub has no lineage). Otherwise
+        falls back to the backend relationships endpoint
+        (``GET /api/assets/{urn}/relationships``). The ``urn`` is URL-encoded.
+        """
+
+        encoded = quote(urn, safe="")
+        if self._portal_url is not None:
+            return self._send(
+                "GET", f"/api/datasets/{encoded}/lineage", base=self._portal_url
+            )
+        return self._get(f"/api/assets/{encoded}/relationships")
 
     def annotate(
         self,

--- a/src/seeknal/integrations/atlas_catalog.py
+++ b/src/seeknal/integrations/atlas_catalog.py
@@ -456,12 +456,15 @@ class AtlasCatalogClient:
         tags: Sequence[str] | None = None,
         description: str | None = None,
         owners: Sequence[str] | None = None,
+        terms: Sequence[str] | None = None,
+        domain: str | None = None,
     ) -> dict[str, Any]:
         """Upsert the unified-catalog asset annotations.
 
-        Fetches the current asset, unions any new ``tags`` with the existing ones,
-        overrides ``description`` when supplied, records ``owners`` in metadata when
-        given, then POSTs the merged asset to ``/api/contracts/assets/register``.
+        Fetches the current asset, unions any new ``tags``/``terms`` with the
+        existing ones, overrides ``description`` when supplied, records ``owners``
+        and ``domain`` in metadata when given, then POSTs the merged asset to
+        ``/api/contracts/assets/register``. Pass ``domain=""`` to clear it.
         Returns the backend response.
         """
 
@@ -482,6 +485,15 @@ class AtlasCatalogClient:
         metadata["tags"] = merged_tags
         if owners:
             metadata["owners"] = list(owners)
+        if terms:
+            merged_terms = list(metadata.get("glossaryTerms") or [])
+            for term in terms:
+                if term and term not in merged_terms:
+                    merged_terms.append(term)
+            metadata["glossaryTerms"] = merged_terms
+        if domain is not None:
+            # An empty string clears the domain assignment.
+            metadata["domain"] = domain or None
 
         source_id = str(
             current.metadata.get("source_id", "")

--- a/src/seeknal/integrations/atlas_catalog.py
+++ b/src/seeknal/integrations/atlas_catalog.py
@@ -1,0 +1,330 @@
+"""Read-only Atlas data-catalog client, active only when Atlas is configured.
+
+This is the *catalog* surface of the Atlas integration: a GET-only client over the
+unified-catalog read API. Where :mod:`seeknal.integrations.atlas_client` handles
+apply-time dual writes and :mod:`seeknal.integrations.atlas_governance` enforces
+runtime access, this module lets a caller *browse* the catalog — list, fetch,
+search, and sample assets — plus a single write (:meth:`AtlasCatalogClient.annotate`)
+that upserts annotations onto an existing asset.
+
+Like the governance gate it is **config-activated**: with no ``ATLAS_API_URL`` the
+factory returns ``None`` and callers can skip catalog features entirely. It reuses
+the same :class:`~seeknal.integrations.atlas_client.AtlasContractConfig` and the
+per-user token resolution so a single Atlas configuration drives every surface.
+
+The backend asset shape is a JSON dict::
+
+    {id, asset_type, name, namespace, source_system, source_id, canonical_source,
+     metadata: {description, tags, canonical_asset_id}, created_at, updated_at}
+
+:class:`Dataset` is the typed projection of that dict the rest of Seeknal consumes.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Sequence
+
+import httpx
+
+from seeknal.integrations.atlas_client import AtlasContractConfig, AtlasContractError
+from seeknal.integrations.atlas_governance import user_token_from_credentials
+
+__all__ = ["Dataset", "AtlasCatalogClient", "create_catalog_client_from_env"]
+
+
+@dataclass(frozen=True)
+class Dataset:
+    """Typed projection of a unified-catalog asset.
+
+    Construct from a raw backend asset dict via :meth:`from_api`. ``description``,
+    ``tags``, and ``canonical_id`` are flattened out of the nested ``metadata`` block
+    the backend returns, while the full ``metadata`` dict is retained verbatim.
+    """
+
+    id: str
+    name: str
+    namespace: str = ""
+    asset_type: str = ""
+    source_system: str = ""
+    description: str = ""
+    tags: tuple[str, ...] = ()
+    canonical_id: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_api(cls, d: dict[str, Any]) -> "Dataset":
+        """Map a raw backend asset dict to a :class:`Dataset`.
+
+        Tolerant of missing fields: any absent key falls back to its dataclass
+        default. ``description``, ``tags``, and ``canonical_asset_id`` are read from
+        the nested ``metadata`` block; the whole ``metadata`` dict is preserved.
+        """
+
+        metadata = d.get("metadata") or {}
+        raw_tags = metadata.get("tags") or []
+        tags = tuple(str(tag) for tag in raw_tags if tag)
+        return cls(
+            id=str(d.get("id", "")),
+            name=str(d.get("name", "")),
+            namespace=str(d.get("namespace", "")),
+            asset_type=str(d.get("asset_type", "")),
+            source_system=str(d.get("source_system", "")),
+            description=str(metadata.get("description", "")),
+            tags=tags,
+            canonical_id=str(metadata.get("canonical_asset_id", "")),
+            metadata=dict(metadata),
+        )
+
+    @property
+    def fqn(self) -> str:
+        """Fully-qualified name for the dataset.
+
+        Prefers the canonical asset id when present; otherwise composes
+        ``"{namespace}.{name}"`` (dropping the leading dot when no namespace is set).
+        """
+
+        if self.canonical_id:
+            return self.canonical_id
+        if self.namespace:
+            return f"{self.namespace}.{self.name}"
+        return self.name
+
+
+class AtlasCatalogClient:
+    """GET-only HTTP client for the Atlas unified-catalog read API.
+
+    Construct via :func:`create_catalog_client_from_env`. Pass an explicit ``client``
+    (e.g. backed by :class:`httpx.MockTransport`) in tests. Mirrors the headers and
+    HTTP/error handling of :class:`~seeknal.integrations.atlas_governance.GovernanceGate`.
+    """
+
+    def __init__(
+        self,
+        config: AtlasContractConfig,
+        *,
+        client: httpx.Client | None = None,
+    ) -> None:
+        self.config = config
+        self._client = client
+
+    # -- HTTP plumbing -------------------------------------------------------
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.config.token:
+            headers["Authorization"] = f"Bearer {self.config.token}"
+        return headers
+
+    def _get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        url = f"{self.config.base_url}{path}"
+        clean = {
+            key: value for key, value in (params or {}).items() if value is not None
+        }
+        try:
+            if self._client is not None:
+                response = self._client.get(url, params=clean, headers=self._headers())
+            else:
+                response = httpx.get(
+                    url,
+                    params=clean,
+                    headers=self._headers(),
+                    timeout=self.config.timeout_seconds,
+                )
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as exc:
+            message = exc.response.text.strip() or str(exc)
+            raise AtlasContractError(
+                f"Atlas catalog request failed for {path}: {message}"
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise AtlasContractError(
+                f"Atlas catalog request failed for {path}: {exc}"
+            ) from exc
+
+    def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        url = f"{self.config.base_url}{path}"
+        try:
+            if self._client is not None:
+                response = self._client.post(url, json=payload, headers=self._headers())
+            else:
+                response = httpx.post(
+                    url,
+                    json=payload,
+                    headers=self._headers(),
+                    timeout=self.config.timeout_seconds,
+                )
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as exc:
+            message = exc.response.text.strip() or str(exc)
+            raise AtlasContractError(
+                f"Atlas catalog request failed for {path}: {message}"
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise AtlasContractError(
+                f"Atlas catalog request failed for {path}: {exc}"
+            ) from exc
+
+    # -- Public API ----------------------------------------------------------
+
+    def list_datasets(
+        self,
+        *,
+        query: str | None = None,
+        asset_type: str | None = None,
+        namespace: str | None = None,
+        source_system: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[Dataset]:
+        """List catalog assets, optionally filtered. Returns a list of :class:`Dataset`.
+
+        GET ``/api/assets``. ``query`` maps to the ``q`` parameter and ``asset_type``
+        to ``type``. The backend returns a JSON array of asset dicts.
+        """
+
+        params = {
+            "q": query,
+            "type": asset_type,
+            "namespace": namespace,
+            "source_system": source_system,
+            "limit": limit,
+            "offset": offset,
+        }
+        resp = self._get("/api/assets", params)
+        return [Dataset.from_api(asset) for asset in (resp or [])]
+
+    def get_dataset(self, dataset_id: str) -> Dataset:
+        """Fetch a single catalog asset by id.
+
+        GET ``/api/assets/{dataset_id}`` and project the result into a :class:`Dataset`.
+        """
+
+        resp = self._get(f"/api/assets/{dataset_id}")
+        return Dataset.from_api(resp)
+
+    def search(
+        self,
+        query: str,
+        *,
+        asset_types: Sequence[str] | None = None,
+        tags: Sequence[str] | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[Dataset]:
+        """Full-text search across the catalog. Returns a list of :class:`Dataset`.
+
+        GET ``/api/search`` with ``q=query``. The response may be a bare JSON array or
+        a dict wrapping the hits under ``results``/``items``/``assets``; both shapes are
+        handled, and each hit is mapped tolerantly via :meth:`Dataset.from_api`.
+        """
+
+        params = {
+            "q": query,
+            "asset_types": list(asset_types) if asset_types else None,
+            "tags": list(tags) if tags else None,
+            "limit": limit,
+            "offset": offset,
+        }
+        resp = self._get("/api/search", params)
+        if isinstance(resp, dict):
+            hits = resp.get("results") or resp.get("items") or resp.get("assets") or []
+        else:
+            hits = resp or []
+        return [Dataset.from_api(hit) for hit in hits if isinstance(hit, dict)]
+
+    def sample(
+        self, identifier: str, *, limit: int = 20, offset: int = 0
+    ) -> dict[str, Any]:
+        """Fetch a row sample for an asset, returning the backend JSON verbatim.
+
+        GET ``/api/sample`` with the required ``identifier`` plus ``limit``/``offset``.
+        The response is returned unmodified for the caller to render.
+        """
+
+        return self._get(
+            "/api/sample",
+            {"identifier": identifier, "limit": limit, "offset": offset},
+        )
+
+    def annotate(
+        self,
+        dataset_id: str,
+        *,
+        tags: Sequence[str] | None = None,
+        description: str | None = None,
+        owners: Sequence[str] | None = None,
+    ) -> dict[str, Any]:
+        """Upsert the unified-catalog asset annotations.
+
+        Fetches the current asset, unions any new ``tags`` with the existing ones,
+        overrides ``description`` when supplied, records ``owners`` in metadata when
+        given, then POSTs the merged asset to ``/api/contracts/assets/register``.
+        Returns the backend response.
+        """
+
+        current = self.get_dataset(dataset_id)
+
+        merged_tags = list(current.tags)
+        if tags:
+            for tag in tags:
+                if tag and tag not in merged_tags:
+                    merged_tags.append(tag)
+
+        description_value = (
+            description if description is not None else current.description
+        )
+
+        metadata = dict(current.metadata)
+        metadata["description"] = description_value
+        metadata["tags"] = merged_tags
+        if owners:
+            metadata["owners"] = list(owners)
+
+        source_id = str(
+            current.metadata.get("source_id", "")
+            or f"{current.asset_type}:{current.name}"
+        )
+        asset = {
+            "asset_type": current.asset_type,
+            "name": current.name,
+            "namespace": current.namespace,
+            "source_system": current.source_system,
+            "source_id": source_id,
+            "description": description_value,
+            "tags": merged_tags,
+            "metadata": metadata,
+        }
+        payload = {
+            "project_name": os.getenv("SEEKNAL_PROJECT_NAME") or current.namespace,
+            "environment": os.getenv("ATLAS_ENVIRONMENT", "dev"),
+            "asset": asset,
+        }
+        return self._post("/api/contracts/assets/register", payload)
+
+
+def create_catalog_client_from_env() -> "AtlasCatalogClient | None":
+    """Build a catalog client only when Atlas is configured.
+
+    Returns ``None`` when ``ATLAS_API_URL`` is unset, signalling catalog features are
+    inactive. Otherwise mirrors
+    :func:`~seeknal.integrations.atlas_governance.create_governance_gate_from_env`:
+    an explicit ``ATLAS_API_TOKEN`` wins, else the logged-in user's token is used so
+    per-user identity flows to Atlas.
+    """
+
+    base_url = os.getenv("ATLAS_API_URL", "").strip()
+    if not base_url:
+        return None
+
+    timeout = float(os.getenv("ATLAS_API_TIMEOUT_SECONDS", "10"))
+    token = os.getenv("ATLAS_API_TOKEN") or user_token_from_credentials()
+    config = AtlasContractConfig(
+        base_url=base_url.rstrip("/"),
+        token=token,
+        timeout_seconds=timeout,
+    )
+    return AtlasCatalogClient(config)

--- a/src/seeknal/integrations/atlas_catalog.py
+++ b/src/seeknal/integrations/atlas_catalog.py
@@ -35,6 +35,7 @@ from seeknal.integrations.atlas_client import (
     AtlasContractError,
     SESSION_EXPIRED_HINT,
 )
+from seeknal.integrations.atlas_config import atlas_config
 from seeknal.integrations.atlas_governance import (
     refresh_access_token,
     user_token_from_credentials,
@@ -514,7 +515,8 @@ def create_catalog_client_from_env() -> "AtlasCatalogClient | None":
     per-user identity flows to Atlas.
     """
 
-    base_url = os.getenv("ATLAS_API_URL", "").strip()
+    cfg = atlas_config()
+    base_url = os.getenv("ATLAS_API_URL", "").strip() or cfg.api_url
     if not base_url:
         return None
 
@@ -527,5 +529,5 @@ def create_catalog_client_from_env() -> "AtlasCatalogClient | None":
     )
     # When the portal is configured, ``list_datasets`` lists from its ``/api/datasets``
     # aggregator so the CLI catalog matches the web (Lakekeeper tables + cube products).
-    portal_url = os.getenv("ATLAS_PORTAL_URL", "").strip() or None
+    portal_url = (os.getenv("ATLAS_PORTAL_URL", "").strip() or cfg.portal_url) or None
     return AtlasCatalogClient(config, portal_url=portal_url)

--- a/src/seeknal/integrations/atlas_catalog.py
+++ b/src/seeknal/integrations/atlas_catalog.py
@@ -85,6 +85,48 @@ class Dataset:
             metadata=dict(metadata),
         )
 
+    @classmethod
+    def from_portal(cls, d: dict[str, Any]) -> "Dataset":
+        """Map a portal ``/api/datasets`` row (the web catalog shape) to a Dataset.
+
+        The portal aggregates Lakekeeper Iceberg tables and DataHub cube products and
+        returns rows shaped as ``{urn, name:"{ns}.{table}", displayName, namespace,
+        platform, type, tags}`` — where ``name`` is already the fully-qualified
+        ``namespace.table``. We keep the short ``displayName`` as :attr:`name` and the
+        ``namespace`` separate so :attr:`fqn` recomposes the governed identifier
+        (``namespace.name``) without doubling the namespace. ``platform`` (iceberg/cube)
+        becomes ``source_system`` and ``type`` (table/cube) becomes ``asset_type`` so the
+        CLI renders the same columns the registry path produces.
+        """
+
+        namespace = str(d.get("namespace", "") or "")
+        full_name = str(d.get("name", "") or "")
+        display = str(d.get("displayName", "") or "")
+        if display:
+            name = display
+        elif namespace and full_name.startswith(f"{namespace}."):
+            name = full_name[len(namespace) + 1 :]
+        else:
+            name = full_name
+        raw_tags = d.get("tags") or []
+        tags = tuple(str(tag) for tag in raw_tags if tag)
+        return cls(
+            id=str(d.get("urn") or full_name),
+            name=name,
+            namespace=namespace,
+            asset_type=str(d.get("type", "") or ""),
+            source_system=str(d.get("platform", "") or ""),
+            description=str(d.get("description", "") or ""),
+            tags=tags,
+            canonical_id="",
+            metadata={
+                "urn": d.get("urn"),
+                "fullName": full_name,
+                "displayName": display,
+                "platform": d.get("platform"),
+            },
+        )
+
     @property
     def fqn(self) -> str:
         """Fully-qualified name for the dataset.
@@ -114,6 +156,7 @@ class AtlasCatalogClient:
         *,
         client: httpx.Client | None = None,
         token_refresher: Callable[[], str | None] | None = None,
+        portal_url: str | None = None,
     ) -> None:
         self.config = config
         self._client = client
@@ -121,6 +164,11 @@ class AtlasCatalogClient:
         # refresh can swap in a new access token without rebuilding the frozen config.
         self._token = config.token
         self._token_refresher = token_refresher or refresh_access_token
+        # When set (env ``ATLAS_PORTAL_URL``), ``list_datasets`` reads the portal's
+        # ``/api/datasets`` aggregator — the *same* source the web UI lists — so the CLI
+        # catalog matches the web (Lakekeeper tables + cubes) instead of the seeknal
+        # asset registry. Unset → the registry path (``/api/assets``) is used.
+        self._portal_url = (portal_url or "").rstrip("/") or None
 
     # -- HTTP plumbing -------------------------------------------------------
 
@@ -165,6 +213,7 @@ class AtlasCatalogClient:
         *,
         params: dict[str, Any] | None = None,
         json_body: dict[str, Any] | None = None,
+        base: str | None = None,
     ) -> Any:
         """Send a request, transparently refreshing the token once on HTTP 401.
 
@@ -173,9 +222,13 @@ class AtlasCatalogClient:
         still 401), an :class:`AtlasAuthError` carrying a re-authentication hint is
         raised — never a raw traceback. Other HTTP/transport failures map to
         :class:`AtlasContractError` as before.
+
+        ``base`` overrides the request host (default :attr:`config.base_url`) so the
+        same per-user-token + 401-refresh plumbing can reach the portal aggregator at
+        ``ATLAS_PORTAL_URL`` as well as the seeknal-api backend.
         """
 
-        url = f"{self.config.base_url}{path}"
+        url = f"{base or self.config.base_url}{path}"
         refreshed = False
         while True:
             try:
@@ -223,9 +276,22 @@ class AtlasCatalogClient:
     ) -> list[Dataset]:
         """List catalog assets, optionally filtered. Returns a list of :class:`Dataset`.
 
-        GET ``/api/assets``. ``query`` maps to the ``q`` parameter and ``asset_type``
-        to ``type``. The backend returns a JSON array of asset dicts.
+        When ``ATLAS_PORTAL_URL`` is configured this reads the portal's
+        ``/api/datasets`` aggregator (the same Lakekeeper-tables + cube-products catalog
+        the web UI lists) so the CLI matches the web. Otherwise it reads the seeknal
+        asset registry: GET ``/api/assets`` (``query``→``q``, ``asset_type``→``type``),
+        which returns a JSON array of asset dicts.
         """
+
+        if self._portal_url is not None:
+            return self._list_from_portal(
+                query=query,
+                asset_type=asset_type,
+                namespace=namespace,
+                source_system=source_system,
+                limit=limit,
+                offset=offset,
+            )
 
         params = {
             "q": query,
@@ -237,6 +303,43 @@ class AtlasCatalogClient:
         }
         resp = self._get("/api/assets", params)
         return [Dataset.from_api(asset) for asset in (resp or [])]
+
+    def _list_from_portal(
+        self,
+        *,
+        query: str | None,
+        asset_type: str | None,
+        namespace: str | None,
+        source_system: str | None,
+        limit: int,
+        offset: int,
+    ) -> list[Dataset]:
+        """List datasets from the portal ``/api/datasets`` aggregator (web parity).
+
+        The portal accepts ``q``/``namespace``/``platform``/``limit``/``offset`` and
+        returns ``{"datasets": [...], "total", "facets"}`` (a bare array is also
+        tolerated). ``source_system`` is forwarded as the portal's ``platform`` filter;
+        ``asset_type`` (which the portal does not filter on) is applied client-side so
+        the CLI's ``--type`` flag keeps working across both catalog sources.
+        """
+
+        params = {
+            "q": query,
+            "namespace": namespace,
+            "platform": source_system,
+            "limit": limit,
+            "offset": offset,
+        }
+        clean = {key: value for key, value in params.items() if value is not None}
+        resp = self._send("GET", "/api/datasets", params=clean, base=self._portal_url)
+        if isinstance(resp, dict):
+            rows = resp.get("datasets") or resp.get("results") or resp.get("items") or []
+        else:
+            rows = resp or []
+        datasets = [Dataset.from_portal(row) for row in rows if isinstance(row, dict)]
+        if asset_type:
+            datasets = [d for d in datasets if d.asset_type == asset_type]
+        return datasets
 
     def get_dataset(self, dataset_id: str) -> Dataset:
         """Fetch a single catalog asset by id.
@@ -368,4 +471,7 @@ def create_catalog_client_from_env() -> "AtlasCatalogClient | None":
         token=token,
         timeout_seconds=timeout,
     )
-    return AtlasCatalogClient(config)
+    # When the portal is configured, ``list_datasets`` lists from its ``/api/datasets``
+    # aggregator so the CLI catalog matches the web (Lakekeeper tables + cube products).
+    portal_url = os.getenv("ATLAS_PORTAL_URL", "").strip() or None
+    return AtlasCatalogClient(config, portal_url=portal_url)

--- a/src/seeknal/integrations/atlas_client.py
+++ b/src/seeknal/integrations/atlas_client.py
@@ -7,7 +7,7 @@ import os
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import httpx
 
@@ -37,6 +37,12 @@ class AtlasAuthError(AtlasContractError):
 #: could not be refreshed automatically. Surfaced verbatim by the CLI (no traceback).
 SESSION_EXPIRED_HINT = (
     "Your Atlas session has expired. Run `seeknal auth login` to sign in again."
+)
+
+#: Hint for the never-logged-in case: Atlas rejected the request and we had no token
+#: to send at all (no ATLAS_API_TOKEN and no credentials file).
+NOT_LOGGED_IN_HINT = (
+    "Atlas requires authentication. Run `seeknal auth login` to sign in."
 )
 
 
@@ -69,8 +75,15 @@ def create_atlas_contract_client_from_env() -> "AtlasContractClient | None":
     if not base_url:
         return None
 
+    # Lazy import: atlas_governance imports from this module, so a top-level
+    # import here would be circular.
+    from seeknal.integrations.atlas_governance import user_token_from_credentials
+
     timeout = float(os.getenv("ATLAS_API_TIMEOUT_SECONDS", "10"))
-    token = os.getenv("ATLAS_API_TOKEN")
+    # An explicit service token wins; otherwise fall back to the logged-in user's
+    # token so apply-time contract calls authenticate after `seeknal auth login`,
+    # matching the governance gate and the catalog client.
+    token = os.getenv("ATLAS_API_TOKEN") or user_token_from_credentials()
     return AtlasContractClient(
         AtlasContractConfig(base_url=base_url.rstrip("/"), token=token, timeout_seconds=timeout)
     )
@@ -258,33 +271,73 @@ def _build_asset_ref(
 
 
 class AtlasContractClient:
-    """Minimal HTTP client for Atlas Phase 1 contract endpoints."""
+    """Minimal HTTP client for Atlas Phase 1 contract endpoints.
 
-    def __init__(self, config: AtlasContractConfig):
+    Pass an explicit ``client`` (e.g. backed by :class:`httpx.MockTransport`) and/or
+    ``token_refresher`` in tests; both default to the production behavior.
+    """
+
+    def __init__(
+        self,
+        config: AtlasContractConfig,
+        *,
+        client: httpx.Client | None = None,
+        token_refresher: "Callable[[], str | None] | None" = None,
+    ):
         self.config = config
+        self._client = client
+        # Mutable bearer copy so a 401 can be recovered by refreshing the access token
+        # (the frozen config stays the source of the *initial* token).
+        self._token = config.token
+        self._token_refresher = token_refresher
 
     def _headers(self) -> dict[str, str]:
         headers = {"Content-Type": "application/json"}
-        if self.config.token:
-            headers["Authorization"] = f"Bearer {self.config.token}"
+        if self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
         return headers
+
+    def _refresh_token(self) -> str | None:
+        if self._token_refresher is not None:
+            return self._token_refresher()
+        # Lazy import: atlas_governance imports from this module (circular otherwise).
+        from seeknal.integrations.atlas_governance import refresh_access_token
+
+        return refresh_access_token()
 
     def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
         url = f"{self.config.base_url}{path}"
-        try:
-            response = httpx.post(
-                url,
-                json=payload,
-                headers=self._headers(),
-                timeout=self.config.timeout_seconds,
-            )
-            response.raise_for_status()
-            return response.json()
-        except httpx.HTTPStatusError as exc:
-            message = exc.response.text.strip() or str(exc)
-            raise AtlasContractError(f"Atlas contract request failed for {path}: {message}") from exc
-        except httpx.HTTPError as exc:
-            raise AtlasContractError(f"Atlas contract request failed for {path}: {exc}") from exc
+        refreshed = False
+        while True:
+            try:
+                if self._client is not None:
+                    response = self._client.post(url, json=payload, headers=self._headers())
+                else:
+                    response = httpx.post(
+                        url,
+                        json=payload,
+                        headers=self._headers(),
+                        timeout=self.config.timeout_seconds,
+                    )
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPStatusError as exc:
+                # Transparently refresh the access token once on a 401, then retry —
+                # mirrors GovernanceGate._post / AtlasCatalogClient._send so a single
+                # `seeknal auth login` covers the apply-time contract surface too.
+                if exc.response.status_code == 401:
+                    if not refreshed:
+                        refreshed = True
+                        new_token = self._refresh_token()
+                        if new_token:
+                            self._token = new_token
+                            continue
+                    hint = SESSION_EXPIRED_HINT if self._token else NOT_LOGGED_IN_HINT
+                    raise AtlasAuthError(hint) from exc
+                message = exc.response.text.strip() or str(exc)
+                raise AtlasContractError(f"Atlas contract request failed for {path}: {message}") from exc
+            except httpx.HTTPError as exc:
+                raise AtlasContractError(f"Atlas contract request failed for {path}: {exc}") from exc
 
     def preflight_apply(
         self,

--- a/src/seeknal/integrations/atlas_client.py
+++ b/src/seeknal/integrations/atlas_client.py
@@ -135,6 +135,93 @@ def _extract_upstreams(
     return upstreams
 
 
+def _extract_owners(yaml_data: dict[str, Any]) -> list[str]:
+    """Normalize a node's `owner`/`owners` YAML into a de-duplicated list.
+
+    Sources declare a single `owner:` string; richer nodes may carry an
+    `owners:` list. Both are forwarded so Atlas/DataHub can set the ownership
+    aspect instead of leaving seeknal-applied datasets unassigned.
+    """
+
+    owners: list[str] = []
+
+    def _add(value: Any) -> None:
+        text = str(value).strip()
+        if text and text not in owners:
+            owners.append(text)
+
+    owner = yaml_data.get("owner")
+    if isinstance(owner, (list, tuple)):
+        for item in owner:
+            _add(item)
+    elif owner:
+        _add(owner)
+
+    extra = yaml_data.get("owners")
+    if isinstance(extra, (list, tuple)):
+        for item in extra:
+            _add(item)
+    elif extra:
+        _add(extra)
+
+    return owners
+
+
+def _extract_columns(yaml_data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Normalize a node's column metadata into ``[{name, description?, data_type?}]``.
+
+    Merges two YAML shapes seeknal uses: ``columns`` (a ``{name: description}``
+    mapping, or a list of dicts) and ``schema`` (a list of ``{name, data_type}``).
+    Forwarded so the backend can emit ``schemaMetadata`` / per-column
+    ``editableSchemaMetadata`` descriptions for Phase 4 column-level parity.
+    """
+
+    cols: dict[str, dict[str, Any]] = {}
+
+    def _slot(name: Any) -> dict[str, Any] | None:
+        text = str(name).strip()
+        if not text:
+            return None
+        return cols.setdefault(text, {"name": text})
+
+    for entry in yaml_data.get("schema", []) or []:
+        if isinstance(entry, dict) and entry.get("name"):
+            slot = _slot(entry["name"])
+            if slot is not None and entry.get("data_type"):
+                slot["data_type"] = str(entry["data_type"])
+
+    columns = yaml_data.get("columns")
+    if isinstance(columns, dict):
+        for name, value in columns.items():
+            slot = _slot(name)
+            if slot is None:
+                continue
+            if isinstance(value, dict):
+                desc = value.get("desc") or value.get("description")
+                if desc:
+                    slot["description"] = str(desc)
+                dtype = value.get("data_type") or value.get("dtype")
+                if dtype:
+                    slot["data_type"] = str(dtype)
+            elif value:
+                slot["description"] = str(value)
+    elif isinstance(columns, (list, tuple)):
+        for entry in columns:
+            if not isinstance(entry, dict) or not entry.get("name"):
+                continue
+            slot = _slot(entry["name"])
+            if slot is None:
+                continue
+            desc = entry.get("desc") or entry.get("description")
+            if desc:
+                slot["description"] = str(desc)
+            dtype = entry.get("data_type") or entry.get("dtype")
+            if dtype:
+                slot["data_type"] = str(dtype)
+
+    return list(cols.values())
+
+
 def _build_asset_ref(
     *,
     node_type: str,
@@ -147,6 +234,17 @@ def _build_asset_ref(
     asset_type = _asset_type_for_node(node_type)
     description = yaml_data.get("description")
     tags = list(yaml_data.get("tags", []) or [])
+    metadata: dict[str, Any] = {
+        "kind": node_type,
+        "path": str(target_path),
+        "inputs": len(yaml_data.get("inputs", []) or []),
+    }
+    owners = _extract_owners(yaml_data)
+    if owners:
+        metadata["owners"] = owners
+    columns = _extract_columns(yaml_data)
+    if columns:
+        metadata["columns"] = columns
     return {
         "asset_type": asset_type,
         "name": name,
@@ -155,11 +253,7 @@ def _build_asset_ref(
         "source_id": f"{asset_type}:{name}",
         "description": description,
         "tags": tags,
-        "metadata": {
-            "kind": node_type,
-            "path": str(target_path),
-            "inputs": len(yaml_data.get("inputs", []) or []),
-        },
+        "metadata": metadata,
     }
 
 
@@ -307,6 +401,32 @@ class AtlasContractClient:
                 details={"phase": "complete-apply"},
             )
             raise
+
+    def publish_lineage(
+        self,
+        *,
+        project_name: str,
+        environment: str,
+        asset: dict[str, Any],
+        upstreams: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Publish an ``asset → upstreams`` lineage edge set to Atlas/DataHub.
+
+        Standalone counterpart to the apply-time lineage publish, usable from
+        ``seeknal atlas lineage publish`` without the optional
+        ``atlas-data-platform`` package — it hits the same
+        ``/api/contracts/lineage/publish`` endpoint over plain HTTP.
+        """
+
+        return self._post(
+            "/api/contracts/lineage/publish",
+            {
+                "project_name": project_name,
+                "environment": environment,
+                "asset": asset,
+                "upstreams": upstreams,
+            },
+        )
 
     def report_local_failure(
         self,

--- a/src/seeknal/integrations/atlas_client.py
+++ b/src/seeknal/integrations/atlas_client.py
@@ -11,6 +11,8 @@ from typing import Any
 
 import httpx
 
+from seeknal.integrations.atlas_config import atlas_config
+
 
 class AtlasContractError(RuntimeError):
     """Raised when Atlas contract sync fails."""
@@ -63,7 +65,7 @@ class AtlasApplyContext:
 def create_atlas_contract_client_from_env() -> "AtlasContractClient | None":
     """Create a client only when Atlas sync is explicitly configured."""
 
-    base_url = os.getenv("ATLAS_API_URL", "").strip()
+    base_url = os.getenv("ATLAS_API_URL", "").strip() or atlas_config().api_url
     if not base_url:
         return None
 

--- a/src/seeknal/integrations/atlas_client.py
+++ b/src/seeknal/integrations/atlas_client.py
@@ -20,6 +20,24 @@ class AtlasPolicyDenied(AtlasContractError):
     """Raised when Atlas explicitly denies a Seeknal operation."""
 
 
+class AtlasAuthError(AtlasContractError):
+    """Raised when the caller's Atlas session is missing or expired (HTTP 401).
+
+    Carries a user-facing, re-authentication hint. It is only raised after an
+    automatic token refresh has been attempted and failed (or no refresh token was
+    available), so the right remedy is always to log in again. Subclasses
+    :class:`AtlasContractError` so existing ``except AtlasContractError`` handlers
+    keep working while callers may special-case the auth message.
+    """
+
+
+#: One-line, user-facing hint shown when the Atlas session is missing/expired and
+#: could not be refreshed automatically. Surfaced verbatim by the CLI (no traceback).
+SESSION_EXPIRED_HINT = (
+    "Your Atlas session has expired. Run `seeknal auth login` to sign in again."
+)
+
+
 @dataclass(frozen=True)
 class AtlasContractConfig:
     """Environment-backed Atlas client configuration."""

--- a/src/seeknal/integrations/atlas_config.py
+++ b/src/seeknal/integrations/atlas_config.py
@@ -1,0 +1,146 @@
+"""Persisted Atlas connection config, so the CLI doesn't need 3 env vars per shell.
+
+The integration needs three connection settings — the seeknal-api URL, the portal
+URL, and the Keycloak issuer. Requiring them as environment variables in every shell
+is error-prone (the recurring "not synced" / "session expired" confusion). This
+module persists them once to ``~/.config/seeknal/atlas.json`` (override
+``SEEKNAL_ATLAS_CONFIG_PATH``) and the ``*_from_env`` factories fall back to it.
+
+Precedence everywhere is **environment variable > this config file > built-in
+default**, so existing env-var users are unaffected. The file holds only *stable*
+connection settings; tokens live separately in the credentials file. Reading never
+raises: a missing or malformed file yields an empty config.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+#: Default config location (override with ``SEEKNAL_ATLAS_CONFIG_PATH``).
+_DEFAULT_CONFIG_PATH = "~/.config/seeknal/atlas.json"
+
+#: Standard ATLAS deployment ports/realm used when deriving from a single host.
+_DEFAULT_API_PORT = 8000
+_DEFAULT_PORTAL_PORT = 4200
+_DEFAULT_KEYCLOAK_PORT = 8080
+_DEFAULT_REALM = "atlas"
+_DEFAULT_CLIENT_ID = "seeknal-cli"
+
+
+@dataclass(frozen=True)
+class AtlasConfig:
+    """The stable Atlas connection settings. Empty strings mean "not configured"."""
+
+    api_url: str = ""
+    portal_url: str = ""
+    keycloak_issuer: str = ""
+    oidc_client_id: str = ""
+
+
+def config_path() -> Path:
+    """Resolve the Atlas config file path (env override, else the default)."""
+
+    raw = os.getenv("SEEKNAL_ATLAS_CONFIG_PATH", "").strip() or _DEFAULT_CONFIG_PATH
+    return Path(raw).expanduser()
+
+
+def atlas_config() -> AtlasConfig:
+    """Load the persisted Atlas config. Never raises — an absent/garbled file or a
+    non-object payload yields an empty :class:`AtlasConfig`, preserving the env-var
+    path."""
+
+    try:
+        data = json.loads(config_path().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return AtlasConfig()
+    if not isinstance(data, dict):
+        return AtlasConfig()
+
+    def _str(key: str) -> str:
+        value = data.get(key)
+        return value.strip() if isinstance(value, str) else ""
+
+    return AtlasConfig(
+        api_url=_str("api_url").rstrip("/"),
+        portal_url=_str("portal_url").rstrip("/"),
+        keycloak_issuer=_str("keycloak_issuer").rstrip("/"),
+        oidc_client_id=_str("oidc_client_id"),
+    )
+
+
+def save_atlas_config(config: AtlasConfig) -> Path:
+    """Persist ``config`` atomically (mode 0600 from creation). Returns the path."""
+
+    path = config_path()
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    payload = {
+        "api_url": config.api_url,
+        "portal_url": config.portal_url,
+        "keycloak_issuer": config.keycloak_issuer,
+        "oidc_client_id": config.oidc_client_id,
+    }
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".atlas-", suffix=".tmp")
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, indent=2))
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+    return path
+
+
+def _host_of(value: str) -> str:
+    """Return the bare hostname from a URL or a ``host[:port]`` string."""
+
+    if not value:
+        return ""
+    if "://" in value:
+        return urlparse(value).hostname or ""
+    # bare "host" or "host:port"
+    return value.split("/")[0].split(":")[0]
+
+
+def derive_config(
+    *,
+    host: str = "",
+    api_url: str = "",
+    portal_url: str = "",
+    keycloak_issuer: str = "",
+    realm: str = _DEFAULT_REALM,
+    oidc_client_id: str = "",
+) -> AtlasConfig:
+    """Build a full :class:`AtlasConfig` from a single ``host`` (or ``api_url``).
+
+    Any explicit ``portal_url``/``keycloak_issuer`` wins; otherwise they are derived
+    from the host using the standard ATLAS ports (api 8000, portal 4200, keycloak
+    8080 + realm). This is what powers ``seeknal auth config set --host atlas-dev``.
+    """
+
+    base_host = _host_of(host or api_url)
+    resolved_api = api_url.rstrip("/") or (
+        f"http://{base_host}:{_DEFAULT_API_PORT}" if base_host else ""
+    )
+    resolved_portal = portal_url.rstrip("/") or (
+        f"http://{base_host}:{_DEFAULT_PORTAL_PORT}" if base_host else ""
+    )
+    resolved_keycloak = keycloak_issuer.rstrip("/") or (
+        f"http://{base_host}:{_DEFAULT_KEYCLOAK_PORT}/realms/{realm or _DEFAULT_REALM}"
+        if base_host
+        else ""
+    )
+    return AtlasConfig(
+        api_url=resolved_api,
+        portal_url=resolved_portal,
+        keycloak_issuer=resolved_keycloak,
+        oidc_client_id=oidc_client_id.strip() or _DEFAULT_CLIENT_ID,
+    )

--- a/src/seeknal/integrations/atlas_config.py
+++ b/src/seeknal/integrations/atlas_config.py
@@ -110,6 +110,25 @@ def _host_of(value: str) -> str:
     return value.split("/")[0].split(":")[0]
 
 
+def _api_from_host(host: str) -> str:
+    """Build the API URL from a ``--host`` value, honoring an explicit scheme or port.
+
+    ``atlas-dev`` → ``http://atlas-dev:8000`` (standard port); ``atlas:9000`` →
+    ``http://atlas:9000`` (the given port is kept); ``https://atlas:8443`` is used
+    verbatim. portal/keycloak still derive from the bare host (override them
+    explicitly for non-standard ports).
+    """
+
+    if not host:
+        return ""
+    cleaned = host.rstrip("/")
+    if "://" in cleaned:
+        return cleaned
+    if ":" in cleaned:  # host:port — honor the port the user gave
+        return f"http://{cleaned}"
+    return f"http://{cleaned}:{_DEFAULT_API_PORT}"
+
+
 def derive_config(
     *,
     host: str = "",
@@ -127,9 +146,7 @@ def derive_config(
     """
 
     base_host = _host_of(host or api_url)
-    resolved_api = api_url.rstrip("/") or (
-        f"http://{base_host}:{_DEFAULT_API_PORT}" if base_host else ""
-    )
+    resolved_api = api_url.rstrip("/") or _api_from_host(host)
     resolved_portal = portal_url.rstrip("/") or (
         f"http://{base_host}:{_DEFAULT_PORTAL_PORT}" if base_host else ""
     )

--- a/src/seeknal/integrations/atlas_governance.py
+++ b/src/seeknal/integrations/atlas_governance.py
@@ -28,16 +28,19 @@ import getpass
 import json
 import os
 import re
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any, Callable, Iterable, Mapping, Sequence
 
 import httpx
 
 from seeknal.integrations.atlas_client import (
+    AtlasAuthError,
     AtlasContractConfig,
     AtlasContractError,
     AtlasPolicyDenied,
+    SESSION_EXPIRED_HINT,
 )
 
 __all__ = [
@@ -55,6 +58,7 @@ __all__ = [
     "user_token_from_credentials",
     "user_sub_from_credentials",
     "user_email_from_credentials",
+    "refresh_access_token",
 ]
 
 #: Replacement rendered for a fully masked value.
@@ -129,6 +133,114 @@ def _user_token_from_credentials() -> str | None:
 
 #: Public alias for reuse by the CLI; mirrors the private gate-side reader.
 user_token_from_credentials = _user_token_from_credentials
+
+
+#: OIDC config for refreshing the stored access token. Mirrors ``cli/auth.py`` so a
+#: single ``KEYCLOAK_ISSUER`` / ``SEEKNAL_OIDC_CLIENT_ID`` drives login *and* refresh.
+_DEFAULT_OIDC_ISSUER = "http://localhost:8080/realms/atlas"
+_DEFAULT_OIDC_CLIENT_ID = "seeknal-cli"
+#: Seconds to wait on the token endpoint before giving up on a refresh.
+_REFRESH_TIMEOUT_SECONDS = 30.0
+
+
+def _oidc_issuer() -> str:
+    """Return the Keycloak realm issuer used for token refresh (no trailing slash)."""
+
+    return (os.getenv("KEYCLOAK_ISSUER", "").strip() or _DEFAULT_OIDC_ISSUER).rstrip("/")
+
+
+def _oidc_client_id() -> str:
+    """Return the public OIDC client id used for token refresh."""
+
+    return os.getenv("SEEKNAL_OIDC_CLIENT_ID", "").strip() or _DEFAULT_OIDC_CLIENT_ID
+
+
+def _persist_refreshed_tokens(existing: dict[str, Any], tokens: dict[str, Any]) -> None:
+    """Best-effort write of refreshed tokens to the credentials file (mode 0600).
+
+    Preserves the previous ``refresh_token``/``refresh_expires_in`` when the refresh
+    response omits them (Keycloak usually rotates the refresh token, but not always).
+    Never raises: a refresh whose token we already hold in memory must still succeed
+    even if the on-disk write fails.
+    """
+
+    payload = {
+        "access_token": tokens.get("access_token"),
+        "refresh_token": tokens.get("refresh_token") or existing.get("refresh_token"),
+        "expires_in": tokens.get("expires_in"),
+        "refresh_expires_in": (
+            tokens.get("refresh_expires_in") or existing.get("refresh_expires_in")
+        ),
+    }
+    try:
+        path = credentials_path()
+        path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        # Write to a temp file that is owner-only (0600) from creation, then atomically
+        # rename into place. This avoids the brief world/group-readable window of
+        # ``write_text`` + ``chmod`` and prevents a torn file if the process dies mid-write.
+        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".credentials-", suffix=".tmp")
+        try:
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(json.dumps(payload, indent=2))
+            os.replace(tmp, path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+    except OSError:
+        pass
+
+
+def refresh_access_token(*, client: httpx.Client | None = None) -> str | None:
+    """Mint a fresh access token from the stored refresh token, or return ``None``.
+
+    Uses the OAuth2 ``refresh_token`` grant against the Keycloak realm (the public
+    ``seeknal-cli`` client). On success the rotated tokens are persisted to the
+    credentials file (mode 0600) and the new access token is returned. Returns
+    ``None`` (never raises) when there is no usable refresh token, the grant is
+    rejected (e.g. the refresh token itself has expired), or the identity provider is
+    unreachable — callers then surface a "log in again" hint instead of a traceback.
+
+    ``client`` lets tests inject an :class:`httpx.Client` (e.g. ``MockTransport``).
+    """
+
+    creds = _read_credentials()
+    if not creds:
+        return None
+    refresh_token = creds.get("refresh_token")
+    if not isinstance(refresh_token, str) or not refresh_token.strip():
+        return None
+
+    data = {
+        "grant_type": "refresh_token",
+        "client_id": _oidc_client_id(),
+        "refresh_token": refresh_token,
+    }
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    endpoint = f"{_oidc_issuer()}/protocol/openid-connect/token"
+    try:
+        if client is not None:
+            response = client.post(
+                endpoint, data=data, headers=headers, timeout=_REFRESH_TIMEOUT_SECONDS
+            )
+        else:
+            response = httpx.post(
+                endpoint, data=data, headers=headers, timeout=_REFRESH_TIMEOUT_SECONDS
+            )
+        response.raise_for_status()
+        tokens = response.json()
+    except (httpx.HTTPError, ValueError):
+        return None
+    if not isinstance(tokens, dict):
+        return None
+    new_token = tokens.get("access_token")
+    if not isinstance(new_token, str) or not new_token.strip():
+        return None
+    _persist_refreshed_tokens(creds, tokens)
+    return new_token
 
 
 def _decode_jwt_payload(token: str) -> dict[str, Any] | None:
@@ -401,10 +513,15 @@ class GovernanceGate:
         *,
         fail_open: bool | None = None,
         client: httpx.Client | None = None,
+        token_refresher: Callable[[], str | None] | None = None,
     ) -> None:
         self.config = config
         self._fail_open = _fail_open_default() if fail_open is None else fail_open
         self._client = client
+        # Mutable bearer copy so a 401 can be recovered by refreshing the access token
+        # (the frozen config stays the source of the *initial* token).
+        self._token = config.token
+        self._token_refresher = token_refresher or refresh_access_token
 
     @property
     def fail_open(self) -> bool:
@@ -416,31 +533,47 @@ class GovernanceGate:
 
     def _headers(self) -> dict[str, str]:
         headers = {"Content-Type": "application/json"}
-        if self.config.token:
-            headers["Authorization"] = f"Bearer {self.config.token}"
+        if self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
         return headers
 
     def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
         url = f"{self.config.base_url}{path}"
-        try:
-            if self._client is not None:
-                response = self._client.post(url, json=payload, headers=self._headers())
-            else:
-                response = httpx.post(
-                    url,
-                    json=payload,
-                    headers=self._headers(),
-                    timeout=self.config.timeout_seconds,
-                )
-            response.raise_for_status()
-            return response.json()
-        except httpx.HTTPStatusError as exc:
-            message = exc.response.text.strip() or str(exc)
-            raise AtlasContractError(
-                f"Atlas governance request failed for {path}: {message}"
-            ) from exc
-        except httpx.HTTPError as exc:
-            raise AtlasContractError(f"Atlas governance request failed for {path}: {exc}") from exc
+        refreshed = False
+        while True:
+            try:
+                if self._client is not None:
+                    response = self._client.post(url, json=payload, headers=self._headers())
+                else:
+                    response = httpx.post(
+                        url,
+                        json=payload,
+                        headers=self._headers(),
+                        timeout=self.config.timeout_seconds,
+                    )
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPStatusError as exc:
+                # Transparently refresh the access token once on a 401, then retry.
+                if exc.response.status_code == 401:
+                    if not refreshed:
+                        refreshed = True
+                        new_token = self._token_refresher()
+                        if new_token:
+                            self._token = new_token
+                            continue
+                    # Unrecoverable auth failure. Raise AtlasAuthError (a subclass of
+                    # AtlasContractError) to mirror AtlasCatalogClient._send: check_access
+                    # still catches it and fails closed, so the run/ask/repl callers that
+                    # only expect AtlasPolicyDenied are unaffected, but the decision now
+                    # carries a clear "session expired" reason instead of "unreachable".
+                    raise AtlasAuthError(SESSION_EXPIRED_HINT) from exc
+                message = exc.response.text.strip() or str(exc)
+                raise AtlasContractError(
+                    f"Atlas governance request failed for {path}: {message}"
+                ) from exc
+            except httpx.HTTPError as exc:
+                raise AtlasContractError(f"Atlas governance request failed for {path}: {exc}") from exc
 
     # -- Public API ----------------------------------------------------------
 
@@ -471,6 +604,12 @@ class GovernanceGate:
 
         try:
             decision = self._post("/api/contracts/access-check", payload)
+        except AtlasAuthError as exc:
+            # An expired/missing session is an authentication problem, not an
+            # availability one: always fail closed (even when fail-open is enabled —
+            # an unauthenticated caller must never be waved through) and surface the
+            # re-authentication hint so the reason is actionable.
+            return AccessDecision(allowed=False, reason=str(exc))
         except AtlasContractError as exc:
             if self._fail_open:
                 return AccessDecision(

--- a/src/seeknal/integrations/atlas_governance.py
+++ b/src/seeknal/integrations/atlas_governance.py
@@ -22,10 +22,14 @@ single Atlas configuration drives both surfaces.
 
 from __future__ import annotations
 
+import base64
+import binascii
 import getpass
+import json
 import os
 import re
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
 
 import httpx
@@ -47,6 +51,10 @@ __all__ = [
     "referenced_tables",
     "mask_value",
     "MASK_TOKEN",
+    "credentials_path",
+    "user_token_from_credentials",
+    "user_sub_from_credentials",
+    "user_email_from_credentials",
 ]
 
 #: Replacement rendered for a fully masked value.
@@ -63,6 +71,125 @@ def _fail_open_default() -> bool:
     """
 
     return os.getenv("ATLAS_FAIL_OPEN", "").strip().lower() in _TRUTHY
+
+
+#: Default location of the seeknal credentials file written by the login flow.
+_DEFAULT_CREDENTIALS_PATH = "~/.config/seeknal/credentials.json"
+
+
+def credentials_path() -> Path:
+    """Return the resolved path to the seeknal credentials file.
+
+    Honours the ``SEEKNAL_CREDENTIALS_PATH`` environment override, falling back to
+    ``~/.config/seeknal/credentials.json``. The file holds the JSON written by the
+    login flow (``access_token``, ``refresh_token``, ...); this function does not
+    require the file to exist.
+    """
+
+    override = os.getenv("SEEKNAL_CREDENTIALS_PATH", "").strip()
+    raw = override or _DEFAULT_CREDENTIALS_PATH
+    return Path(raw).expanduser()
+
+
+def _read_credentials() -> dict[str, Any] | None:
+    """Load the credentials JSON, returning ``None`` if absent or invalid.
+
+    Never raises: a missing file, unreadable file, or malformed JSON all yield
+    ``None`` so callers can treat "logged out" and "broken creds" uniformly.
+    """
+
+    path = credentials_path()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return None
+    try:
+        data = json.loads(text)
+    except (ValueError, TypeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _user_token_from_credentials() -> str | None:
+    """Return the stored ``access_token`` from the credentials file, or ``None``.
+
+    Used by :func:`create_governance_gate_from_env` so per-user identity flows to
+    Atlas once the user has logged in. Returns ``None`` (never raises) when the
+    credentials file is missing, malformed, or carries no usable token.
+    """
+
+    creds = _read_credentials()
+    if not creds:
+        return None
+    token = creds.get("access_token")
+    if isinstance(token, str) and token.strip():
+        return token
+    return None
+
+
+#: Public alias for reuse by the CLI; mirrors the private gate-side reader.
+user_token_from_credentials = _user_token_from_credentials
+
+
+def _decode_jwt_payload(token: str) -> dict[str, Any] | None:
+    """Base64url-decode a JWT's payload segment into a dict.
+
+    No signature verification is performed — the Atlas backend validates the token;
+    this only needs to read claims locally. Returns ``None`` (never raises) when the
+    token is not a well-formed three-segment JWT or the payload is not a JSON object.
+    """
+
+    if not isinstance(token, str):
+        return None
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    segment = parts[1]
+    padding = "=" * (-len(segment) % 4)
+    try:
+        raw = base64.urlsafe_b64decode(segment + padding)
+        payload = json.loads(raw)
+    except (ValueError, TypeError, binascii.Error):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def user_sub_from_credentials() -> str | None:
+    """Return the ``sub`` claim of the stored access token, or ``None``.
+
+    Reads the credentials file, base64url-decodes the JWT payload (no signature
+    check), and extracts the ``sub`` claim. Returns ``None`` (never raises) when the
+    file is absent/invalid, the token is not a JWT, or no ``sub`` claim is present.
+    """
+
+    token = _user_token_from_credentials()
+    if not token:
+        return None
+    payload = _decode_jwt_payload(token)
+    if not payload:
+        return None
+    sub = payload.get("sub")
+    return sub if isinstance(sub, str) and sub else None
+
+
+def user_email_from_credentials() -> str | None:
+    """Return the caller's email from the stored access token, or ``None``.
+
+    Prefers the ``email`` claim, falling back to ``preferred_username``. Returns
+    ``None`` (never raises) when no usable identity claim is available.
+    """
+
+    token = _user_token_from_credentials()
+    if not token:
+        return None
+    payload = _decode_jwt_payload(token)
+    if not payload:
+        return None
+    for claim in ("email", "preferred_username"):
+        value = payload.get(claim)
+        if isinstance(value, str) and value:
+            return value
+    return None
 
 
 @dataclass(frozen=True)
@@ -93,7 +220,9 @@ def create_governance_gate_from_env() -> "GovernanceGate | None":
         return None
 
     timeout = float(os.getenv("ATLAS_API_TIMEOUT_SECONDS", "10"))
-    token = os.getenv("ATLAS_API_TOKEN")
+    # An explicit service token wins; otherwise fall back to the logged-in user's
+    # token so per-user identity flows to Atlas. Both absent → token stays ``None``.
+    token = os.getenv("ATLAS_API_TOKEN") or _user_token_from_credentials()
     config = AtlasContractConfig(
         base_url=base_url.rstrip("/"),
         token=token,

--- a/src/seeknal/integrations/atlas_governance.py
+++ b/src/seeknal/integrations/atlas_governance.py
@@ -1,0 +1,366 @@
+"""Runtime data-access governance gate, active only when Atlas is configured.
+
+This extends the apply-time contract gate in :mod:`seeknal.integrations.atlas_client`
+to *runtime* data access. When ``ATLAS_API_URL`` is set, Seeknal delegates every
+governed read to the Atlas policy backend (OpenFGA-backed): Atlas decides whether
+the caller may read a resource and which columns must be masked. The rules live in
+Atlas — not in editable local YAML — so a project author cannot loosen governance
+by editing a file.
+
+Two deliberate properties:
+
+* **Config-activated.** With no ``ATLAS_API_URL`` the gate is inactive and reads pass
+  through unchanged (full backward compatibility). Governance turns on exactly when
+  the operator configures the Atlas setup.
+* **Fail-closed.** When the gate *is* active, a denied decision or a transport error
+  results in *denied* access (unless ``ATLAS_FAIL_OPEN`` is explicitly set). Governance
+  cannot be bypassed by breaking the connection to Atlas.
+
+The gate reuses the connection settings and error types of the apply-time client so a
+single Atlas configuration drives both surfaces.
+"""
+
+from __future__ import annotations
+
+import getpass
+import os
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Sequence
+
+import httpx
+
+from seeknal.integrations.atlas_client import (
+    AtlasContractConfig,
+    AtlasContractError,
+    AtlasPolicyDenied,
+)
+
+__all__ = [
+    "AccessDecision",
+    "GovernanceGate",
+    "create_governance_gate_from_env",
+    "apply_column_masks",
+    "mask_rows",
+    "govern_read",
+    "mask_value",
+    "MASK_TOKEN",
+]
+
+#: Replacement rendered for a fully masked value.
+MASK_TOKEN = "******"
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _fail_open_default() -> bool:
+    """Return whether the gate should fail *open* on transport errors.
+
+    Defaults to ``False`` (fail-closed). Set ``ATLAS_FAIL_OPEN=true`` only in
+    environments where availability must win over enforcement.
+    """
+
+    return os.getenv("ATLAS_FAIL_OPEN", "").strip().lower() in _TRUTHY
+
+
+@dataclass(frozen=True)
+class AccessDecision:
+    """Outcome of an Atlas access check for a single resource."""
+
+    allowed: bool
+    reason: str = ""
+    masked_columns: tuple[str, ...] = ()
+    classification: str = "internal"
+
+    @property
+    def has_masking(self) -> bool:
+        """``True`` when Atlas requires one or more columns to be masked."""
+
+        return bool(self.masked_columns)
+
+
+def create_governance_gate_from_env() -> "GovernanceGate | None":
+    """Build a gate only when Atlas access enforcement is configured.
+
+    Returns ``None`` when ``ATLAS_API_URL`` is unset, signalling that governance is
+    inactive and callers should pass data through unchanged.
+    """
+
+    base_url = os.getenv("ATLAS_API_URL", "").strip()
+    if not base_url:
+        return None
+
+    timeout = float(os.getenv("ATLAS_API_TIMEOUT_SECONDS", "10"))
+    token = os.getenv("ATLAS_API_TOKEN")
+    config = AtlasContractConfig(
+        base_url=base_url.rstrip("/"),
+        token=token,
+        timeout_seconds=timeout,
+    )
+    return GovernanceGate(config)
+
+
+def mask_value(value: Any, *, keep: int = 0) -> Any:
+    """Mask a single cell value, optionally preserving a leading prefix.
+
+    ``None`` is preserved (a null stays null). With ``keep > 0`` the first ``keep``
+    characters of the stringified value are retained and the remainder replaced with
+    :data:`MASK_TOKEN` (e.g. ``keep=6`` turns ``"3201011234567"`` into ``"320101******"``).
+    """
+
+    if value is None:
+        return None
+    if keep <= 0:
+        return MASK_TOKEN
+    text = str(value)
+    if len(text) <= keep:
+        return text
+    return f"{text[:keep]}{MASK_TOKEN}"
+
+
+def apply_column_masks(
+    rows: Iterable[Mapping[str, Any]],
+    masked_columns: Sequence[str],
+    *,
+    keep: int = 0,
+) -> list[dict[str, Any]]:
+    """Return a masked copy of ``rows`` with ``masked_columns`` redacted.
+
+    Operates on a sequence of row mappings (the lowest-common-denominator shape across
+    DuckDB/Spark result rows). Columns not present in a row are ignored; non-masked
+    columns are copied verbatim. The input is never mutated.
+    """
+
+    masked_set = set(masked_columns)
+    if not masked_set:
+        return [dict(row) for row in rows]
+
+    result: list[dict[str, Any]] = []
+    for row in rows:
+        new_row = dict(row)
+        for column in masked_set:
+            if column in new_row:
+                new_row[column] = mask_value(new_row[column], keep=keep)
+        result.append(new_row)
+    return result
+
+
+def mask_rows(
+    columns: Sequence[str],
+    rows: Iterable[Sequence[Any]],
+    masked_columns: Sequence[str],
+    *,
+    keep: int = 0,
+) -> list[tuple[Any, ...]]:
+    """Mask positional (``columns``, ``rows``) results — the ``execute_oneshot`` shape.
+
+    ``columns`` are the column names aligned to each row tuple. Masked columns not
+    present in ``columns`` are ignored. Returns new row tuples; inputs are not mutated.
+    """
+
+    target_indices = [index for index, name in enumerate(columns) if name in set(masked_columns)]
+    if not target_indices:
+        return [tuple(row) for row in rows]
+
+    result: list[tuple[Any, ...]] = []
+    for row in rows:
+        new_row = list(row)
+        for index in target_indices:
+            if index < len(new_row):
+                new_row[index] = mask_value(new_row[index], keep=keep)
+        result.append(tuple(new_row))
+    return result
+
+
+def govern_read(
+    gate: "GovernanceGate | None",
+    *,
+    resource: str,
+    columns: Sequence[str],
+    rows: Iterable[Sequence[Any]],
+    action: str = "read",
+    actor: str | None = None,
+    keep: int = 0,
+) -> list[tuple[Any, ...]]:
+    """Apply runtime governance to a positional read result.
+
+    The single chokepoint a read call site needs:
+
+    * ``gate is None`` (Atlas not configured) → rows pass through unchanged.
+    * otherwise the read is access-checked via :meth:`GovernanceGate.enforce_access`
+      (raising :class:`~seeknal.integrations.atlas_client.AtlasPolicyDenied` on deny),
+      then any columns Atlas marks sensitive are masked.
+
+    Returns the (possibly masked) rows as tuples.
+    """
+
+    if gate is None:
+        return [tuple(row) for row in rows]
+    decision = gate.enforce_access(resource=resource, action=action, actor=actor)
+    return mask_rows(columns, rows, decision.masked_columns, keep=keep)
+
+
+class GovernanceGate:
+    """Delegates runtime access decisions and masking to the Atlas backend.
+
+    Construct via :func:`create_governance_gate_from_env`. Pass an explicit
+    ``client`` (e.g. backed by :class:`httpx.MockTransport`) in tests.
+    """
+
+    def __init__(
+        self,
+        config: AtlasContractConfig,
+        *,
+        fail_open: bool | None = None,
+        client: httpx.Client | None = None,
+    ) -> None:
+        self.config = config
+        self._fail_open = _fail_open_default() if fail_open is None else fail_open
+        self._client = client
+
+    @property
+    def fail_open(self) -> bool:
+        """Whether the gate allows access when Atlas is unreachable (default: False)."""
+
+        return self._fail_open
+
+    # -- HTTP plumbing -------------------------------------------------------
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.config.token:
+            headers["Authorization"] = f"Bearer {self.config.token}"
+        return headers
+
+    def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        url = f"{self.config.base_url}{path}"
+        try:
+            if self._client is not None:
+                response = self._client.post(url, json=payload, headers=self._headers())
+            else:
+                response = httpx.post(
+                    url,
+                    json=payload,
+                    headers=self._headers(),
+                    timeout=self.config.timeout_seconds,
+                )
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as exc:
+            message = exc.response.text.strip() or str(exc)
+            raise AtlasContractError(
+                f"Atlas governance request failed for {path}: {message}"
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise AtlasContractError(f"Atlas governance request failed for {path}: {exc}") from exc
+
+    # -- Public API ----------------------------------------------------------
+
+    def check_access(
+        self,
+        *,
+        resource: str,
+        action: str = "read",
+        actor: str | None = None,
+        classification: str | None = None,
+    ) -> AccessDecision:
+        """Ask Atlas whether ``actor`` may ``action`` ``resource``.
+
+        On a transport error the result honours the fail-open/closed policy: a
+        fail-closed gate (the default) returns a *denied* decision rather than
+        propagating the error, so callers uniformly act on :class:`AccessDecision`.
+        """
+
+        resolved_actor = actor or os.getenv("ATLAS_ACTOR") or getpass.getuser()
+        payload: dict[str, Any] = {
+            "operation": "access-check",
+            "resource": resource,
+            "action": action,
+            "actor": resolved_actor,
+        }
+        if classification:
+            payload["classification"] = classification
+
+        try:
+            decision = self._post("/api/contracts/access-check", payload)
+        except AtlasContractError as exc:
+            if self._fail_open:
+                return AccessDecision(
+                    allowed=True,
+                    reason=f"fail-open: Atlas unreachable ({exc})",
+                )
+            return AccessDecision(
+                allowed=False,
+                reason=f"fail-closed: Atlas unreachable ({exc})",
+            )
+
+        masked = decision.get("masked_columns") or []
+        masked_columns = tuple(str(column) for column in masked if column)
+        return AccessDecision(
+            allowed=bool(decision.get("allowed", False)),
+            reason=str(decision.get("reason", "")),
+            masked_columns=masked_columns,
+            classification=str(decision.get("classification", classification or "internal")),
+        )
+
+    def enforce_access(
+        self,
+        *,
+        resource: str,
+        action: str = "read",
+        actor: str | None = None,
+        classification: str | None = None,
+    ) -> AccessDecision:
+        """Like :meth:`check_access` but raise :class:`AtlasPolicyDenied` on deny.
+
+        Returns the :class:`AccessDecision` (carrying any required masking) when
+        access is allowed. Emits a best-effort audit event for the denial.
+        """
+
+        decision = self.check_access(
+            resource=resource,
+            action=action,
+            actor=actor,
+            classification=classification,
+        )
+        if not decision.allowed:
+            self.audit(
+                action=action,
+                resource=resource,
+                actor=actor,
+                status="denied",
+                details={"reason": decision.reason},
+            )
+            raise AtlasPolicyDenied(decision.reason or f"Atlas denied {action} on {resource}")
+        return decision
+
+    def audit(
+        self,
+        *,
+        action: str,
+        resource: str,
+        actor: str | None = None,
+        status: str = "success",
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        """Record a best-effort audit event. Never raises.
+
+        Audit is advisory from the engine's perspective — the authoritative, immutable
+        record lives in Atlas. A failure to log must not break a governed read.
+        """
+
+        resolved_actor = actor or os.getenv("ATLAS_ACTOR") or getpass.getuser()
+        payload: dict[str, Any] = {
+            "operation": "access",
+            "action": action,
+            "resource": resource,
+            "actor": resolved_actor,
+            "status": status,
+            "project_name": os.getenv("SEEKNAL_PROJECT_NAME", ""),
+            "environment": os.getenv("ATLAS_ENVIRONMENT", os.getenv("SEEKNAL_ENV", "dev")),
+        }
+        if details:
+            payload["details"] = details
+        try:
+            self._post("/api/contracts/runs/report", payload)
+        except AtlasContractError:
+            pass

--- a/src/seeknal/integrations/atlas_governance.py
+++ b/src/seeknal/integrations/atlas_governance.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import getpass
 import os
+import re
 from dataclasses import dataclass
 from typing import Any, Iterable, Mapping, Sequence
 
@@ -42,6 +43,8 @@ __all__ = [
     "apply_column_masks",
     "mask_rows",
     "govern_read",
+    "govern_query",
+    "referenced_tables",
     "mask_value",
     "MASK_TOKEN",
 ]
@@ -197,6 +200,63 @@ def govern_read(
         return [tuple(row) for row in rows]
     decision = gate.enforce_access(resource=resource, action=action, actor=actor)
     return mask_rows(columns, rows, decision.masked_columns, keep=keep)
+
+
+_FROM_JOIN_RE = re.compile(r"\b(?:FROM|JOIN)\s+([\"`\w.]+)", re.IGNORECASE)
+_WITH_CTE_RE = re.compile(r"\b(\w+)\s+AS\s*\(", re.IGNORECASE)
+
+
+def referenced_tables(sql: str) -> list[str]:
+    """Best-effort extraction of base table identifiers referenced by a query.
+
+    Returns ``FROM``/``JOIN`` targets (surrounding quotes stripped), excluding
+    names defined as CTEs in a ``WITH`` clause. This is a heuristic used to scope
+    governance checks — Atlas remains the authority, so over- or under-identifying
+    a table only changes which resources are checked, not whether Atlas enforces.
+    """
+
+    ctes = {name.lower() for name in _WITH_CTE_RE.findall(sql)}
+    tables: list[str] = []
+    seen: set[str] = set()
+    for raw in _FROM_JOIN_RE.findall(sql):
+        name = raw.strip('"`')
+        key = name.lower()
+        if not name or key in ctes or key in seen:
+            continue
+        seen.add(key)
+        tables.append(name)
+    return tables
+
+
+def govern_query(
+    gate: "GovernanceGate | None",
+    *,
+    sql: str,
+    columns: Sequence[str],
+    rows: Iterable[Sequence[Any]],
+    actor: str | None = None,
+    keep: int = 0,
+) -> list[tuple[Any, ...]]:
+    """Govern an ad-hoc SQL read: access-check referenced tables, then mask columns.
+
+    * ``gate is None`` → rows pass through unchanged.
+    * otherwise each base table referenced by ``sql`` is access-checked via
+      :meth:`GovernanceGate.enforce_access` (raising
+      :class:`~seeknal.integrations.atlas_client.AtlasPolicyDenied` on the first
+      deny), and the union of columns Atlas marks sensitive across those tables is
+      masked in the result.
+
+    A tableless query (no ``FROM``/``JOIN``) reads no governed resource and passes
+    through unchanged.
+    """
+
+    if gate is None:
+        return [tuple(row) for row in rows]
+    masked: set[str] = set()
+    for table in referenced_tables(sql):
+        decision = gate.enforce_access(resource=table, action="read", actor=actor)
+        masked.update(decision.masked_columns)
+    return mask_rows(columns, rows, tuple(masked), keep=keep)
 
 
 class GovernanceGate:

--- a/src/seeknal/integrations/atlas_governance.py
+++ b/src/seeknal/integrations/atlas_governance.py
@@ -42,6 +42,7 @@ from seeknal.integrations.atlas_client import (
     AtlasPolicyDenied,
     SESSION_EXPIRED_HINT,
 )
+from seeknal.integrations.atlas_config import atlas_config
 
 __all__ = [
     "AccessDecision",
@@ -146,13 +147,21 @@ _REFRESH_TIMEOUT_SECONDS = 30.0
 def _oidc_issuer() -> str:
     """Return the Keycloak realm issuer used for token refresh (no trailing slash)."""
 
-    return (os.getenv("KEYCLOAK_ISSUER", "").strip() or _DEFAULT_OIDC_ISSUER).rstrip("/")
+    return (
+        os.getenv("KEYCLOAK_ISSUER", "").strip()
+        or atlas_config().keycloak_issuer
+        or _DEFAULT_OIDC_ISSUER
+    ).rstrip("/")
 
 
 def _oidc_client_id() -> str:
     """Return the public OIDC client id used for token refresh."""
 
-    return os.getenv("SEEKNAL_OIDC_CLIENT_ID", "").strip() or _DEFAULT_OIDC_CLIENT_ID
+    return (
+        os.getenv("SEEKNAL_OIDC_CLIENT_ID", "").strip()
+        or atlas_config().oidc_client_id
+        or _DEFAULT_OIDC_CLIENT_ID
+    )
 
 
 def _persist_refreshed_tokens(existing: dict[str, Any], tokens: dict[str, Any]) -> None:
@@ -327,7 +336,7 @@ def create_governance_gate_from_env() -> "GovernanceGate | None":
     inactive and callers should pass data through unchanged.
     """
 
-    base_url = os.getenv("ATLAS_API_URL", "").strip()
+    base_url = os.getenv("ATLAS_API_URL", "").strip() or atlas_config().api_url
     if not base_url:
         return None
 

--- a/src/seeknal/sources/config.py
+++ b/src/seeknal/sources/config.py
@@ -801,6 +801,22 @@ def _preview_table(
 ) -> str:
     try:
         columns, rows = repl.execute_oneshot(f"SELECT * FROM {qualified}", limit=limit)
+        # Runtime governance: when Atlas is configured (ATLAS_API_URL), enforce read
+        # access on the table and mask sensitive columns before sample rows are
+        # persisted into the Ask context. Inactive when Atlas is not configured. A
+        # denial raises AtlasPolicyDenied, which degrades below to "Preview
+        # unavailable" so no governed rows leak into context.
+        from seeknal.integrations.atlas_governance import (
+            create_governance_gate_from_env,
+            govern_read,
+        )
+
+        rows = govern_read(
+            create_governance_gate_from_env(),
+            resource=qualified,
+            columns=columns,
+            rows=rows,
+        )
     except Exception as exc:  # noqa: BLE001 - sync should continue
         return f"# Preview for {qualified}\n\nPreview unavailable: {exc}\n"
 

--- a/src/seeknal/workflow/apply.py
+++ b/src/seeknal/workflow/apply.py
@@ -20,6 +20,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from seeknal.ui.output import echo_success as _echo_success, echo_error as _echo_error, echo_warning as _echo_warning, echo_info as _echo_info
 from seeknal.integrations.atlas_client import (
+    AtlasAuthError,
     AtlasContractError,
     AtlasPolicyDenied,
     create_atlas_contract_client_from_env,
@@ -757,6 +758,10 @@ def apply_command(
                 project_path=project_path,
             )
         except AtlasPolicyDenied as exc:
+            _echo_error(str(exc))
+            raise typer.Exit(1)
+        except AtlasAuthError as exc:
+            # Auth problem, not an Atlas outage: surface the login hint verbatim.
             _echo_error(str(exc))
             raise typer.Exit(1)
         except AtlasContractError as exc:

--- a/src/seeknal/workflow/manifest_builder.py
+++ b/src/seeknal/workflow/manifest_builder.py
@@ -1,0 +1,83 @@
+"""Public manifest builder — converts a DAGBuilder result into a Manifest.
+
+Previously lived as the private ``_build_manifest_from_dag`` helper in
+``cli/main.py``. Promoted so the heartbeat daemon (and any future caller)
+can reuse it without importing CLI internals.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_manifest_from_dag(dag_builder: Any, project_name: str):
+    """Build a Manifest from a built ``DAGBuilder`` instance.
+
+    Args:
+        dag_builder: A built DAGBuilder (with ``.nodes`` dict and
+            ``.get_downstream()`` method).
+        project_name: Project name for the manifest metadata.
+
+    Returns:
+        A ``seeknal.dag.manifest.Manifest`` populated from the DAGBuilder.
+    """
+    from seeknal.dag.manifest import Manifest, Node, NodeType as ManifestNodeType
+
+    node_type_map = {
+        "source": ManifestNodeType.SOURCE,
+        "transform": ManifestNodeType.TRANSFORM,
+        "feature_group": ManifestNodeType.FEATURE_GROUP,
+        "model": ManifestNodeType.MODEL,
+        "rule": ManifestNodeType.RULE,
+        "aggregation": ManifestNodeType.AGGREGATION,
+        "second_order_aggregation": ManifestNodeType.SECOND_ORDER_AGGREGATION,
+        "exposure": ManifestNodeType.EXPOSURE,
+        "python": ManifestNodeType.PYTHON,
+        "semantic_model": ManifestNodeType.SEMANTIC_MODEL,
+        "metric": ManifestNodeType.METRIC,
+        "profile": ManifestNodeType.PROFILE,
+    }
+
+    manifest = Manifest(project=project_name)
+    for node_id, node in dag_builder.nodes.items():
+        kind_str = node.kind.value if hasattr(node.kind, "value") else str(node.kind)
+        manifest_node_type = node_type_map.get(kind_str, ManifestNodeType.SOURCE)
+        raw_columns: dict[str, Any] = {}
+        if hasattr(node, "yaml_data"):
+            raw_columns = node.yaml_data.get("columns", {}) or {}
+
+        manifest.add_node(
+            Node(
+                id=node_id,
+                name=node.name,
+                node_type=manifest_node_type,
+                description=node.yaml_data.get("description")
+                if hasattr(node, "yaml_data")
+                else None,
+                tags=list(node.tags) if hasattr(node, "tags") and node.tags else [],
+                columns=raw_columns,
+                config=node.yaml_data if hasattr(node, "yaml_data") else {},
+                file_path=node.file_path if hasattr(node, "file_path") else None,
+            )
+        )
+
+    # Dedup edges: a node may depend on the same upstream twice (once via the
+    # YAML `inputs:` list, once via a `ref()` in the SQL body), so
+    # `get_downstream` can yield the same pair more than once. `Manifest.edges`
+    # is a plain list with no dedup, and `DAGRunner._get_topological_order`
+    # counts in-degree from raw edges but decrements from the deduped
+    # adjacency set — duplicate edges would leave a node's in-degree above
+    # zero forever and be misreported as a cycle.
+    seen_edges: set[tuple[str, str]] = set()
+    for node_id in dag_builder.nodes:
+        for downstream_id in dag_builder.get_downstream(node_id):
+            edge_key = (node_id, downstream_id)
+            if edge_key in seen_edges:
+                continue
+            seen_edges.add(edge_key)
+            manifest.add_edge(node_id, downstream_id)
+
+    return manifest
+
+
+__all__ = ["build_manifest_from_dag"]

--- a/tests/ask/access/conftest.py
+++ b/tests/ask/access/conftest.py
@@ -1,0 +1,29 @@
+"""Shared fixtures for Ask access-policy tests."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture
+def tmp_path(tmp_path: Path) -> Iterator[Path]:
+    """Repo-internal replacement for the builtin ``tmp_path``.
+
+    These tests exercise ``AccessPolicy``/``PendingQueue``, which validate paths
+    with ``is_insecure_path`` — and that rejects anything under ``/tmp``, exactly
+    where the builtin ``tmp_path`` lives on Linux CI. A unique directory under
+    ``<repo>/.seeknal/test-tmp`` keeps per-test isolation while passing the
+    security check (mirrors ``_secure_project_dir`` in the atlas apply tests).
+    """
+
+    secure = _REPO_ROOT / ".seeknal" / "test-tmp" / tmp_path.name
+    shutil.rmtree(secure, ignore_errors=True)
+    secure.mkdir(parents=True, exist_ok=True)
+    yield secure
+    shutil.rmtree(secure, ignore_errors=True)

--- a/tests/ask/access/test_access_yml.py
+++ b/tests/ask/access/test_access_yml.py
@@ -1,0 +1,165 @@
+"""Tests for AccessPolicy YAML loader (AC19)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from seeknal.ask.access.policy import AccessPolicy, AllowlistEntry, DenyEntry
+from seeknal.ask.access.roles import Role
+
+
+def _write(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    return path
+
+
+def test_load_missing_file_returns_empty(tmp_path: Path):
+    policy = AccessPolicy.load(tmp_path / ".seeknal" / "access.yml")
+    assert policy.allowlist == []
+    assert policy.deny_list == []
+    assert policy.default_role is None
+
+
+def test_load_basic(tmp_path: Path):
+    body = """
+schema_version: 1
+default_role: viewer
+allowlist:
+  - telegram_user_id: 1
+    role: operator
+    notes: "ops"
+  - telegram_chat_id: -100123
+    role: viewer
+deny_list:
+  - telegram_user_id: 9
+    reason: "removed"
+"""
+    path = _write(tmp_path / ".seeknal" / "access.yml", body)
+    policy = AccessPolicy.load(path)
+    assert policy.default_role == Role.VIEWER
+    assert len(policy.allowlist) == 2
+    assert len(policy.deny_list) == 1
+
+
+def test_insecure_path_rejected():
+    with pytest.raises(ValueError, match="Insecure access policy"):
+        AccessPolicy.load(Path("/tmp/access.yml"))
+
+
+def test_resolve_user_id_keyed(tmp_path: Path):
+    body = """
+default_role: none
+allowlist:
+  - telegram_user_id: 42
+    telegram_username: alice
+    role: engineer
+"""
+    path = _write(tmp_path / ".seeknal/access.yml", body)
+    policy = AccessPolicy.load(path)
+    assert policy.resolve(user_id=42) == Role.ENGINEER
+
+
+def test_username_change_does_not_grant_access(tmp_path: Path):
+    """username is display-only; only user_id grants access."""
+    body = """
+default_role: none
+allowlist:
+  - telegram_user_id: 42
+    telegram_username: alice
+    role: engineer
+"""
+    path = _write(tmp_path / ".seeknal/access.yml", body)
+    policy = AccessPolicy.load(path)
+    # different user_id, same username → no access
+    assert policy.resolve(user_id=99, username="alice") is None
+
+
+def test_resolve_deny_list_overrides_allowlist(tmp_path: Path):
+    body = """
+default_role: viewer
+allowlist:
+  - telegram_user_id: 7
+    role: admin
+deny_list:
+  - telegram_user_id: 7
+    reason: removed
+"""
+    path = _write(tmp_path / ".seeknal/access.yml", body)
+    policy = AccessPolicy.load(path)
+    assert policy.resolve(user_id=7) is None
+
+
+def test_resolve_chat_id_fallback(tmp_path: Path):
+    body = """
+default_role: none
+allowlist:
+  - telegram_chat_id: -100777
+    role: viewer
+"""
+    path = _write(tmp_path / ".seeknal/access.yml", body)
+    policy = AccessPolicy.load(path)
+    assert policy.resolve(user_id=12345, chat_id=-100777) == Role.VIEWER
+    # Without chat_id → default_role (none → None)
+    assert policy.resolve(user_id=12345) is None
+
+
+def test_resolve_default_role(tmp_path: Path):
+    body = """
+default_role: viewer
+"""
+    path = _write(tmp_path / ".seeknal/access.yml", body)
+    policy = AccessPolicy.load(path)
+    assert policy.resolve(user_id=9999) == Role.VIEWER
+
+
+def test_unknown_role_raises(tmp_path: Path):
+    body = """
+allowlist:
+  - telegram_user_id: 1
+    role: god
+"""
+    path = _write(tmp_path / ".seeknal/access.yml", body)
+    with pytest.raises(ValueError, match="Unknown role"):
+        AccessPolicy.load(path)
+
+
+def test_save_and_round_trip(tmp_path: Path):
+    target = tmp_path / ".seeknal/access.yml"
+    policy = AccessPolicy.empty(source_path=target)
+    policy.default_role = Role.VIEWER
+    policy.grant(
+        telegram_user_id=1, role=Role.OPERATOR, username="alice", added_by="bob"
+    )
+    policy.save()
+
+    loaded = AccessPolicy.load(target)
+    assert loaded.default_role == Role.VIEWER
+    assert len(loaded.allowlist) == 1
+    assert loaded.allowlist[0].telegram_user_id == 1
+    assert loaded.allowlist[0].role == Role.OPERATOR
+
+
+def test_grant_overwrites_existing(tmp_path: Path):
+    policy = AccessPolicy.empty(source_path=tmp_path / "access.yml")
+    policy.grant(telegram_user_id=1, role=Role.VIEWER)
+    policy.grant(telegram_user_id=1, role=Role.ADMIN)
+    assert len(policy.allowlist) == 1
+    assert policy.allowlist[0].role == Role.ADMIN
+
+
+def test_revoke_removes_entry(tmp_path: Path):
+    policy = AccessPolicy.empty(source_path=tmp_path / "access.yml")
+    policy.grant(telegram_user_id=1, role=Role.VIEWER)
+    assert policy.revoke(1) is True
+    assert policy.allowlist == []
+
+
+def test_revoke_with_deny_reason(tmp_path: Path):
+    policy = AccessPolicy.empty(source_path=tmp_path / "access.yml")
+    policy.grant(telegram_user_id=1, role=Role.VIEWER)
+    policy.revoke(1, deny_reason="left team")
+    assert any(e.telegram_user_id == 1 for e in policy.deny_list)
+    assert policy.resolve(user_id=1) is None

--- a/tests/ask/access/test_admin_approval.py
+++ b/tests/ask/access/test_admin_approval.py
@@ -1,0 +1,145 @@
+"""Tests for the admin approval queue (Step 15, AC16)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from seeknal.ask.access.pending import (
+    DEFAULT_TTL_DAYS,
+    PendingQueue,
+    PendingRequest,
+)
+from seeknal.ask.access.policy import AccessPolicy
+from seeknal.ask.access.roles import Role
+
+
+def test_load_empty(tmp_path: Path):
+    queue = PendingQueue.load(tmp_path / ".seeknal/access_pending.json")
+    assert queue.requests == []
+
+
+def test_insecure_path():
+    with pytest.raises(ValueError, match="Insecure"):
+        PendingQueue.load(Path("/tmp/access_pending.json"))
+
+
+def test_pending_flow(tmp_path: Path):
+    """AC16: unlisted → pending → admin approval → policy updated."""
+    path = tmp_path / ".seeknal/access_pending.json"
+    queue = PendingQueue.load(path)
+    queue.add(
+        telegram_user_id=555,
+        telegram_username="new_person",
+        intro_message="Hi, I'm Carol from analytics — Bob said to message you.",
+    )
+    queue.save()
+
+    loaded = PendingQueue.load(path)
+    assert len(loaded.requests) == 1
+    assert loaded.requests[0].telegram_user_id == 555
+    assert "Carol" in loaded.requests[0].intro_message
+
+
+def test_add_idempotent_for_same_user(tmp_path: Path):
+    queue = PendingQueue.load(tmp_path / "p.json")
+    queue.add(telegram_user_id=1, intro_message="first")
+    queue.add(telegram_user_id=1, intro_message="second")
+    assert len(queue.requests) == 1
+    assert queue.requests[0].intro_message == "second"
+
+
+def test_remove(tmp_path: Path):
+    queue = PendingQueue.load(tmp_path / "p.json")
+    queue.add(telegram_user_id=1, intro_message="x")
+    assert queue.remove(1) is True
+    assert queue.remove(1) is False
+    assert queue.requests == []
+
+
+def test_mark_notified(tmp_path: Path):
+    queue = PendingQueue.load(tmp_path / "p.json")
+    queue.add(telegram_user_id=1, intro_message="x")
+    queue.mark_notified(1, admin_id=42)
+    queue.mark_notified(1, admin_id=42)  # idempotent
+    assert queue.requests[0].notified_admins == [42]
+
+
+def test_ttl_cleanup(tmp_path: Path):
+    queue = PendingQueue.load(tmp_path / "p.json")
+    queue.add(telegram_user_id=1, intro_message="old")
+    # Force ttl into the past
+    queue.requests[0].ttl_until = (
+        datetime.now(tz=timezone.utc) - timedelta(days=1)
+    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+    dropped = queue.cleanup_expired()
+    assert dropped == 1
+    assert queue.requests == []
+
+
+def test_ttl_default_30_days(tmp_path: Path):
+    queue = PendingQueue.load(tmp_path / "p.json")
+    queue.add(telegram_user_id=1, intro_message="x")
+    ttl = queue.requests[0].ttl_until
+    parsed = datetime.strptime(ttl, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    delta = parsed - datetime.now(tz=timezone.utc)
+    assert timedelta(days=DEFAULT_TTL_DAYS - 1) <= delta <= timedelta(days=DEFAULT_TTL_DAYS + 1)
+
+
+def test_intro_message_truncated(tmp_path: Path):
+    queue = PendingQueue.load(tmp_path / "p.json")
+    long_message = "x" * 1000
+    req = queue.add(telegram_user_id=1, intro_message=long_message)
+    assert len(req.intro_message) == 500
+
+
+def test_approval_updates_policy(tmp_path: Path):
+    """End-to-end: admin approves → policy.grant + queue.remove + persistence."""
+    policy_path = tmp_path / ".seeknal/access.yml"
+    queue_path = tmp_path / ".seeknal/access_pending.json"
+
+    policy = AccessPolicy.empty(source_path=policy_path)
+    queue = PendingQueue.load(queue_path)
+
+    queue.add(
+        telegram_user_id=999,
+        telegram_username="newcomer",
+        intro_message="Please add me",
+    )
+    queue.save()
+
+    # Admin approves as viewer
+    policy.grant(telegram_user_id=999, role=Role.VIEWER, username="newcomer")
+    policy.save()
+    queue.remove(999)
+    queue.save()
+
+    loaded_policy = AccessPolicy.load(policy_path)
+    loaded_queue = PendingQueue.load(queue_path)
+    assert loaded_policy.resolve(user_id=999) == Role.VIEWER
+    assert loaded_queue.requests == []
+
+
+def test_two_admin_race(tmp_path: Path):
+    """If two admins approve, second sees the first's already-approved state."""
+    policy_path = tmp_path / "access.yml"
+    policy = AccessPolicy.empty(source_path=policy_path)
+    policy.grant(telegram_user_id=1, role=Role.VIEWER)
+    policy.save()
+
+    # Second admin's flow: try to grant — should overwrite without error.
+    reloaded = AccessPolicy.load(policy_path)
+    reloaded.grant(telegram_user_id=1, role=Role.OPERATOR)
+    reloaded.save()
+    final = AccessPolicy.load(policy_path)
+    assert final.resolve(user_id=1) == Role.OPERATOR
+
+
+def test_corrupt_queue_starts_empty(tmp_path: Path):
+    path = tmp_path / ".seeknal/access_pending.json"
+    path.parent.mkdir()
+    path.write_text("{not json")
+    queue = PendingQueue.load(path)
+    assert queue.requests == []

--- a/tests/ask/access/test_middleware.py
+++ b/tests/ask/access/test_middleware.py
@@ -1,0 +1,135 @@
+"""Middleware tests: role-gated wrapping (AC15)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from seeknal.ask.access.middleware import (
+    AccessError,
+    InsufficientRoleError,
+    MissingToolRoleError,
+    make_role_gated_tool,
+)
+from seeknal.ask.access.registry import register_tool_role, tool_min_role
+from seeknal.ask.access.roles import Role
+
+
+class _FakeContext:
+    def __init__(self, role=None, user_id=None):
+        self.requestor_role = role
+        if user_id is not None:
+            self.telegram_user_id = user_id
+
+
+@pytest.fixture
+def gated_sync_tool():
+    name = "_test_gated_sync"
+    register_tool_role(name, Role.OPERATOR, overwrite=True)
+
+    def _test_gated_sync(arg: int = 0) -> int:
+        return arg * 2
+
+    wrapped = make_role_gated_tool(_test_gated_sync)
+    yield wrapped
+    # Cleanup
+    tool_min_role.pop(name, None)
+
+
+@pytest.fixture
+def gated_async_tool():
+    name = "_test_gated_async"
+    register_tool_role(name, Role.OPERATOR, overwrite=True)
+
+    async def _test_gated_async(arg: int = 0) -> int:
+        return arg + 1
+
+    wrapped = make_role_gated_tool(_test_gated_async)
+    yield wrapped
+    tool_min_role.pop(name, None)
+
+
+def test_unregistered_tool_fail_closed_at_wrap_time():
+    def _never_registered():
+        return 1
+
+    with pytest.raises(MissingToolRoleError):
+        make_role_gated_tool(_never_registered)
+
+
+def test_role_gating_blocks_insufficient_role(gated_sync_tool):
+    ctx = _FakeContext(role=Role.VIEWER)
+    with patch(
+        "seeknal.ask.agents.tools._context.get_tool_context", return_value=ctx
+    ):
+        with pytest.raises(InsufficientRoleError) as exc_info:
+            gated_sync_tool(arg=5)
+    assert exc_info.value.required == Role.OPERATOR
+    assert exc_info.value.actual == Role.VIEWER
+
+
+def test_role_gating_passes_sufficient_role(gated_sync_tool):
+    ctx = _FakeContext(role=Role.ADMIN)
+    with patch(
+        "seeknal.ask.agents.tools._context.get_tool_context", return_value=ctx
+    ):
+        result = gated_sync_tool(arg=5)
+    assert result == 10
+
+
+def test_role_gating_blocks_no_role(gated_sync_tool):
+    ctx = _FakeContext(role=None)
+    with patch(
+        "seeknal.ask.agents.tools._context.get_tool_context", return_value=ctx
+    ):
+        with pytest.raises(InsufficientRoleError):
+            gated_sync_tool(arg=1)
+
+
+def test_async_role_gating(gated_async_tool):
+    ctx = _FakeContext(role=Role.OPERATOR)
+    with patch(
+        "seeknal.ask.agents.tools._context.get_tool_context", return_value=ctx
+    ):
+        result = asyncio.run(gated_async_tool(arg=10))
+    assert result == 11
+
+
+def test_access_error_not_runtime_error_subclass():
+    assert not issubclass(AccessError, RuntimeError)
+
+
+def test_log_record_shape(gated_sync_tool, caplog):
+    """AC15 contract: log fields are exact."""
+    ctx = _FakeContext(role=Role.VIEWER, user_id=12345)
+    with patch(
+        "seeknal.ask.agents.tools._context.get_tool_context", return_value=ctx
+    ):
+        with caplog.at_level(logging.INFO, logger="seeknal.access"):
+            with pytest.raises(InsufficientRoleError):
+                gated_sync_tool(arg=1)
+    records = [r for r in caplog.records if r.name == "seeknal.access"]
+    assert records, "Expected at least one seeknal.access log record"
+    rec = records[0]
+    assert rec.event == "role_denied"
+    assert rec.user_id == 12345
+    assert rec.tool == "_test_gated_sync"
+    assert rec.required == "operator"
+    assert rec.actual == "viewer"
+
+
+def test_resolve_role_string_input(gated_sync_tool):
+    ctx = _FakeContext(role="admin")
+    with patch(
+        "seeknal.ask.agents.tools._context.get_tool_context", return_value=ctx
+    ):
+        # Should succeed thanks to _resolve_role's string handling
+        assert gated_sync_tool(arg=2) == 4
+
+
+def test_signature_preserved(gated_sync_tool):
+    """Decorator preserves docstring and name (via @wraps)."""
+    assert gated_sync_tool.__name__ == "_test_gated_sync"

--- a/tests/ask/access/test_registry.py
+++ b/tests/ask/access/test_registry.py
@@ -1,0 +1,89 @@
+"""Tool-role registry contract tests."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from seeknal.ask.access.registry import (
+    register_tool_role,
+    tool_min_role,
+)
+from seeknal.ask.access.roles import Role
+
+
+def test_registry_has_entries():
+    assert len(tool_min_role) > 0
+
+
+def test_every_role_has_at_least_one_tool():
+    """Sanity: each role should map to at least one tool."""
+    roles_used = set(tool_min_role.values())
+    # VIEWER, ANALYST, OPERATOR, ENGINEER must each appear.
+    assert Role.VIEWER in roles_used
+    assert Role.ANALYST in roles_used
+    assert Role.OPERATOR in roles_used
+    assert Role.ENGINEER in roles_used
+
+
+def test_registry_keys_are_strings():
+    for key, role in tool_min_role.items():
+        assert isinstance(key, str)
+        assert isinstance(role, Role)
+
+
+def test_register_overwrite_guard():
+    with pytest.raises(ValueError, match="already registered"):
+        register_tool_role("list_tables", Role.ADMIN)
+
+
+def test_register_overwrite_allowed():
+    original = tool_min_role.get("execute_sql", Role.VIEWER)
+    register_tool_role("execute_sql", Role.ADMIN, overwrite=True)
+    assert tool_min_role["execute_sql"] == Role.ADMIN
+    # restore
+    register_tool_role("execute_sql", original, overwrite=True)
+
+
+def test_register_new_tool():
+    name = "_test_tool_synthetic_x"
+    register_tool_role(name, Role.OPERATOR)
+    assert tool_min_role[name] == Role.OPERATOR
+
+
+def test_all_tools_have_role():
+    """Every tool importable from seeknal.ask.agents.tools.toolset (in the
+    aggregated tool lists) must have an entry in ``tool_min_role`` —
+    fail-closed contract per AC15.
+    """
+    from seeknal.ask.agents.tools import toolset as toolset_module
+
+    seen: set[str] = set()
+    # toolset.py defines several _CONSTANT lists of tool functions.
+    for attr_name in dir(toolset_module):
+        if not attr_name.startswith("_"):
+            continue
+        attr = getattr(toolset_module, attr_name, None)
+        if not isinstance(attr, list):
+            continue
+        for item in attr:
+            if callable(item):
+                seen.add(item.__name__)
+
+    # ask_user is also added in the wrapper.
+    seen.add("ask_user")
+
+    missing = sorted(seen - set(tool_min_role.keys()))
+    assert not missing, (
+        f"Tools missing role registration: {missing}. "
+        "Add them to src/seeknal/ask/access/registry.py."
+    )
+
+
+def test_iter_returns_sorted():
+    from seeknal.ask.access.registry import iter_tool_min_roles
+
+    items = list(iter_tool_min_roles())
+    names = [n for n, _ in items]
+    assert names == sorted(names)

--- a/tests/ask/access/test_roles.py
+++ b/tests/ask/access/test_roles.py
@@ -1,0 +1,43 @@
+"""Role IntEnum hierarchy tests (AC18)."""
+
+from __future__ import annotations
+
+import pytest
+
+from seeknal.ask.access.roles import Role
+
+
+def test_role_ordering():
+    assert Role.VIEWER < Role.ANALYST < Role.OPERATOR < Role.ENGINEER < Role.ADMIN
+
+
+def test_inheritance():
+    """A higher role can do everything a lower role can (AC18)."""
+    assert Role.ADMIN.can(Role.VIEWER)
+    assert Role.ADMIN.can(Role.OPERATOR)
+    assert Role.ENGINEER.can(Role.OPERATOR)
+    assert Role.OPERATOR.can(Role.ANALYST)
+    assert Role.ANALYST.can(Role.VIEWER)
+    # Reverse should fail
+    assert not Role.VIEWER.can(Role.ANALYST)
+    assert not Role.OPERATOR.can(Role.ENGINEER)
+
+
+def test_role_can_self():
+    assert Role.OPERATOR.can(Role.OPERATOR)
+
+
+def test_from_string_case_insensitive():
+    assert Role.from_string("viewer") == Role.VIEWER
+    assert Role.from_string("ADMIN") == Role.ADMIN
+    assert Role.from_string("Operator") == Role.OPERATOR
+
+
+def test_from_string_unknown():
+    with pytest.raises(ValueError, match="Unknown role"):
+        Role.from_string("god_mode")
+
+
+def test_label_lowercase():
+    assert Role.VIEWER.label() == "viewer"
+    assert Role.ADMIN.label() == "admin"

--- a/tests/ask/test_extract_finance_document.py
+++ b/tests/ask/test_extract_finance_document.py
@@ -1,0 +1,110 @@
+"""Tests for finance document extraction with mocked model output."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import duckdb
+import pytest
+
+from seeknal.ask.agents.tools._context import ToolContext, set_tool_context
+from seeknal.ask.agents.tools.extract_finance_document import (
+    _parse_json_output,
+    extract_finance_document,
+)
+
+
+class _REPLStub:
+    def __init__(self) -> None:
+        self.conn = duckdb.connect(":memory:")
+
+
+@pytest.fixture
+def ctx(tmp_path: Path) -> ToolContext:
+    context = ToolContext(
+        repl=_REPLStub(),
+        artifact_discovery=MagicMock(),
+        project_path=tmp_path,
+    )
+    set_tool_context(context)
+    return context
+
+
+def _fake_pdf(path: Path) -> Path:
+    path.write_bytes(b"%PDF-1.4\n1 0 obj\n<<>>\nendobj\n%%EOF\n")
+    return path
+
+
+def test_extract_supplier_invoice_pdf(tmp_path, ctx):
+    pdf = _fake_pdf(tmp_path / "supplier-invoice.pdf")
+    payload = {
+        "document_kind": "supplier_invoice",
+        "direction": "ap",
+        "document_number": "INV-1001",
+        "counterparty_name": "Kilang Textile Sdn Bhd",
+        "issue_date": "2026-05-01",
+        "due_date": "2026-05-31",
+        "currency": "MYR",
+        "subtotal_amount": 1000.0,
+        "tax_amount": 80.0,
+        "sst_amount": 80.0,
+        "total_amount": 1080.0,
+        "line_items": [],
+        "readiness_flags": [],
+        "confidence": 0.91,
+        "raw_text": "Invoice INV-1001",
+    }
+
+    with patch(
+        "seeknal.ask.agents.tools.extract_finance_document._call_model",
+        return_value=payload,
+    ):
+        out = extract_finance_document(str(pdf), hint="supplier invoice")
+
+    assert "Extracted finance document draft" in out
+    assert "INV-1001" in out
+    assert "No required review fields" in out
+    assert ctx.last_read_staging_path == str(pdf)
+
+
+def test_parse_markdown_json_fence():
+    raw = "```json\n" + json.dumps({"document_kind": "receipt", "total_amount": 12}) + "\n```"
+    parsed = _parse_json_output(raw)
+    assert parsed["document_kind"] == "receipt"
+    assert parsed["currency"] == "MYR"
+    assert parsed["line_items"] == []
+
+
+def test_missing_review_fields_are_reported(tmp_path, ctx):
+    pdf = _fake_pdf(tmp_path / "invoice.pdf")
+    payload = {
+        "document_kind": "supplier_invoice",
+        "counterparty_name": None,
+        "total_amount": None,
+    }
+
+    with patch(
+        "seeknal.ask.agents.tools.extract_finance_document._call_model",
+        return_value=payload,
+    ):
+        out = extract_finance_document(str(pdf))
+
+    assert "Fields needing review" in out
+    assert "counterparty_name" in out
+    assert "total_amount" in out
+
+
+def test_unsupported_suffix_rejected(tmp_path, ctx):
+    txt = tmp_path / "note.txt"
+    txt.write_text("not a finance document", encoding="utf-8")
+    out = extract_finance_document(str(txt))
+    assert out.startswith("Error:")
+    assert "unsupported" in out.lower()
+
+
+def test_missing_file_rejected(tmp_path, ctx):
+    out = extract_finance_document(str(tmp_path / "missing.pdf"))
+    assert out.startswith("Error:")
+    assert "not found" in out.lower()

--- a/tests/ask/test_memory.py
+++ b/tests/ask/test_memory.py
@@ -83,7 +83,14 @@ class TestMemoryAgentConfiguration:
 
             call_kwargs = mock_create.call_args[1]
             processors = call_kwargs["history_processors"]
-            assert len(processors) == 2
+            # auto_summarization defaults OFF (since 2.9.7), so the default agent
+            # ships exactly the always-on ensure_trailing_model_request safety-net
+            # processor. The summarization processors are added only when
+            # auto_summarization is enabled.
+            from seeknal.ask.processors import ensure_trailing_model_request
+
+            assert len(processors) == 1
+            assert processors[-1] is ensure_trailing_model_request
 
     def test_seeknal_directory_created(self, tmp_path):
         """Verify .seeknal/ directory is created."""

--- a/tests/ask/test_write_seeknal_project_asset.py
+++ b/tests/ask/test_write_seeknal_project_asset.py
@@ -1,0 +1,58 @@
+"""Tests for project-setup asset writer."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from seeknal.ask.agents.tools._context import ToolContext, set_tool_context
+from seeknal.ask.agents.tools.write_seeknal_project_asset import (
+    write_seeknal_project_asset,
+)
+
+
+def _set_context(project_path: Path) -> None:
+    set_tool_context(
+        ToolContext(
+            repl=MagicMock(),
+            artifact_discovery=MagicMock(),
+            project_path=project_path,
+        )
+    )
+
+
+def test_write_seeknal_project_asset_allows_sql_pair(tmp_path: Path):
+    _set_context(tmp_path)
+
+    result = write_seeknal_project_asset(
+        "seeknal/sql_pairs/revenue.yml",
+        """name: revenue\nprompt: Total revenue\nsql: |\n  SELECT 1 AS revenue\n""",
+    )
+
+    assert result.startswith("Wrote `seeknal/sql_pairs/revenue.yml`")
+    assert (tmp_path / "seeknal/sql_pairs/revenue.yml").exists()
+
+
+def test_write_seeknal_project_asset_requires_overwrite(tmp_path: Path):
+    _set_context(tmp_path)
+    target = tmp_path / "SEEKNAL_ASK.md"
+    target.write_text("old")
+
+    result = write_seeknal_project_asset("SEEKNAL_ASK.md", "new")
+
+    assert result.startswith("Error:")
+    assert target.read_text() == "old"
+
+    result = write_seeknal_project_asset("SEEKNAL_ASK.md", "new", overwrite=True)
+
+    assert result.startswith("Wrote `SEEKNAL_ASK.md`")
+    assert target.read_text() == "new"
+
+
+def test_write_seeknal_project_asset_rejects_unsupported_and_secret_paths(tmp_path: Path):
+    _set_context(tmp_path)
+
+    assert write_seeknal_project_asset("../x.yml", "content").startswith("Error:")
+    assert write_seeknal_project_asset("seeknal/sources/orders.yml", "kind: source").startswith("Error:")
+    assert write_seeknal_project_asset(
+        "context/note.md",
+        "database_url: postgresql://user:pass@example/db",
+    ).startswith("Error:")

--- a/tests/cli/test_admin_access.py
+++ b/tests/cli/test_admin_access.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
+from typing import Iterator
 
 import pytest
 from typer.testing import CliRunner
@@ -15,6 +17,26 @@ from seeknal.cli.admin import app
 
 
 runner = CliRunner()
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def tmp_path(tmp_path: Path) -> Iterator[Path]:
+    """Repo-internal replacement for the builtin ``tmp_path``.
+
+    The admin CLI loads/saves AccessPolicy/PendingQueue, which validate paths
+    with ``is_insecure_path`` — and that rejects anything under ``/tmp``, exactly
+    where the builtin ``tmp_path`` lives on Linux CI. A unique directory under
+    ``<repo>/.seeknal/test-tmp`` keeps per-test isolation while passing the
+    security check.
+    """
+
+    secure = _REPO_ROOT / ".seeknal" / "test-tmp" / tmp_path.name
+    shutil.rmtree(secure, ignore_errors=True)
+    secure.mkdir(parents=True, exist_ok=True)
+    yield secure
+    shutil.rmtree(secure, ignore_errors=True)
 
 
 def test_grant_and_list(tmp_path: Path, monkeypatch):

--- a/tests/cli/test_admin_access.py
+++ b/tests/cli/test_admin_access.py
@@ -1,0 +1,144 @@
+"""Tests for `seeknal admin access` CLI (Step 16)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from seeknal.ask.access.pending import PendingQueue
+from seeknal.ask.access.policy import AccessPolicy
+from seeknal.ask.access.roles import Role
+from seeknal.cli.admin import app
+
+
+runner = CliRunner()
+
+
+def test_grant_and_list(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    r = runner.invoke(app, ["access", "grant", "100", "viewer", "-u", "alice"])
+    assert r.exit_code == 0, r.output
+    assert "viewer" in r.output.lower()
+
+    r = runner.invoke(app, ["access", "list"])
+    assert r.exit_code == 0
+    assert "user=100" in r.output
+    assert "alice" in r.output
+
+
+def test_grant_unknown_role(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    r = runner.invoke(app, ["access", "grant", "100", "wizard"])
+    assert r.exit_code != 0
+    assert "Unknown role" in r.output
+
+
+def test_revoke(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner.invoke(app, ["access", "grant", "100", "operator"])
+    r = runner.invoke(app, ["access", "revoke", "100"])
+    assert r.exit_code == 0
+    policy = AccessPolicy.load(tmp_path / ".seeknal/access.yml")
+    assert all(e.telegram_user_id != 100 for e in policy.allowlist)
+
+
+def test_revoke_with_deny(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner.invoke(app, ["access", "grant", "200", "viewer"])
+    r = runner.invoke(app, ["access", "revoke", "200", "--deny", "--reason", "left"])
+    assert r.exit_code == 0
+    policy = AccessPolicy.load(tmp_path / ".seeknal/access.yml")
+    assert policy.resolve(user_id=200) is None
+    assert any(e.telegram_user_id == 200 for e in policy.deny_list)
+
+
+def test_set_default(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    r = runner.invoke(app, ["access", "set-default", "viewer"])
+    assert r.exit_code == 0
+    policy = AccessPolicy.load(tmp_path / ".seeknal/access.yml")
+    assert policy.default_role == Role.VIEWER
+
+
+def test_pending_list_empty(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    r = runner.invoke(app, ["access", "pending"])
+    assert r.exit_code == 0
+    assert "No pending" in r.output
+
+
+def test_pending_approve_flow(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    queue = PendingQueue.load(tmp_path / ".seeknal/access_pending.json")
+    queue.add(telegram_user_id=555, intro_message="please")
+    queue.save()
+    r = runner.invoke(app, ["access", "pending", "--approve", "555", "--role", "viewer"])
+    assert r.exit_code == 0, r.output
+    policy = AccessPolicy.load(tmp_path / ".seeknal/access.yml")
+    assert policy.resolve(user_id=555) == Role.VIEWER
+    queue2 = PendingQueue.load(tmp_path / ".seeknal/access_pending.json")
+    assert queue2.requests == []
+
+
+def test_pending_approve_requires_role(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    queue = PendingQueue.load(tmp_path / ".seeknal/access_pending.json")
+    queue.add(telegram_user_id=555, intro_message="please")
+    queue.save()
+    r = runner.invoke(app, ["access", "pending", "--approve", "555"])
+    assert r.exit_code != 0
+    assert "--role" in r.output
+
+
+def test_pending_deny(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    queue = PendingQueue.load(tmp_path / ".seeknal/access_pending.json")
+    queue.add(telegram_user_id=555, intro_message="x")
+    queue.save()
+    r = runner.invoke(app, ["access", "pending", "--deny", "555", "--reason", "no"])
+    assert r.exit_code == 0
+    queue2 = PendingQueue.load(tmp_path / ".seeknal/access_pending.json")
+    assert queue2.requests == []
+    policy = AccessPolicy.load(tmp_path / ".seeknal/access.yml")
+    assert any(e.telegram_user_id == 555 for e in policy.deny_list)
+
+
+def test_export_import_round_trip(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner.invoke(app, ["access", "grant", "100", "viewer"])
+    runner.invoke(app, ["access", "grant", "200", "operator"])
+
+    target = tmp_path / "backup.json"
+    r = runner.invoke(app, ["access", "export", str(target)])
+    assert r.exit_code == 0
+    payload = json.loads(target.read_text())
+    assert len(payload["allowlist"]) == 2
+
+    # Wipe and re-import
+    (tmp_path / ".seeknal/access.yml").unlink()
+    r = runner.invoke(app, ["access", "import", str(target)])
+    assert r.exit_code == 0
+    policy = AccessPolicy.load(tmp_path / ".seeknal/access.yml")
+    assert policy.resolve(user_id=100) == Role.VIEWER
+    assert policy.resolve(user_id=200) == Role.OPERATOR
+
+
+def test_import_requires_overwrite(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner.invoke(app, ["access", "grant", "100", "viewer"])
+    target = tmp_path / "b.json"
+    runner.invoke(app, ["access", "export", str(target)])
+    r = runner.invoke(app, ["access", "import", str(target)])
+    assert r.exit_code != 0
+    assert "--overwrite" in r.output
+
+
+def test_top_level_admin_registered(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from seeknal.cli.main import app as main_app
+    r = runner.invoke(main_app, ["admin", "--help"])
+    assert r.exit_code == 0
+    assert "access" in r.output

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -1,0 +1,253 @@
+"""
+Tests for the ``seeknal auth`` command group.
+
+These cover the pure, testable PKCE/OIDC helpers (no network, no browser, no live
+loopback) plus the ``status`` and ``logout`` commands via ``CliRunner`` against a
+temporary credentials file. ``webbrowser.open`` and the local loopback server are
+mocked; the live redirect round-trip is intentionally not exercised here.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from typing import Any
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from seeknal.cli import auth as auth_module
+from seeknal.cli.main import app
+
+runner = CliRunner()
+
+
+# -- PKCE / URL / token-exchange helpers ------------------------------------
+
+
+def test_pkce_pair_s256_relationship() -> None:
+    verifier, challenge = auth_module._pkce_pair()
+
+    # Verifier is non-trivial and URL-safe (no '=' padding, no '+'/'/').
+    assert len(verifier) >= 43
+    assert "=" not in verifier and "+" not in verifier and "/" not in verifier
+
+    # Challenge is base64url(SHA256(verifier)) with padding stripped.
+    expected = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest())
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    assert challenge == expected
+    assert "=" not in challenge
+
+    # Distinct invocations produce distinct verifiers.
+    other_verifier, _ = auth_module._pkce_pair()
+    assert other_verifier != verifier
+
+
+def test_build_authorize_url_carries_pkce_and_flow_params() -> None:
+    endpoints = {
+        "authorization_endpoint": "http://localhost:8080/realms/atlas/protocol/openid-connect/auth",
+        "token_endpoint": "http://localhost:8080/realms/atlas/protocol/openid-connect/token",
+    }
+    url = auth_module._build_authorize_url(
+        endpoints,
+        client_id="seeknal-cli",
+        redirect_uri="http://127.0.0.1:8765/callback",
+        code_challenge="abc123",
+        state="state-xyz",
+    )
+
+    assert url.startswith(endpoints["authorization_endpoint"] + "?")
+    from urllib.parse import parse_qs, urlparse
+
+    query = parse_qs(urlparse(url).query)
+    assert query["response_type"] == ["code"]
+    assert query["client_id"] == ["seeknal-cli"]
+    assert query["code_challenge"] == ["abc123"]
+    assert query["code_challenge_method"] == ["S256"]
+    assert query["redirect_uri"] == ["http://127.0.0.1:8765/callback"]
+    assert query["state"] == ["state-xyz"]
+
+
+def test_exchange_code_posts_pkce_and_returns_tokens() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["body"] = request.content.decode("utf-8")
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "at-1",
+                "refresh_token": "rt-1",
+                "expires_in": 300,
+                "refresh_expires_in": 1800,
+            },
+        )
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    tokens = auth_module._exchange_code(
+        "http://localhost:8080/realms/atlas/protocol/openid-connect/token",
+        code="the-code",
+        code_verifier="the-verifier",
+        client_id="seeknal-cli",
+        redirect_uri="http://127.0.0.1:8765/callback",
+        client=client,
+    )
+
+    assert tokens["access_token"] == "at-1"
+    assert tokens["refresh_token"] == "rt-1"
+
+    # PKCE verifier + authorization_code grant are sent; public client (no secret).
+    from urllib.parse import parse_qs
+
+    sent = parse_qs(captured["body"])
+    assert sent["grant_type"] == ["authorization_code"]
+    assert sent["code"] == ["the-code"]
+    assert sent["code_verifier"] == ["the-verifier"]
+    assert sent["client_id"] == ["seeknal-cli"]
+    assert "client_secret" not in sent
+
+
+def test_write_credentials_to_tmp_path(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    creds = tmp_path / "nested" / "credentials.json"
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(creds))
+
+    path = auth_module._write_credentials(
+        {
+            "access_token": "at-1",
+            "refresh_token": "rt-1",
+            "expires_in": 300,
+            "refresh_expires_in": 1800,
+            "extra_ignored": "x",
+        }
+    )
+
+    assert path == creds
+    data = json.loads(creds.read_text(encoding="utf-8"))
+    assert data == {
+        "access_token": "at-1",
+        "refresh_token": "rt-1",
+        "expires_in": 300,
+        "refresh_expires_in": 1800,
+    }
+    # File written 0600 (owner read/write only).
+    assert (creds.stat().st_mode & 0o777) == 0o600
+
+
+# -- status / logout via CliRunner ------------------------------------------
+
+
+def _unsigned_jwt(payload: dict[str, Any]) -> str:
+    """Build an unsigned-but-decodable JWT for ``user_*_from_credentials`` to read."""
+
+    def seg(obj: dict[str, Any]) -> str:
+        raw = json.dumps(obj).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+    return f"{seg({'alg': 'none'})}.{seg(payload)}.sig"
+
+
+def _write_creds_file(tmp_path, monkeypatch: pytest.MonkeyPatch, *, sub: str, email: str) -> None:
+    token = _unsigned_jwt({"sub": sub, "email": email})
+    creds = tmp_path / "credentials.json"
+    creds.write_text(json.dumps({"access_token": token}), encoding="utf-8")
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(creds))
+
+
+def test_status_authenticated(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_creds_file(tmp_path, monkeypatch, sub="user-123", email="alice@example.com")
+
+    result = runner.invoke(app, ["auth", "status"])
+
+    assert result.exit_code == 0, result.output
+    assert "user-123" in result.output
+    assert "alice@example.com" in result.output
+
+
+def test_status_not_authenticated_exits_1(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(tmp_path / "missing.json"))
+
+    result = runner.invoke(app, ["auth", "status"])
+
+    assert result.exit_code == 1
+    assert "no" in result.output.lower()
+
+
+def test_logout_removes_credentials(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    creds = tmp_path / "credentials.json"
+    creds.write_text(json.dumps({"access_token": "at"}), encoding="utf-8")
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(creds))
+
+    result = runner.invoke(app, ["auth", "logout"])
+
+    assert result.exit_code == 0, result.output
+    assert not creds.exists()
+
+
+def test_logout_when_missing_is_noop(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(tmp_path / "missing.json"))
+
+    result = runner.invoke(app, ["auth", "logout"])
+
+    assert result.exit_code == 0, result.output
+
+
+def test_login_no_browser_prints_url_and_writes_credentials(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    creds = tmp_path / "credentials.json"
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(creds))
+
+    # A real token so the success line can echo the decoded email.
+    access_token = _unsigned_jwt({"sub": "user-9", "email": "bob@example.com"})
+
+    monkeypatch.setattr(
+        auth_module,
+        "_discover_endpoints",
+        lambda issuer, client=None: {
+            "authorization_endpoint": "http://kc/auth",
+            "token_endpoint": "http://kc/token",
+        },
+    )
+    captured_state: dict[str, Any] = {}
+
+    def fake_capture(port: int, **kwargs: Any) -> dict[str, Any]:
+        # Echo back the state generated inside login() by reading the authorize URL.
+        return {"code": "auth-code", "state": captured_state["state"], "error": None}
+
+    def fake_build_url(endpoints, *, state: str, **kwargs: Any) -> str:
+        captured_state["state"] = state
+        return "http://kc/auth?state=" + state
+
+    monkeypatch.setattr(auth_module, "_build_authorize_url", fake_build_url)
+    monkeypatch.setattr(auth_module, "_capture_authorization_code", fake_capture)
+    monkeypatch.setattr(
+        auth_module,
+        "_exchange_code",
+        lambda token_endpoint, **kwargs: {
+            "access_token": access_token,
+            "refresh_token": "rt",
+            "expires_in": 300,
+            "refresh_expires_in": 1800,
+        },
+    )
+
+    opened: list[str] = []
+    monkeypatch.setattr(auth_module.webbrowser, "open", lambda url: opened.append(url))
+
+    result = runner.invoke(app, ["auth", "login", "--no-browser"])
+
+    assert result.exit_code == 0, result.output
+    # --no-browser: URL printed, browser not opened.
+    assert opened == []
+    assert "http://kc/auth" in result.output
+    assert "bob@example.com" in result.output
+
+    data = json.loads(creds.read_text(encoding="utf-8"))
+    assert data["access_token"] == access_token
+    assert data["refresh_token"] == "rt"

--- a/tests/cli/test_auth_config.py
+++ b/tests/cli/test_auth_config.py
@@ -1,0 +1,57 @@
+"""Tests for `seeknal auth config` set/show and `auth login --host` one-step setup."""
+
+from __future__ import annotations
+
+import httpx
+from typer.testing import CliRunner
+
+import seeknal.cli.auth as auth_mod
+from seeknal.cli.auth import auth_app
+
+runner = CliRunner()
+
+
+def _isolate_config(monkeypatch, tmp_path):
+    path = tmp_path / "atlas.json"
+    monkeypatch.setenv("SEEKNAL_ATLAS_CONFIG_PATH", str(path))
+    return path
+
+
+def test_config_set_host_derives_and_persists(monkeypatch, tmp_path):
+    path = _isolate_config(monkeypatch, tmp_path)
+    result = runner.invoke(auth_app, ["config", "set", "--host", "myhost"])
+    assert result.exit_code == 0
+    assert "http://myhost:8000" in result.output
+    assert "http://myhost:4200" in result.output
+    assert "http://myhost:8080/realms/atlas" in result.output
+    assert path.exists()
+
+
+def test_config_set_requires_host_or_api_url(monkeypatch, tmp_path):
+    _isolate_config(monkeypatch, tmp_path)
+    result = runner.invoke(auth_app, ["config", "set"])
+    assert result.exit_code == 1
+    assert "Provide --host" in result.output
+
+
+def test_config_show_marks_env_override(monkeypatch, tmp_path):
+    _isolate_config(monkeypatch, tmp_path)
+    runner.invoke(auth_app, ["config", "set", "--host", "fhost"])
+    monkeypatch.setenv("ATLAS_API_URL", "http://envhost:8000")
+    result = runner.invoke(auth_app, ["config", "show"])
+    assert result.exit_code == 0
+    assert "http://envhost:8000  [env]" in result.output
+    assert "http://fhost:4200  [config]" in result.output
+
+
+def test_login_host_persists_config_before_auth(monkeypatch, tmp_path):
+    path = _isolate_config(monkeypatch, tmp_path)
+
+    def _boom(*args, **kwargs):
+        raise httpx.HTTPError("discovery offline in test")
+
+    # Fail OIDC discovery fast so the test never reaches a real Keycloak.
+    monkeypatch.setattr(auth_mod, "_discover_endpoints", _boom)
+    result = runner.invoke(auth_app, ["login", "--host", "lhost", "--no-browser"])
+    assert path.exists()  # config persisted before the (failed) login
+    assert result.exit_code == 1

--- a/tests/cli/test_dataset.py
+++ b/tests/cli/test_dataset.py
@@ -122,6 +122,18 @@ def test_show_with_sample(monkeypatch):
     client.sample.assert_called_once()
 
 
+def test_resolve_ambiguous_name_warns_and_picks_first(monkeypatch):
+    client = _fake_client()
+    d1 = Dataset(id="urn:1", name="customers", namespace="curated", asset_type="table")
+    d2 = Dataset(id="urn:2", name="customers", namespace="analytics", asset_type="table")
+    client.list_datasets.return_value = [d1, d2]
+    _patch(monkeypatch, client=client)
+    result = runner.invoke(dataset_app, ["show", "customers"])
+    assert result.exit_code == 0
+    assert "matches 2 datasets" in result.output
+    assert "curated.customers" in result.output and "analytics.customers" in result.output
+
+
 def test_annotate_calls_client(monkeypatch):
     client = _fake_client()
     _patch(monkeypatch, client=client)

--- a/tests/cli/test_dataset.py
+++ b/tests/cli/test_dataset.py
@@ -98,7 +98,8 @@ def test_list_accessible_filters_to_allowed(monkeypatch):
     assert "accessible" in result.output
 
 
-def test_list_hints_to_set_portal_url_when_unset(monkeypatch):
+def test_list_hints_to_set_portal_url_when_unset(monkeypatch, tmp_path):
+    monkeypatch.setenv("SEEKNAL_ATLAS_CONFIG_PATH", str(tmp_path / "none.json"))
     monkeypatch.delenv("ATLAS_PORTAL_URL", raising=False)
     _patch(monkeypatch, client=_fake_client())
     result = runner.invoke(dataset_app, ["list"])
@@ -106,12 +107,25 @@ def test_list_hints_to_set_portal_url_when_unset(monkeypatch):
     assert "ATLAS_PORTAL_URL" in result.output
 
 
-def test_list_no_hint_when_portal_set(monkeypatch):
+def test_list_no_hint_when_portal_set(monkeypatch, tmp_path):
+    monkeypatch.setenv("SEEKNAL_ATLAS_CONFIG_PATH", str(tmp_path / "none.json"))
     monkeypatch.setenv("ATLAS_PORTAL_URL", "http://portal:4200")
     _patch(monkeypatch, client=_fake_client())
     result = runner.invoke(dataset_app, ["list"])
     assert result.exit_code == 0
-    assert "Set ATLAS_PORTAL_URL" not in result.output
+    assert "seeknal asset registry" not in result.output
+
+
+def test_list_no_hint_when_portal_in_config(monkeypatch, tmp_path):
+    from seeknal.integrations.atlas_config import derive_config, save_atlas_config
+
+    monkeypatch.setenv("SEEKNAL_ATLAS_CONFIG_PATH", str(tmp_path / "atlas.json"))
+    save_atlas_config(derive_config(host="cfg-host"))  # config provides portal_url
+    monkeypatch.delenv("ATLAS_PORTAL_URL", raising=False)
+    _patch(monkeypatch, client=_fake_client())
+    result = runner.invoke(dataset_app, ["list"])
+    assert result.exit_code == 0
+    assert "seeknal asset registry" not in result.output  # config suppresses the hint
 
 
 def test_show_prints_metadata_and_access(monkeypatch):
@@ -197,6 +211,29 @@ def test_query_accepts_direct_table_identifier(monkeypatch):
     assert result.exit_code == 0
     gate.enforce_access.assert_called_with(resource="retail_demo.sales", action="read")
     client.sample.assert_called_with("retail_demo.sales", limit=20)
+
+
+def test_request_access_uses_config_api_url_when_env_unset(monkeypatch, tmp_path):
+    from seeknal.integrations.atlas_config import derive_config, save_atlas_config
+
+    monkeypatch.setenv("SEEKNAL_ATLAS_CONFIG_PATH", str(tmp_path / "atlas.json"))
+    save_atlas_config(derive_config(host="cfg-host"))
+    monkeypatch.delenv("SEEKNAL_API_URL", raising=False)
+    monkeypatch.delenv("ATLAS_API_URL", raising=False)
+    _patch(monkeypatch, client=_fake_client())
+    seen: dict[str, str] = {}
+    response = MagicMock(status_code=200)
+    response.json.return_value = {"id": "AR-1", "status": "pending"}
+    response.content = b"{}"
+
+    def fake_post(url, **kwargs):
+        seen["url"] = url
+        return response
+
+    monkeypatch.setattr(dataset_mod.httpx, "post", fake_post)
+    result = runner.invoke(dataset_app, ["request-access", "sales", "--reason", "x"])
+    assert result.exit_code == 0
+    assert seen["url"].startswith("http://cfg-host:8000/")  # base from config, not localhost
 
 
 def test_request_access_prints_ar_id(monkeypatch):

--- a/tests/cli/test_dataset.py
+++ b/tests/cli/test_dataset.py
@@ -75,6 +75,29 @@ def test_list_json(monkeypatch):
     assert '"name": "sales"' in result.output
 
 
+def test_list_shows_source_column(monkeypatch):
+    _patch(monkeypatch, client=_fake_client())
+    result = runner.invoke(dataset_app, ["list"])
+    assert result.exit_code == 0
+    assert "Source" in result.output and "lakekeeper" in result.output
+
+
+def test_list_accessible_filters_to_allowed(monkeypatch):
+    client = _fake_client()
+    d1 = Dataset(id="1", name="ok", namespace="ns", asset_type="table", source_system="iceberg")
+    d2 = Dataset(id="2", name="nope", namespace="ns", asset_type="table", source_system="iceberg")
+    client.list_datasets.return_value = [d1, d2]
+    gate = MagicMock()
+    gate.check_access.side_effect = lambda *, resource, action: AccessDecision(
+        allowed=(resource == "ns.ok")
+    )
+    _patch(monkeypatch, client=client, gate=gate)
+    result = runner.invoke(dataset_app, ["list", "--accessible"])
+    assert result.exit_code == 0
+    assert "ok" in result.output and "nope" not in result.output
+    assert "accessible" in result.output
+
+
 def test_list_hints_to_set_portal_url_when_unset(monkeypatch):
     monkeypatch.delenv("ATLAS_PORTAL_URL", raising=False)
     _patch(monkeypatch, client=_fake_client())

--- a/tests/cli/test_dataset.py
+++ b/tests/cli/test_dataset.py
@@ -75,6 +75,22 @@ def test_list_json(monkeypatch):
     assert '"name": "sales"' in result.output
 
 
+def test_list_hints_to_set_portal_url_when_unset(monkeypatch):
+    monkeypatch.delenv("ATLAS_PORTAL_URL", raising=False)
+    _patch(monkeypatch, client=_fake_client())
+    result = runner.invoke(dataset_app, ["list"])
+    assert result.exit_code == 0
+    assert "ATLAS_PORTAL_URL" in result.output
+
+
+def test_list_no_hint_when_portal_set(monkeypatch):
+    monkeypatch.setenv("ATLAS_PORTAL_URL", "http://portal:4200")
+    _patch(monkeypatch, client=_fake_client())
+    result = runner.invoke(dataset_app, ["list"])
+    assert result.exit_code == 0
+    assert "Set ATLAS_PORTAL_URL" not in result.output
+
+
 def test_show_prints_metadata_and_access(monkeypatch):
     _patch(monkeypatch, client=_fake_client())
     result = runner.invoke(dataset_app, ["show", "sales"])

--- a/tests/cli/test_dataset.py
+++ b/tests/cli/test_dataset.py
@@ -7,9 +7,13 @@ from unittest.mock import MagicMock
 from typer.testing import CliRunner
 
 import seeknal.cli.dataset as dataset_mod
-from seeknal.cli.dataset import dataset_app
+from seeknal.cli.dataset import _extract_sample, dataset_app
 from seeknal.integrations.atlas_catalog import Dataset
-from seeknal.integrations.atlas_client import AtlasPolicyDenied
+from seeknal.integrations.atlas_client import (
+    AtlasAuthError,
+    AtlasPolicyDenied,
+    SESSION_EXPIRED_HINT,
+)
 from seeknal.integrations.atlas_governance import AccessDecision
 
 runner = CliRunner()
@@ -135,3 +139,89 @@ def test_request_access_prints_ar_id(monkeypatch):
     result = runner.invoke(dataset_app, ["request-access", "sales", "--reason", "need it"])
     assert result.exit_code == 0
     assert "AR-9" in result.output
+
+
+def test_extract_sample_unwraps_backend_values_envelope():
+    # The Atlas /api/sample backend returns columns as schema dicts and rows
+    # wrapped as {"values": {col: val}} -- the shape that previously rendered blank.
+    data = {
+        "columns": [{"name": "sale_id"}, {"name": "customer_name"}, {"name": "region"}],
+        "rows": [
+            {"values": {"sale_id": 1, "customer_name": "Alice", "region": "us-east"}},
+            {"values": {"sale_id": 2, "customer_name": "Bob", "region": "us-west"}},
+        ],
+    }
+    columns, rows = _extract_sample(data)
+    assert columns == ["sale_id", "customer_name", "region"]
+    assert rows == [[1, "Alice", "us-east"], [2, "Bob", "us-west"]]
+
+
+def test_query_renders_backend_values_envelope(monkeypatch):
+    client = _fake_client()
+    client.sample.return_value = {
+        "columns": [{"name": "sale_id"}, {"name": "region"}],
+        "rows": [{"values": {"sale_id": 1, "region": "us-east"}}],
+    }
+    _patch(monkeypatch, client=client)
+    result = runner.invoke(dataset_app, ["query", "retail_demo.sales"])
+    assert result.exit_code == 0
+    assert "us-east" in result.output
+    assert "1 row(s)." in result.output
+
+
+def test_show_presents_expired_session_without_traceback(monkeypatch):
+    client = _fake_client()
+    client.list_datasets.side_effect = AtlasAuthError(SESSION_EXPIRED_HINT)
+    _patch(monkeypatch, client=client)
+    result = runner.invoke(dataset_app, ["show", "sales"])
+    assert result.exit_code == 1
+    assert "seeknal auth login" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_query_presents_expired_session_without_traceback(monkeypatch):
+    client = _fake_client()
+    client.list_datasets.side_effect = AtlasAuthError(SESSION_EXPIRED_HINT)
+    _patch(monkeypatch, client=client)
+    result = runner.invoke(dataset_app, ["query", "retail_demo.sales"])
+    assert result.exit_code == 1
+    assert "seeknal auth login" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_request_access_refreshes_token_on_401(monkeypatch):
+    client = _fake_client()
+    _patch(monkeypatch, client=client)
+
+    calls = {"n": 0}
+    ok = MagicMock(status_code=200)
+    ok.json.return_value = {"id": "AR-12", "status": "pending"}
+    ok.content = b"{}"
+    expired = MagicMock(status_code=401)
+    expired.text = "Token has expired"
+
+    def fake_post(*a, **k):
+        calls["n"] += 1
+        return expired if calls["n"] == 1 else ok
+
+    monkeypatch.setattr(dataset_mod.httpx, "post", fake_post)
+    monkeypatch.setattr(dataset_mod, "refresh_access_token", lambda: "fresh-token")
+
+    result = runner.invoke(dataset_app, ["request-access", "sales", "--reason", "x"])
+    assert result.exit_code == 0
+    assert calls["n"] == 2  # 401 -> refresh -> retry succeeds
+    assert "AR-12" in result.output
+
+
+def test_request_access_friendly_when_refresh_fails(monkeypatch):
+    client = _fake_client()
+    _patch(monkeypatch, client=client)
+    expired = MagicMock(status_code=401)
+    expired.text = "Token has expired"
+    monkeypatch.setattr(dataset_mod.httpx, "post", lambda *a, **k: expired)
+    monkeypatch.setattr(dataset_mod, "refresh_access_token", lambda: None)
+
+    result = runner.invoke(dataset_app, ["request-access", "sales", "--reason", "x"])
+    assert result.exit_code == 1
+    assert "seeknal auth login" in result.output
+    assert "Traceback" not in result.output

--- a/tests/cli/test_dataset.py
+++ b/tests/cli/test_dataset.py
@@ -27,6 +27,7 @@ DS = Dataset(
     description="Retail sales",
     tags=("gold",),
     canonical_id="atlas.retail_demo.sales",
+    columns=(("sale_id", "long"), ("region", "string")),
 )
 
 
@@ -75,6 +76,21 @@ def test_show_prints_metadata_and_access(monkeypatch):
     result = runner.invoke(dataset_app, ["show", "sales"])
     assert result.exit_code == 0
     assert "retail_demo" in result.output and "ALLOW" in result.output
+
+
+def test_show_renders_columns(monkeypatch):
+    _patch(monkeypatch, client=_fake_client())
+    result = runner.invoke(dataset_app, ["show", "sales"])
+    assert result.exit_code == 0
+    assert "columns" in result.output
+    assert "sale_id" in result.output and "region" in result.output and "(long)" in result.output
+
+
+def test_show_json_includes_columns(monkeypatch):
+    _patch(monkeypatch, client=_fake_client())
+    result = runner.invoke(dataset_app, ["show", "sales", "--json"])
+    assert result.exit_code == 0
+    assert '"name": "sale_id"' in result.output and '"type": "long"' in result.output
 
 
 def test_show_with_sample(monkeypatch):

--- a/tests/cli/test_dataset.py
+++ b/tests/cli/test_dataset.py
@@ -37,6 +37,10 @@ def _fake_client() -> MagicMock:
     client.get_dataset.return_value = DS
     client.sample.return_value = {"columns": ["sale_id", "region"], "rows": [[1, "us-east"]]}
     client.annotate.return_value = {"ok": True}
+    client.lineage.return_value = {
+        "upstreamLineage": [{"name": "raw.sales", "type": "DATASET"}],
+        "downstreamLineage": [{"name": "gold.sales_daily", "type": "DATASET"}],
+    }
     return client
 
 
@@ -155,6 +159,32 @@ def test_request_access_prints_ar_id(monkeypatch):
     result = runner.invoke(dataset_app, ["request-access", "sales", "--reason", "need it"])
     assert result.exit_code == 0
     assert "AR-9" in result.output
+
+
+def test_lineage_renders_tree(monkeypatch):
+    client = _fake_client()
+    _patch(monkeypatch, client=client)
+    result = runner.invoke(dataset_app, ["lineage", "sales"])
+    assert result.exit_code == 0
+    assert "upstream" in result.output and "raw.sales" in result.output
+    assert "downstream" in result.output and "gold.sales_daily" in result.output
+
+
+def test_lineage_empty_is_friendly(monkeypatch):
+    client = _fake_client()
+    client.lineage.return_value = {"upstreamLineage": [], "downstreamLineage": []}
+    _patch(monkeypatch, client=client)
+    result = runner.invoke(dataset_app, ["lineage", "sales"])
+    assert result.exit_code == 0
+    assert "No lineage recorded" in result.output
+
+
+def test_lineage_json(monkeypatch):
+    client = _fake_client()
+    _patch(monkeypatch, client=client)
+    result = runner.invoke(dataset_app, ["lineage", "sales", "--json"])
+    assert result.exit_code == 0
+    assert '"name": "raw.sales"' in result.output and '"downstream"' in result.output
 
 
 def test_extract_sample_unwraps_backend_values_envelope():

--- a/tests/cli/test_dataset.py
+++ b/tests/cli/test_dataset.py
@@ -187,6 +187,38 @@ def test_lineage_json(monkeypatch):
     assert '"name": "raw.sales"' in result.output and '"downstream"' in result.output
 
 
+def test_use_prints_iceberg_source(monkeypatch):
+    _patch(monkeypatch, client=_fake_client())
+    result = runner.invoke(dataset_app, ["use", "sales"])
+    assert result.exit_code == 0
+    assert "kind: source" in result.output
+    assert "source: iceberg" in result.output
+    assert "table: atlas.retail_demo.sales" in result.output
+
+
+def test_use_rejects_cube(monkeypatch):
+    client = _fake_client()
+    cube = Dataset(
+        id="urn:cube", name="Orders", namespace="public", asset_type="cube", source_system="cube"
+    )
+    client.list_datasets.return_value = [cube]
+    _patch(monkeypatch, client=client)
+    result = runner.invoke(dataset_app, ["use", "Orders"])
+    assert result.exit_code == 1
+    assert "cube" in result.output.lower()
+
+
+def test_use_write_creates_source_file(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    _patch(monkeypatch, client=_fake_client())
+    result = runner.invoke(dataset_app, ["use", "sales", "--write"])
+    assert result.exit_code == 0
+    dest = tmp_path / "seeknal" / "sources" / "sales.yml"
+    assert dest.exists()
+    content = dest.read_text()
+    assert "source: iceberg" in content and "table: atlas.retail_demo.sales" in content
+
+
 def test_extract_sample_unwraps_backend_values_envelope():
     # The Atlas /api/sample backend returns columns as schema dicts and rows
     # wrapped as {"values": {col: val}} -- the shape that previously rendered blank.

--- a/tests/cli/test_dataset.py
+++ b/tests/cli/test_dataset.py
@@ -1,0 +1,137 @@
+"""Tests for the `seeknal dataset` CLI command group."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from typer.testing import CliRunner
+
+import seeknal.cli.dataset as dataset_mod
+from seeknal.cli.dataset import dataset_app
+from seeknal.integrations.atlas_catalog import Dataset
+from seeknal.integrations.atlas_client import AtlasPolicyDenied
+from seeknal.integrations.atlas_governance import AccessDecision
+
+runner = CliRunner()
+
+DS = Dataset(
+    id="abc-123",
+    name="sales",
+    namespace="retail_demo",
+    asset_type="source",
+    source_system="lakekeeper",
+    description="Retail sales",
+    tags=("gold",),
+    canonical_id="atlas.retail_demo.sales",
+)
+
+
+def _fake_client() -> MagicMock:
+    client = MagicMock()
+    client.list_datasets.return_value = [DS]
+    client.get_dataset.return_value = DS
+    client.sample.return_value = {"columns": ["sale_id", "region"], "rows": [[1, "us-east"]]}
+    client.annotate.return_value = {"ok": True}
+    return client
+
+
+def _patch(monkeypatch, *, client, gate="allow"):
+    monkeypatch.setattr(dataset_mod, "create_catalog_client_from_env", lambda: client)
+    if gate == "allow":
+        gate = MagicMock()
+        gate.check_access.return_value = AccessDecision(allowed=True)
+        gate.enforce_access.return_value = AccessDecision(allowed=True)
+    monkeypatch.setattr(dataset_mod, "create_governance_gate_from_env", lambda: gate)
+    return gate
+
+
+def test_not_configured_exits_2(monkeypatch):
+    _patch(monkeypatch, client=None)
+    result = runner.invoke(dataset_app, ["list"])
+    assert result.exit_code == 2
+    assert "not configured" in result.output.lower()
+
+
+def test_list_renders_datasets(monkeypatch):
+    _patch(monkeypatch, client=_fake_client())
+    result = runner.invoke(dataset_app, ["list"])
+    assert result.exit_code == 0
+    assert "sales" in result.output and "retail_demo" in result.output
+
+
+def test_list_json(monkeypatch):
+    _patch(monkeypatch, client=_fake_client())
+    result = runner.invoke(dataset_app, ["list", "--json"])
+    assert result.exit_code == 0
+    assert '"name": "sales"' in result.output
+
+
+def test_show_prints_metadata_and_access(monkeypatch):
+    _patch(monkeypatch, client=_fake_client())
+    result = runner.invoke(dataset_app, ["show", "sales"])
+    assert result.exit_code == 0
+    assert "retail_demo" in result.output and "ALLOW" in result.output
+
+
+def test_show_with_sample(monkeypatch):
+    client = _fake_client()
+    _patch(monkeypatch, client=client)
+    result = runner.invoke(dataset_app, ["show", "sales", "--sample"])
+    assert result.exit_code == 0
+    assert "us-east" in result.output
+    client.sample.assert_called_once()
+
+
+def test_annotate_calls_client(monkeypatch):
+    client = _fake_client()
+    _patch(monkeypatch, client=client)
+    result = runner.invoke(dataset_app, ["annotate", "sales", "--tag", "pii", "--description", "d"])
+    assert result.exit_code == 0
+    client.annotate.assert_called_once()
+
+
+def test_annotate_requires_a_flag(monkeypatch):
+    _patch(monkeypatch, client=_fake_client())
+    result = runner.invoke(dataset_app, ["annotate", "sales"])
+    assert result.exit_code == 1
+    assert "at least one" in result.output.lower()
+
+
+def test_query_denied_exits_1_with_hint(monkeypatch):
+    gate = MagicMock()
+    gate.enforce_access.side_effect = AtlasPolicyDenied("OpenFGA denies can_select")
+    _patch(monkeypatch, client=_fake_client(), gate=gate)
+    result = runner.invoke(dataset_app, ["query", "sales"])
+    assert result.exit_code == 1
+    assert "request-access" in result.output
+
+
+def test_query_allowed_prints_rows(monkeypatch):
+    client = _fake_client()
+    _patch(monkeypatch, client=client)
+    result = runner.invoke(dataset_app, ["query", "sales"])
+    assert result.exit_code == 0
+    assert "us-east" in result.output
+
+
+def test_query_accepts_direct_table_identifier(monkeypatch):
+    client = _fake_client()
+    client.list_datasets.return_value = []  # not a registered asset
+    gate = _patch(monkeypatch, client=client)
+    result = runner.invoke(dataset_app, ["query", "retail_demo.sales"])
+    assert result.exit_code == 0
+    gate.enforce_access.assert_called_with(resource="retail_demo.sales", action="read")
+    client.sample.assert_called_with("retail_demo.sales", limit=20)
+
+
+def test_request_access_prints_ar_id(monkeypatch):
+    client = _fake_client()
+    _patch(monkeypatch, client=client)
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {"id": "AR-9", "status": "pending"}
+    response.content = b"{}"
+    monkeypatch.setattr(dataset_mod.httpx, "post", lambda *a, **k: response)
+    result = runner.invoke(dataset_app, ["request-access", "sales", "--reason", "need it"])
+    assert result.exit_code == 0
+    assert "AR-9" in result.output

--- a/tests/cli/test_gov.py
+++ b/tests/cli/test_gov.py
@@ -1,0 +1,164 @@
+"""
+Tests for ``seeknal gov request-access``.
+
+These exercise the CLI command in isolation by monkeypatching ``httpx.post`` so no
+network call is made. The behaviours under test: the POST body carries the expected
+keys, the created request id is printed on a 201, and a non-2xx response exits 1.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from seeknal.cli import gov as gov_module
+from seeknal.cli.main import app
+
+runner = CliRunner()
+
+
+def _captured_post(
+    captured: dict[str, Any],
+    *,
+    status_code: int,
+    json_body: dict[str, Any] | None = None,
+    text: str = "",
+):
+    """Build a fake ``httpx.post`` that records its call and returns a canned response."""
+
+    def fake_post(url: str, *, json: dict[str, Any], headers: dict[str, str], timeout: float):
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        request = httpx.Request("POST", url)
+        if json_body is not None:
+            return httpx.Response(status_code, json=json_body, request=request)
+        return httpx.Response(status_code, text=text, request=request)
+
+    return fake_post
+
+
+def test_request_access_posts_expected_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SEEKNAL_API_URL", "https://atlas.example.com")
+    monkeypatch.delenv("ATLAS_API_URL", raising=False)
+    monkeypatch.setattr(gov_module, "user_email_from_credentials", lambda: "alice@example.com")
+    monkeypatch.setattr(gov_module, "user_token_from_credentials", lambda: "tok-123")
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        _captured_post(
+            captured,
+            status_code=201,
+            json_body={"id": "AR-7", "status": "pending"},
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "gov",
+            "request-access",
+            "warehouse.namespace.table",
+            "--reason",
+            "need it for the Q3 model",
+            "--access",
+            "read",
+            "--duration",
+            "90d",
+            "--priority",
+            "medium",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["url"] == "https://atlas.example.com/governance/access-requests"
+    body = captured["json"]
+    assert body == {
+        "requester": "alice@example.com",
+        "entityName": "warehouse.namespace.table",
+        "entityUrn": "",
+        "requestedAccess": "read",
+        "reason": "need it for the Q3 model",
+        "duration": "90d",
+        "priority": "medium",
+        "type": "dataset",
+    }
+    assert captured["headers"]["Authorization"] == "Bearer tok-123"
+    assert "AR-7" in result.output
+
+
+def test_request_access_includes_urn_when_given(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SEEKNAL_API_URL", "https://atlas.example.com")
+    monkeypatch.setattr(gov_module, "user_email_from_credentials", lambda: "bob@example.com")
+    monkeypatch.setattr(gov_module, "user_token_from_credentials", lambda: None)
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        _captured_post(captured, status_code=201, json_body={"id": "AR-9", "status": "pending"}),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "gov",
+            "request-access",
+            "prod.gold.customer",
+            "--reason",
+            "audit",
+            "--urn",
+            "urn:li:dataset:(x,prod.gold.customer,PROD)",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["json"]["entityUrn"] == "urn:li:dataset:(x,prod.gold.customer,PROD)"
+    # No credentials token → no Authorization header.
+    assert "Authorization" not in captured["headers"]
+
+
+def test_request_access_non_2xx_exits_1(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SEEKNAL_API_URL", "https://atlas.example.com")
+    monkeypatch.setattr(gov_module, "user_email_from_credentials", lambda: "alice@example.com")
+    monkeypatch.setattr(gov_module, "user_token_from_credentials", lambda: None)
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        _captured_post(captured, status_code=403, text="forbidden"),
+    )
+
+    result = runner.invoke(
+        app,
+        ["gov", "request-access", "prod.gold.finance", "--reason", "nope"],
+    )
+
+    assert result.exit_code == 1
+    assert "403" in result.output
+
+
+def test_request_access_transport_error_exits_1(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SEEKNAL_API_URL", "https://atlas.example.com")
+    monkeypatch.setattr(gov_module, "user_email_from_credentials", lambda: "alice@example.com")
+    monkeypatch.setattr(gov_module, "user_token_from_credentials", lambda: None)
+
+    def boom(url: str, *, json: dict[str, Any], headers: dict[str, str], timeout: float):
+        raise httpx.ConnectError("atlas down", request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx, "post", boom)
+
+    result = runner.invoke(
+        app,
+        ["gov", "request-access", "prod.gold.finance", "--reason", "x"],
+    )
+
+    assert result.exit_code == 1

--- a/tests/cli/test_run_governance.py
+++ b/tests/cli/test_run_governance.py
@@ -1,0 +1,157 @@
+"""
+Tests for the Atlas pre-run access enforcement hooked into ``seeknal run``.
+
+These exercise the enforcement at the hook level (``_enforce_pre_run``) and the pure
+``_source_fqtn`` resolver -- no data is materialized and no DAG is built. A fake gate
+stands in for the live Atlas backend, and ``create_governance_gate_from_env`` is
+monkeypatched on ``seeknal.cli.main`` so the gate-None / deny / allow paths are
+covered without ATLAS_API_URL or a network.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from seeknal.cli import main as main_module
+from seeknal.dag.manifest import NodeType
+from seeknal.integrations.atlas_client import AtlasPolicyDenied
+
+
+class _FakeNode:
+    """Minimal stand-in for a DAG node exposing ``config`` and ``node_type``."""
+
+    def __init__(self, node_type: NodeType, config: dict[str, Any]) -> None:
+        self.node_type = node_type
+        self.kind = node_type
+        self.config = config
+
+
+class _FakeDAG:
+    """Minimal stand-in for the DAG builder exposing ``nodes`` by id."""
+
+    def __init__(self, nodes: dict[str, _FakeNode]) -> None:
+        self.nodes = nodes
+
+
+class _FakeGate:
+    """Records ``enforce_access`` calls; optionally denies a named resource."""
+
+    def __init__(self, deny: str | None = None) -> None:
+        self.deny = deny
+        self.calls: list[dict[str, Any]] = []
+
+    def enforce_access(self, *, resource: str, action: str, actor: str | None) -> Any:
+        self.calls.append({"resource": resource, "action": action, "actor": actor})
+        if self.deny is not None and resource == self.deny:
+            raise AtlasPolicyDenied(f"denied {action} on {resource}")
+        return object()
+
+
+# -- _source_fqtn ------------------------------------------------------------
+
+
+def test_source_fqtn_iceberg_three_part_table_used_verbatim() -> None:
+    node = _FakeNode(
+        NodeType.SOURCE,
+        {"source": "iceberg", "table": "atlas.qa_iceberg.signal_events"},
+    )
+    assert main_module._source_fqtn(node) == "atlas.qa_iceberg.signal_events"
+
+
+def test_source_fqtn_prepends_warehouse_from_params() -> None:
+    node = _FakeNode(
+        NodeType.SOURCE,
+        {"source": "iceberg", "table": "qa.events", "params": {"warehouse": "seeknal-warehouse"}},
+    )
+    assert main_module._source_fqtn(node) == "seeknal-warehouse.qa.events"
+
+
+def test_source_fqtn_postgresql_schema_table_fallback() -> None:
+    # No warehouse/catalog context -> most-qualified string available is returned.
+    node = _FakeNode(
+        NodeType.SOURCE,
+        {"source": "postgresql", "table": "public.events", "params": {"connection": "pg"}},
+    )
+    assert main_module._source_fqtn(node) == "public.events"
+
+
+def test_source_fqtn_none_when_no_table() -> None:
+    node = _FakeNode(NodeType.SOURCE, {"source": "csv"})
+    assert main_module._source_fqtn(node) is None
+    node_empty = _FakeNode(NodeType.SOURCE, {"source": "csv", "table": "  "})
+    assert main_module._source_fqtn(node_empty) is None
+
+
+# -- _enforce_pre_run --------------------------------------------------------
+
+
+def test_gate_none_skips_enforcement(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A gate that would explode if used -- proves None short-circuits.
+    sentinel = _FakeGate()
+    dag = _FakeDAG(
+        {"source.a": _FakeNode(NodeType.SOURCE, {"source": "iceberg", "table": "w.n.a"})}
+    )
+    # gate is None => no calls.
+    main_module._enforce_pre_run({"source.a"}, dag, None)
+    assert sentinel.calls == []
+
+
+def test_gate_allows_checks_only_sources(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(main_module, "user_sub_from_credentials", lambda: "user-1", raising=False)
+    dag = _FakeDAG(
+        {
+            "source.a": _FakeNode(NodeType.SOURCE, {"source": "iceberg", "table": "w.n.a"}),
+            "transform.b": _FakeNode(NodeType.TRANSFORM, {"transform": "SELECT 1"}),
+        }
+    )
+    gate = _FakeGate()
+
+    main_module._enforce_pre_run({"source.a", "transform.b"}, dag, gate)
+
+    # Only the source node was access-checked, with action=read.
+    assert len(gate.calls) == 1
+    assert gate.calls[0]["resource"] == "w.n.a"
+    assert gate.calls[0]["action"] == "read"
+
+
+def test_gate_denies_aborts_with_request_access_hint(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import typer
+
+    monkeypatch.setattr(main_module, "user_sub_from_credentials", lambda: "user-1", raising=False)
+    dag = _FakeDAG(
+        {"source.secret": _FakeNode(NodeType.SOURCE, {"source": "iceberg", "table": "w.n.secret"})}
+    )
+    gate = _FakeGate(deny="w.n.secret")
+
+    with pytest.raises(typer.Exit) as excinfo:
+        main_module._enforce_pre_run({"source.secret"}, dag, gate)
+
+    assert excinfo.value.exit_code == 1
+    out = capsys.readouterr().out
+    assert "request-access" in out
+    assert "w.n.secret" in out
+
+
+# -- run() integration at the enforcement boundary ---------------------------
+
+
+def test_run_proceeds_when_gate_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """gate None => the factory returns None and enforcement is a no-op."""
+
+    called = {"enforced": False}
+
+    def fake_enforce(nodes_to_run, dag_builder, gate):
+        called["enforced"] = True
+        assert gate is None
+
+    monkeypatch.setattr(main_module, "create_governance_gate_from_env", lambda: None)
+    monkeypatch.setattr(main_module, "_enforce_pre_run", fake_enforce)
+
+    # Call the hook the way run() does.
+    gate = main_module.create_governance_gate_from_env()
+    main_module._enforce_pre_run({"source.a"}, _FakeDAG({}), gate)
+    assert called["enforced"] is True

--- a/tests/heartbeat/classifier/conftest.py
+++ b/tests/heartbeat/classifier/conftest.py
@@ -1,0 +1,61 @@
+"""Shared fixtures for classifier tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from seeknal.heartbeat.classifier.catalog import Catalog, CatalogEntry
+from seeknal.heartbeat.classifier.models import Fingerprint
+
+
+@pytest.fixture
+def sales_fingerprint() -> Fingerprint:
+    return Fingerprint(
+        column_names=["order_id", "customer_id", "amount", "order_date"],
+        column_types=["string", "string", "float", "date"],
+        value_regexes=["uuid", "uuid", "currency_usd", "iso_date"],
+        row_count_sample=100,
+        column_count=4,
+    )
+
+
+@pytest.fixture
+def sales_catalog_entry(sales_fingerprint: Fingerprint) -> CatalogEntry:
+    return CatalogEntry(
+        source_table="bronze.sales",
+        fingerprint=sales_fingerprint,
+        canonical_columns={
+            "order_id": {"aliases": ["orderid", "order_no"]},
+            "customer_id": {"aliases": ["cust_id", "customer"]},
+            "amount": {"aliases": ["total"]},
+            "order_date": {"aliases": ["date", "transaction_date"]},
+        },
+        write_mode="upsert",
+        business_key=["order_id"],
+    )
+
+
+@pytest.fixture
+def catalog_with_sales(tmp_path: Path, sales_catalog_entry: CatalogEntry) -> Catalog:
+    catalog = Catalog(source_path=tmp_path / ".seeknal/source_catalog.yml")
+    catalog.upsert(sales_catalog_entry)
+    return catalog
+
+
+class FakeLLM:
+    """A scripted LLM stub for router tests."""
+
+    def __init__(self, proposal):
+        self._proposal = proposal
+        self.calls = 0
+
+    def classify(self, fp, catalog_summary, file_sample_preview):
+        self.calls += 1
+        return self._proposal
+
+
+@pytest.fixture
+def fake_llm():
+    return FakeLLM

--- a/tests/heartbeat/classifier/test_catalog.py
+++ b/tests/heartbeat/classifier/test_catalog.py
@@ -1,0 +1,120 @@
+"""Catalog persistence tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from seeknal.heartbeat.classifier.catalog import Catalog, CatalogEntry
+from seeknal.heartbeat.classifier.models import Fingerprint
+
+
+def test_catalog_missing_file_returns_empty(tmp_path: Path):
+    catalog = Catalog.load(tmp_path)
+    assert catalog.entries == {}
+
+
+def test_catalog_insecure_path():
+    with pytest.raises(ValueError, match="Insecure catalog"):
+        Catalog.load(Path("/tmp"))
+
+
+def test_save_and_load_round_trip(tmp_path: Path):
+    catalog = Catalog(source_path=tmp_path / ".seeknal/source_catalog.yml")
+    catalog.upsert(
+        CatalogEntry(
+            source_table="bronze.sales",
+            fingerprint=Fingerprint(
+                column_names=["id", "amount"],
+                column_types=["string", "float"],
+                value_regexes=["uuid", "currency_usd"],
+            ),
+            canonical_columns={"id": {"aliases": ["order_id"]}},
+            write_mode="upsert",
+            business_key=["id"],
+        )
+    )
+    catalog.save()
+
+    loaded = Catalog.load(tmp_path)
+    assert "bronze.sales" in loaded.entries
+    entry = loaded.entries["bronze.sales"]
+    assert entry.write_mode == "upsert"
+    assert entry.business_key == ["id"]
+
+
+def test_find_best_match_above_threshold(tmp_path: Path):
+    catalog = Catalog(source_path=tmp_path / "x.yml")
+    catalog.upsert(
+        CatalogEntry(
+            source_table="orders",
+            fingerprint=Fingerprint(
+                column_names=["order_id", "customer_id", "amount"],
+                column_types=["string", "string", "float"],
+                value_regexes=["uuid", "uuid", "currency_usd"],
+            ),
+        )
+    )
+    fp = Fingerprint(
+        column_names=["order_id", "customer_id", "amount"],
+        column_types=["string", "string", "float"],
+        value_regexes=["uuid", "uuid", "currency_usd"],
+    )
+    match = catalog.find_best_match(fp, threshold=0.8)
+    assert match is not None
+    assert match.source_table == "orders"
+
+
+def test_find_best_match_below_threshold(tmp_path: Path):
+    catalog = Catalog(source_path=tmp_path / "x.yml")
+    catalog.upsert(
+        CatalogEntry(
+            source_table="orders",
+            fingerprint=Fingerprint(
+                column_names=["a", "b"],
+                column_types=["int", "int"],
+                value_regexes=["", ""],
+            ),
+        )
+    )
+    fp = Fingerprint(
+        column_names=["x", "y", "z"],
+        column_types=["string", "string", "string"],
+        value_regexes=["", "", ""],
+    )
+    assert catalog.find_best_match(fp, threshold=0.9) is None
+
+
+def test_corrupt_yaml_starts_empty(tmp_path: Path):
+    path = tmp_path / ".seeknal" / "source_catalog.yml"
+    path.parent.mkdir()
+    path.write_text("not: [valid yaml")
+    catalog = Catalog.load(tmp_path)
+    assert catalog.entries == {}
+    # Corrupt file renamed aside
+    corrupted = list(path.parent.glob("source_catalog.yml.corrupt.*"))
+    assert corrupted, "Expected corrupt file rename"
+
+
+def test_alias_learning(tmp_path: Path):
+    """AC14 surface: confirming a mapping adds aliases that route the next file."""
+    catalog = Catalog(source_path=tmp_path / ".seeknal/source_catalog.yml")
+    entry = CatalogEntry(
+        source_table="bronze.sales",
+        fingerprint=Fingerprint(
+            column_names=["order_id", "amount"],
+            column_types=["string", "float"],
+            value_regexes=["uuid", "currency_usd"],
+        ),
+        canonical_columns={"order_id": {"aliases": []}, "amount": {"aliases": []}},
+    )
+    catalog.upsert(entry)
+    # Operator confirms: new alias added.
+    entry.canonical_columns["order_id"]["aliases"].append("orderid")
+    catalog.upsert(entry)
+    catalog.save()
+
+    loaded = Catalog.load(tmp_path)
+    aliases = loaded.entries["bronze.sales"].canonical_columns["order_id"]["aliases"]
+    assert "orderid" in aliases

--- a/tests/heartbeat/classifier/test_disabled.py
+++ b/tests/heartbeat/classifier/test_disabled.py
@@ -1,0 +1,54 @@
+"""AC20: classifier.enabled: false → no LLM/catalog reads; v0.4 fallback intact."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from seeknal.heartbeat.classifier.catalog import Catalog
+from seeknal.heartbeat.classifier.llm_classifier import LLMProposal
+from seeknal.heartbeat.classifier.router import (
+    ClassificationRouter,
+    ClassifierConfig,
+)
+
+
+class CountingLLM:
+    def __init__(self):
+        self.calls = 0
+
+    def classify(self, *args, **kwargs):
+        self.calls += 1
+        return LLMProposal(target_table="x", confidence=1.0)
+
+
+def test_disabled_skips_llm(tmp_path: Path):
+    src = tmp_path / "sales.csv"
+    src.write_text("a\n1\n")
+    config = ClassifierConfig(enabled=False)
+    llm = CountingLLM()
+    router = ClassificationRouter(config=config, catalog=Catalog(), llm=llm)
+    decision = router.classify(src)
+    assert decision.outcome == "default_fallback"
+    assert decision.target_table == "ingested.sales"
+    assert llm.calls == 0
+
+
+def test_disabled_skips_catalog_match(tmp_path: Path):
+    src = tmp_path / "any.csv"
+    src.write_text("a\n1\n")
+    # Even with a catalog that would match perfectly, disabled returns fallback.
+    from seeknal.heartbeat.classifier.catalog import CatalogEntry
+    from seeknal.heartbeat.classifier.models import Fingerprint
+
+    catalog = Catalog()
+    catalog.upsert(
+        CatalogEntry(
+            source_table="bronze.any",
+            fingerprint=Fingerprint(column_names=["a"], column_types=["int"], value_regexes=[""]),
+        )
+    )
+    config = ClassifierConfig(enabled=False)
+    router = ClassificationRouter(config=config, catalog=catalog)
+    decision = router.classify(src)
+    assert decision.outcome == "default_fallback"
+    assert decision.target_table == "ingested.any"

--- a/tests/heartbeat/classifier/test_fingerprint.py
+++ b/tests/heartbeat/classifier/test_fingerprint.py
@@ -1,0 +1,80 @@
+"""Fingerprint extraction tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from seeknal.heartbeat.classifier.fingerprint import (
+    _infer_type,
+    _normalize_name,
+    compute_fingerprint,
+    similarity,
+)
+from seeknal.heartbeat.classifier.models import Fingerprint
+
+
+def test_normalize_name():
+    assert _normalize_name("OrderId") == "order_id"
+    assert _normalize_name("order-id") == "order_id"
+    assert _normalize_name(" Customer Name ") == "customer_name"
+
+
+def test_infer_type_integer():
+    assert _infer_type(["1", "2", "3"]) == "int"
+
+
+def test_infer_type_float():
+    assert _infer_type(["1.0", "2.5", "3.1"]) == "float"
+
+
+def test_infer_type_date():
+    assert _infer_type(["2024-01-01", "2024-02-15"]) == "date"
+
+
+def test_infer_type_string():
+    assert _infer_type(["alice", "bob"]) == "string"
+
+
+def test_compute_fingerprint_csv(tmp_path: Path):
+    f = tmp_path / "sales.csv"
+    f.write_text(
+        "order_id,customer_id,amount,order_date\n"
+        "A001,C1,99.50,2024-01-01\n"
+        "A002,C2,42.00,2024-02-01\n"
+    )
+    fp = compute_fingerprint(f)
+    assert fp.column_names == ["order_id", "customer_id", "amount", "order_date"]
+    assert fp.column_count == 4
+    assert fp.row_count_sample == 2
+
+
+def test_similarity_identical():
+    fp = Fingerprint(
+        column_names=["a", "b"],
+        column_types=["int", "string"],
+        value_regexes=["integer", ""],
+    )
+    assert similarity(fp, fp) == pytest.approx(1.0)
+
+
+def test_similarity_disjoint():
+    a = Fingerprint(column_names=["x"], column_types=["int"], value_regexes=[""])
+    b = Fingerprint(column_names=["y"], column_types=["string"], value_regexes=[""])
+    assert similarity(a, b) < 0.6
+
+
+def test_similarity_partial():
+    a = Fingerprint(
+        column_names=["a", "b", "c"],
+        column_types=["int", "int", "string"],
+        value_regexes=["", "", ""],
+    )
+    b = Fingerprint(
+        column_names=["a", "b", "d"],
+        column_types=["int", "int", "string"],
+        value_regexes=["", "", ""],
+    )
+    score = similarity(a, b)
+    assert 0.4 < score < 1.0

--- a/tests/heartbeat/classifier/test_mapper.py
+++ b/tests/heartbeat/classifier/test_mapper.py
@@ -1,0 +1,75 @@
+"""Column mapper tests (Pass 1)."""
+
+from __future__ import annotations
+
+from seeknal.heartbeat.classifier.mapper import (
+    DEFAULT_UNIT_SENSITIVE_KEYWORDS,
+    Mapper,
+    _levenshtein,
+)
+
+
+def test_levenshtein_basic():
+    assert _levenshtein("kitten", "sitting") == 3
+    assert _levenshtein("abc", "abc") == 0
+
+
+def test_exact_match():
+    mapper = Mapper()
+    mapping = mapper.map_columns(["a", "b"], ["a", "b"])
+    assert mapping.mapping == {"a": "a", "b": "b"}
+    assert mapping.unmapped_file_cols == []
+
+
+def test_snake_normalization():
+    mapper = Mapper()
+    mapping = mapper.map_columns(["OrderId"], ["order_id"])
+    assert mapping.mapping == {"OrderId": "order_id"}
+
+
+def test_alias_lookup():
+    mapper = Mapper()
+    mapping = mapper.map_columns(
+        ["orderid"],
+        ["order_id"],
+        aliases={"order_id": ["orderid", "order_no"]},
+    )
+    assert mapping.mapping == {"orderid": "order_id"}
+
+
+def test_fuzzy_within_distance_2():
+    mapper = Mapper()
+    mapping = mapper.map_columns(["customr"], ["customer"])
+    assert mapping.mapping == {"customr": "customer"}
+
+
+def test_fuzzy_too_far():
+    mapper = Mapper()
+    mapping = mapper.map_columns(["zzzz"], ["customer"])
+    assert mapping.mapping == {}
+    assert mapping.unmapped_file_cols == ["zzzz"]
+
+
+def test_unit_sensitive_flag():
+    mapper = Mapper()
+    mapping = mapper.map_columns(["amount"], ["amount"])
+    assert mapping.has_unit_uncertainty is True
+
+
+def test_unit_sensitive_indonesian_default():
+    """Bilingual default keyword list (Architect Tension C)."""
+    mapper = Mapper()
+    mapping = mapper.map_columns(["jumlah"], ["jumlah"])
+    assert mapping.has_unit_uncertainty is True
+
+
+def test_coverage_calculation():
+    mapper = Mapper()
+    # "a" maps to "a"; "xyz_unmapped" has no candidate within Levenshtein 2.
+    mapping = mapper.map_columns(["a", "xyz_unmapped"], ["a", "different_col"])
+    assert mapping.coverage == 0.5  # one mapped, one unmapped file_col
+
+
+def test_default_keyword_list_includes_indonesian():
+    assert "jumlah" in DEFAULT_UNIT_SENSITIVE_KEYWORDS
+    assert "amount" in DEFAULT_UNIT_SENSITIVE_KEYWORDS

--- a/tests/heartbeat/classifier/test_router.py
+++ b/tests/heartbeat/classifier/test_router.py
@@ -1,0 +1,144 @@
+"""Router tests — high-confidence, low-confidence, disabled, fallback."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from seeknal.heartbeat.classifier.catalog import Catalog, CatalogEntry
+from seeknal.heartbeat.classifier.fingerprint import compute_fingerprint
+from seeknal.heartbeat.classifier.llm_classifier import LLMProposal, NullLLMClassifier
+from seeknal.heartbeat.classifier.mapper import Mapper
+from seeknal.heartbeat.classifier.models import Fingerprint
+from seeknal.heartbeat.classifier.router import (
+    ClassificationRouter,
+    ClassifierConfig,
+)
+
+
+def _csv(tmp_path: Path, name: str, body: str) -> Path:
+    f = tmp_path / name
+    f.write_text(body)
+    return f
+
+
+def test_disabled_falls_back_to_filename(tmp_path: Path):
+    config = ClassifierConfig(enabled=False)
+    router = ClassificationRouter(
+        config=config, catalog=Catalog(), llm=NullLLMClassifier()
+    )
+    decision = router.classify(_csv(tmp_path, "sales.csv", "a\n1\n"))
+    assert decision.outcome == "default_fallback"
+    assert decision.target_table == "ingested.sales"
+
+
+def test_high_confidence_auto_route(tmp_path: Path):
+    catalog = Catalog()
+    catalog.upsert(
+        CatalogEntry(
+            source_table="bronze.sales",
+            fingerprint=Fingerprint(
+                column_names=["order_id", "customer_id"],
+                column_types=["string", "string"],
+                value_regexes=["uuid", "uuid"],
+            ),
+            canonical_columns={
+                "order_id": {"aliases": []},
+                "customer_id": {"aliases": []},
+            },
+            write_mode="append",
+            business_key=["order_id"],
+        )
+    )
+    src = _csv(
+        tmp_path,
+        "sales.csv",
+        "order_id,customer_id\nA,B\nC,D\n",
+    )
+    config = ClassifierConfig(enabled=True, confidence_threshold=0.5)
+    router = ClassificationRouter(
+        config=config, catalog=catalog, llm=NullLLMClassifier()
+    )
+    decision = router.classify(src)
+    assert decision.outcome == "routed"
+    assert decision.target_table == "bronze.sales"
+    assert decision.source == "fingerprint"
+    assert decision.business_key == ["order_id"]
+
+
+def test_low_confidence_quarantine(tmp_path: Path):
+    catalog = Catalog()  # empty
+    src = _csv(tmp_path, "novel.csv", "a,b\n1,2\n")
+
+    class FakeLLM:
+        def classify(self, fp, catalog_summary, file_sample_preview):
+            return LLMProposal(
+                target_table="bronze.maybe",
+                confidence=0.5,
+                column_mapping={"a": "x"},
+                concerns=["weak match"],
+                call_id="msg-1",
+            )
+
+    config = ClassifierConfig(enabled=True, confidence_threshold=0.85)
+    router = ClassificationRouter(config=config, catalog=catalog, llm=FakeLLM())
+    decision = router.classify(src)
+    assert decision.outcome == "quarantined"
+    assert "below_threshold" in (decision.reason or "")
+    assert decision.llm_call_id == "msg-1"
+
+
+def test_unit_sensitive_quarantine(tmp_path: Path):
+    catalog = Catalog()
+    src = _csv(tmp_path, "rev.csv", "amount\n1.0\n")
+
+    class FakeLLM:
+        def classify(self, fp, catalog_summary, file_sample_preview):
+            return LLMProposal(
+                target_table="bronze.revenue",
+                confidence=0.95,
+                column_mapping={"amount": "amount"},
+                call_id="msg-2",
+            )
+
+    config = ClassifierConfig(enabled=True)
+    router = ClassificationRouter(config=config, catalog=catalog, llm=FakeLLM())
+    decision = router.classify(src)
+    assert decision.outcome == "quarantined"
+    assert "unit_sensitive_columns" in (decision.reason or "")
+
+
+def test_llm_outage_falls_back(tmp_path: Path):
+    catalog = Catalog()
+    src = _csv(tmp_path, "x.csv", "a\n1\n")
+
+    class BoomLLM:
+        def classify(self, *args, **kwargs):
+            raise RuntimeError("anthropic offline")
+
+    config = ClassifierConfig(enabled=True)
+    router = ClassificationRouter(config=config, catalog=catalog, llm=BoomLLM())
+    decision = router.classify(src)
+    assert decision.outcome == "default_fallback"
+
+
+def test_llm_success_routes(tmp_path: Path):
+    catalog = Catalog()
+    src = _csv(tmp_path, "x.csv", "a,b\n1,2\n")
+
+    class GoodLLM:
+        def classify(self, fp, catalog_summary, file_sample_preview):
+            return LLMProposal(
+                target_table="bronze.ok",
+                confidence=0.95,
+                column_mapping={"a": "a", "b": "b"},
+                call_id="msg-3",
+            )
+
+    config = ClassifierConfig(enabled=True)
+    router = ClassificationRouter(config=config, catalog=catalog, llm=GoodLLM())
+    decision = router.classify(src)
+    assert decision.outcome == "routed"
+    assert decision.source == "llm"
+    assert decision.target_table == "bronze.ok"

--- a/tests/heartbeat/conftest.py
+++ b/tests/heartbeat/conftest.py
@@ -2,12 +2,33 @@
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
+from typing import Iterator
 from unittest.mock import MagicMock
 
 import pytest
 
 from seeknal.heartbeat.config import HeartbeatConfig
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def tmp_path(tmp_path: Path) -> Iterator[Path]:
+    """Repo-internal replacement for the builtin ``tmp_path``.
+
+    Heartbeat config/inbox/catalog APIs validate paths with ``is_insecure_path``,
+    which rejects anything under ``/tmp`` — exactly where the builtin ``tmp_path``
+    lives on Linux CI. A unique directory under ``<repo>/.seeknal/test-tmp`` keeps
+    per-test isolation while passing the security check.
+    """
+
+    secure = _REPO_ROOT / ".seeknal" / "test-tmp" / tmp_path.name
+    shutil.rmtree(secure, ignore_errors=True)
+    secure.mkdir(parents=True, exist_ok=True)
+    yield secure
+    shutil.rmtree(secure, ignore_errors=True)
 
 
 @pytest.fixture

--- a/tests/heartbeat/conftest.py
+++ b/tests/heartbeat/conftest.py
@@ -1,0 +1,50 @@
+"""Shared fixtures for heartbeat tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from seeknal.heartbeat.config import HeartbeatConfig
+
+
+@pytest.fixture
+def temp_project(tmp_path: Path) -> Path:
+    """A minimal project directory with HEARTBEAT.md."""
+    (tmp_path / "HEARTBEAT.md").write_text(
+        """```yaml
+interval: 0s
+enabled: true
+inbox_folders:
+  - inbox
+```
+"""
+    )
+    (tmp_path / "inbox").mkdir(exist_ok=True)
+    return tmp_path
+
+
+@pytest.fixture
+def disabled_project(tmp_path: Path) -> Path:
+    (tmp_path / "HEARTBEAT.md").write_text(
+        """```yaml
+interval: 30s
+enabled: false
+```
+"""
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def config(temp_project: Path) -> HeartbeatConfig:
+    return HeartbeatConfig.load(temp_project)
+
+
+@pytest.fixture
+def stub_profile_loader() -> MagicMock:
+    loader = MagicMock()
+    loader.load_source_defaults.return_value = {}
+    return loader

--- a/tests/heartbeat/test_cli.py
+++ b/tests/heartbeat/test_cli.py
@@ -1,0 +1,145 @@
+"""Tests for the `seeknal heartbeat` CLI sub-app."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from seeknal.cli.heartbeat import app
+from seeknal.heartbeat.recorder import DagResult, HeartbeatRun, RunRecorder
+from seeknal.heartbeat.runner import HeartbeatRunner
+
+
+runner = CliRunner()
+
+
+def _no_dag():
+    return patch.multiple(
+        HeartbeatRunner,
+        _run_dag=lambda self, errors: DagResult(),
+        _run_exposures=lambda self, errors: [],
+    )
+
+
+def _write_heartbeat_md(project: Path, body: str) -> None:
+    (project / "HEARTBEAT.md").write_text(body)
+
+
+def test_tick_command_runs(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write_heartbeat_md(
+        tmp_path,
+        """```yaml
+interval: 0s
+enabled: true
+```
+""",
+    )
+    (tmp_path / "inbox").mkdir()
+    with _no_dag():
+        result = runner.invoke(app, ["tick"])
+    assert result.exit_code == 0, result.output
+    assert "status=" in result.output
+
+
+def test_tick_ingests_csv(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write_heartbeat_md(
+        tmp_path,
+        """```yaml
+interval: 0s
+```
+""",
+    )
+    (tmp_path / "inbox").mkdir()
+    (tmp_path / "inbox" / "sales.csv").write_text("a,b\n1,2\n")
+    with _no_dag():
+        result = runner.invoke(app, ["tick"])
+    assert result.exit_code == 0
+    assert "ingested=1" in result.output
+    assert (tmp_path / "target/ingested/sales/data.parquet").exists()
+
+
+def test_start_with_interval_zero_exits_clean(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write_heartbeat_md(
+        tmp_path,
+        """```yaml
+interval: 0s
+```
+""",
+    )
+    result = runner.invoke(app, ["start"])
+    assert result.exit_code == 0
+    assert "disabled" in result.output.lower() or "exit" in result.output.lower() or "tick" in result.output.lower()
+
+
+def test_start_with_enabled_false_exits_clean(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write_heartbeat_md(
+        tmp_path,
+        """```yaml
+interval: 30s
+enabled: false
+```
+""",
+    )
+    result = runner.invoke(app, ["start"])
+    assert result.exit_code == 0
+
+
+def test_status_command_empty(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+    assert "No heartbeat runs" in result.output
+
+
+def test_status_command_with_runs(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    recorder = RunRecorder(tmp_path / "target/heartbeat")
+    for i in range(3):
+        run = HeartbeatRun(
+            run_id=f"run-{i}",
+            started_at="2026-05-15T10:00:00Z",
+            finished_at="2026-05-15T10:00:01Z",
+            duration_ms=10,
+            status="ok",
+        )
+        recorder.append(run)
+    result = runner.invoke(app, ["status", "--limit", "2"])
+    assert result.exit_code == 0
+    assert "run-2" in result.output
+    assert "run-1" in result.output
+    assert "run-0" not in result.output
+
+
+def test_review_command_no_run(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["review", "nope"])
+    assert result.exit_code != 0
+    assert "No quarantine entries" in result.output
+
+
+def test_review_command_empty_dir(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    qdir = tmp_path / "target/heartbeat/quarantine/needs_review/abc"
+    qdir.mkdir(parents=True)
+    result = runner.invoke(app, ["review", "abc"])
+    assert result.exit_code == 0
+    assert "No pending review" in result.output
+
+
+def test_main_app_registers_heartbeat(tmp_path: Path, monkeypatch):
+    """Smoke: top-level seeknal app should know about `heartbeat`."""
+    from seeknal.cli.main import app as main_app
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(main_app, ["heartbeat", "--help"])
+    assert result.exit_code == 0
+    assert "tick" in result.output
+    assert "start" in result.output
+    assert "status" in result.output

--- a/tests/heartbeat/test_concurrency.py
+++ b/tests/heartbeat/test_concurrency.py
@@ -1,0 +1,68 @@
+"""Concurrency tests — overlap detection across asyncio + cross-process flock."""
+
+from __future__ import annotations
+
+import asyncio
+import fcntl
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from seeknal.heartbeat.config import HeartbeatConfig
+from seeknal.heartbeat.recorder import DagResult
+from seeknal.heartbeat.runner import HeartbeatRunner
+
+
+def _no_dag():
+    return patch.multiple(
+        HeartbeatRunner,
+        _run_dag=lambda self, errors: DagResult(),
+        _run_exposures=lambda self, errors: [],
+    )
+
+
+@pytest.mark.asyncio
+async def test_asyncio_lock_serializes_concurrent_ticks(
+    config: HeartbeatConfig, temp_project: Path
+):
+    runner = HeartbeatRunner(config, temp_project)
+
+    async def hold_lock(seconds: float):
+        await runner._asyncio_lock.acquire()
+        try:
+            await asyncio.sleep(seconds)
+        finally:
+            runner._asyncio_lock.release()
+
+    with _no_dag():
+        holder = asyncio.create_task(hold_lock(0.15))
+        await asyncio.sleep(0.02)
+        run = await runner.tick_once(reason="manual")
+        await holder
+
+    assert run.status == "skipped"
+    assert run.reason == "tick-in-flight"
+
+
+@pytest.mark.asyncio
+async def test_fcntl_lock_blocks_external_tick(
+    config: HeartbeatConfig, temp_project: Path
+):
+    runner = HeartbeatRunner(config, temp_project)
+    target = temp_project / "target" / "heartbeat"
+    target.mkdir(parents=True, exist_ok=True)
+    lock_path = target / ".lock"
+    holder = open(lock_path, "w")
+    try:
+        fcntl.flock(holder.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        with _no_dag():
+            run = await runner.tick_once(reason="manual")
+        assert run.status == "skipped"
+        assert run.reason == "tick-in-flight"
+    finally:
+        try:
+            fcntl.flock(holder.fileno(), fcntl.LOCK_UN)
+        except Exception:
+            pass
+        holder.close()

--- a/tests/heartbeat/test_config.py
+++ b/tests/heartbeat/test_config.py
@@ -1,0 +1,171 @@
+"""Tests for HeartbeatConfig parsing + fallback resolution."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+from seeknal.heartbeat.config import (
+    DEFAULT_INTERVAL_SECONDS,
+    HeartbeatConfig,
+    _parse_interval,
+    _parse_heartbeat_body,
+)
+
+
+def test_parse_interval_seconds():
+    assert _parse_interval("30s") == 30
+    assert _parse_interval("2m") == 120
+    assert _parse_interval("1h") == 3600
+    assert _parse_interval("0s") == 0
+    assert _parse_interval(45) == 45
+    assert _parse_interval("90") == 90
+
+
+def test_parse_interval_invalid():
+    with pytest.raises(ValueError):
+        _parse_interval(-1)
+    with pytest.raises(ValueError):
+        _parse_interval("nope")
+    with pytest.raises(ValueError):
+        _parse_interval(True)
+
+
+def test_parse_body_pure_yaml():
+    body = "interval: 30s\nenabled: true"
+    assert _parse_heartbeat_body(body) == {"interval": "30s", "enabled": True}
+
+
+def test_parse_body_fenced_yaml():
+    body = """# Heartbeat config
+Documentation goes here.
+
+```yaml
+interval: 60s
+inbox_folders:
+  - inbox
+```
+
+More comments below.
+"""
+    parsed = _parse_heartbeat_body(body)
+    assert parsed["interval"] == "60s"
+    assert parsed["inbox_folders"] == ["inbox"]
+
+
+def test_parse_body_empty():
+    assert _parse_heartbeat_body("") == {}
+    assert _parse_heartbeat_body("   \n  ") == {}
+
+
+def test_parse_body_invalid_yaml():
+    body = "interval: [unclosed"
+    with pytest.raises(yaml.YAMLError):
+        _parse_heartbeat_body(body)
+
+
+def test_parse_body_non_mapping():
+    body = "- just\n- a\n- list"
+    with pytest.raises(ValueError, match="must parse to a mapping"):
+        _parse_heartbeat_body(body)
+
+
+def test_load_missing_file_uses_defaults(tmp_path: Path, caplog):
+    caplog.set_level(logging.WARNING, logger="seeknal.heartbeat.config")
+    config = HeartbeatConfig.load(tmp_path)
+    assert config.interval_seconds == DEFAULT_INTERVAL_SECONDS
+    assert config.enabled is True
+    assert config.ingested_target == "parquet"
+    assert config.project_name == tmp_path.name
+    assert any("not found" in rec.message for rec in caplog.records)
+
+
+def test_load_explicit_values(tmp_path: Path):
+    (tmp_path / "HEARTBEAT.md").write_text(
+        """```yaml
+interval: 30s
+enabled: true
+inbox_folders:
+  - inbox
+  - drop_zone
+ingested_target: parquet
+quarantine_dir: target/heartbeat/quarantine
+```
+"""
+    )
+    config = HeartbeatConfig.load(tmp_path)
+    assert config.interval_seconds == 30
+    assert [p.name for p in config.inbox_folders] == ["inbox", "drop_zone"]
+    assert config.ingested_target == "parquet"
+
+
+def test_load_interval_zero_disables(tmp_path: Path):
+    (tmp_path / "HEARTBEAT.md").write_text("interval: 0s\n")
+    config = HeartbeatConfig.load(tmp_path)
+    assert config.interval_seconds == 0
+
+
+def test_load_insecure_inbox_rejected(tmp_path: Path):
+    (tmp_path / "HEARTBEAT.md").write_text(
+        "inbox_folders:\n  - /tmp/bad_inbox\n"
+    )
+    with pytest.raises(ValueError, match="Insecure inbox folder"):
+        HeartbeatConfig.load(tmp_path)
+
+
+def test_load_unknown_target_raises(tmp_path: Path):
+    (tmp_path / "HEARTBEAT.md").write_text("ingested_target: cassandra\n")
+    with pytest.raises(ValueError, match="Unknown ingested_target"):
+        HeartbeatConfig.load(tmp_path)
+
+
+def test_load_yaml_parse_error(tmp_path: Path):
+    (tmp_path / "HEARTBEAT.md").write_text("interval: [unclosed\n")
+    with pytest.raises(yaml.YAMLError, match="HEARTBEAT.md parse error"):
+        HeartbeatConfig.load(tmp_path)
+
+
+def test_profile_fallback_for_ingested_target(tmp_path: Path):
+    (tmp_path / "HEARTBEAT.md").write_text("interval: 30s\n")
+    loader = MagicMock()
+    loader.load_source_defaults.return_value = {"target": "iceberg"}
+    config = HeartbeatConfig.load(tmp_path, profile_loader=loader)
+    assert config.ingested_target == "iceberg"
+    loader.load_source_defaults.assert_called_once_with("ingested")
+
+
+def test_profile_fallback_unknown_target_raises(tmp_path: Path):
+    (tmp_path / "HEARTBEAT.md").write_text("")
+    loader = MagicMock()
+    loader.load_source_defaults.return_value = {"target": "redis"}
+    with pytest.raises(ValueError, match="Unknown ingested_target"):
+        HeartbeatConfig.load(tmp_path, profile_loader=loader)
+
+
+def test_project_name_explicit(tmp_path: Path):
+    (tmp_path / "HEARTBEAT.md").write_text("project_name: my_demo\n")
+    config = HeartbeatConfig.load(tmp_path)
+    assert config.project_name == "my_demo"
+
+
+def test_project_name_from_seeknal_project_yml(tmp_path: Path):
+    (tmp_path / "seeknal_project.yml").write_text("name: from_yml\n")
+    (tmp_path / "HEARTBEAT.md").write_text("")
+    config = HeartbeatConfig.load(tmp_path)
+    assert config.project_name == "from_yml"
+
+
+def test_project_name_directory_fallback(tmp_path: Path):
+    (tmp_path / "HEARTBEAT.md").write_text("")
+    config = HeartbeatConfig.load(tmp_path)
+    assert config.project_name == tmp_path.name
+
+
+def test_inbox_folders_default_when_missing(tmp_path: Path):
+    (tmp_path / "HEARTBEAT.md").write_text("interval: 30s\n")
+    config = HeartbeatConfig.load(tmp_path)
+    assert config.inbox_folders == [Path("inbox")]

--- a/tests/heartbeat/test_e2e.py
+++ b/tests/heartbeat/test_e2e.py
@@ -1,0 +1,111 @@
+"""End-to-end heartbeat tests (AC11) — full happy-path round-trip."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from seeknal.heartbeat.config import HeartbeatConfig
+from seeknal.heartbeat.recorder import DagResult, ExposureResult
+from seeknal.heartbeat.runner import HeartbeatRunner
+
+
+@pytest.mark.asyncio
+async def test_full_happy_path(tmp_path: Path):
+    """Drop file → tick → parquet + DAG + exposure + runs.jsonl line."""
+    (tmp_path / "HEARTBEAT.md").write_text(
+        """```yaml
+interval: 0s
+enabled: true
+inbox_folders:
+  - inbox
+```
+"""
+    )
+    (tmp_path / "inbox").mkdir()
+    (tmp_path / "inbox" / "orders.csv").write_text(
+        "order_id,amount\nA001,99.50\nA002,42.00\n"
+    )
+
+    cfg = HeartbeatConfig.load(tmp_path)
+    runner = HeartbeatRunner(cfg, tmp_path)
+
+    with patch.object(
+        HeartbeatRunner,
+        "_run_dag",
+        lambda self, errors: DagResult(
+            nodes_attempted=1, nodes_skipped=0, nodes_failed=0
+        ),
+    ), patch.object(
+        HeartbeatRunner,
+        "_run_exposures",
+        lambda self, errors: [
+            ExposureResult(node="exp1", target="file://out.csv", status="ok")
+        ],
+    ):
+        run = await runner.tick_once(reason="manual")
+
+    assert run.status == "ok"
+    assert len(run.ingested) == 1
+    assert run.ingested[0].status == "ok"
+    assert run.ingested[0].table == "orders"
+    assert run.dag.nodes_attempted == 1
+    assert run.exposure and run.exposure[0].status == "ok"
+
+    parquet = tmp_path / "target/ingested/orders/data.parquet"
+    assert parquet.exists()
+
+    jsonl = tmp_path / "target/heartbeat/runs.jsonl"
+    assert jsonl.exists()
+    line = jsonl.read_text().strip().split("\n")[-1]
+    payload = json.loads(line)
+    assert payload["run_id"] == run.run_id
+    # AC4 schema completeness
+    for key in (
+        "run_id",
+        "started_at",
+        "finished_at",
+        "duration_ms",
+        "status",
+        "ingested",
+        "dag",
+        "exposure",
+        "errors",
+    ):
+        assert key in payload
+
+
+@pytest.mark.asyncio
+async def test_repeat_tick_skips_dag_and_exposure(tmp_path: Path):
+    """AC5: no new files → idempotent tick (no DAG/exposure on interval reason)."""
+    (tmp_path / "HEARTBEAT.md").write_text(
+        "interval: 0s\ninbox_folders:\n  - inbox\n"
+    )
+    (tmp_path / "inbox").mkdir()
+    (tmp_path / "inbox" / "first.csv").write_text("a\n1\n")
+
+    cfg = HeartbeatConfig.load(tmp_path)
+    runner = HeartbeatRunner(cfg, tmp_path)
+
+    dag_call_count = {"n": 0}
+    exposure_call_count = {"n": 0}
+
+    def stub_dag(self, errors):
+        dag_call_count["n"] += 1
+        return DagResult(nodes_attempted=1)
+
+    def stub_exposure(self, errors):
+        exposure_call_count["n"] += 1
+        return [ExposureResult(node="e", target="t", status="ok")]
+
+    with patch.object(HeartbeatRunner, "_run_dag", stub_dag), patch.object(
+        HeartbeatRunner, "_run_exposures", stub_exposure
+    ):
+        await runner.tick_once(reason="interval")
+        await runner.tick_once(reason="interval")
+
+    assert dag_call_count["n"] == 1
+    assert exposure_call_count["n"] == 1

--- a/tests/heartbeat/test_failure_modes.py
+++ b/tests/heartbeat/test_failure_modes.py
@@ -1,0 +1,73 @@
+"""Failure-mode tests for DAG/Exposure (AC8, AC9)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from seeknal.heartbeat.config import HeartbeatConfig
+from seeknal.heartbeat.recorder import DagResult, ExposureResult
+from seeknal.heartbeat.runner import HeartbeatRunner
+
+
+@pytest.mark.asyncio
+async def test_dag_failure_does_not_exit_daemon(
+    config: HeartbeatConfig, temp_project: Path
+):
+    (temp_project / "inbox" / "x.csv").write_text("a\n1\n")
+    runner = HeartbeatRunner(config, temp_project)
+
+    def crash_dag(self, errors):
+        errors.append("DAG simulated crash")
+        return DagResult(nodes_failed=1)
+
+    with patch.object(HeartbeatRunner, "_run_dag", crash_dag), patch.object(
+        HeartbeatRunner, "_run_exposures", lambda self, errors: []
+    ):
+        run = await runner.tick_once(reason="manual")
+    assert run.dag.nodes_failed == 1
+    assert any("DAG simulated crash" in e for e in run.errors)
+    assert run.status in {"partial", "failed"}
+
+
+@pytest.mark.asyncio
+async def test_exposure_failure_recorded(
+    config: HeartbeatConfig, temp_project: Path
+):
+    (temp_project / "inbox" / "y.csv").write_text("a\n1\n")
+    runner = HeartbeatRunner(config, temp_project)
+
+    def fail_expo(self, errors):
+        return [ExposureResult(node="e1", target="t", status="failed", error="x")]
+
+    with patch.object(HeartbeatRunner, "_run_dag", lambda self, errors: DagResult()), patch.object(
+        HeartbeatRunner, "_run_exposures", fail_expo
+    ):
+        run = await runner.tick_once(reason="manual")
+    assert run.exposure[0].status == "failed"
+    assert run.status in {"partial", "failed"}
+
+
+@pytest.mark.asyncio
+async def test_inbox_state_save_failure_recorded(
+    config: HeartbeatConfig, temp_project: Path, monkeypatch
+):
+    (temp_project / "inbox" / "z.csv").write_text("a\n1\n")
+    runner = HeartbeatRunner(config, temp_project)
+
+    def boom(self):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(
+        type(runner._inbox_state), "save", boom
+    )
+
+    with patch.object(
+        HeartbeatRunner, "_run_dag", lambda self, errors: DagResult()
+    ), patch.object(
+        HeartbeatRunner, "_run_exposures", lambda self, errors: []
+    ):
+        run = await runner.tick_once(reason="manual")
+    assert any("inbox_state.save failed" in e for e in run.errors)

--- a/tests/heartbeat/test_inbox_state.py
+++ b/tests/heartbeat/test_inbox_state.py
@@ -1,0 +1,132 @@
+"""Tests for InboxState change detection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from seeknal.heartbeat.inbox_state import (
+    InboxFileRecord,
+    InboxState,
+    _compute_sha256,
+)
+
+
+def _make_inbox(tmp_path: Path, name: str = "inbox") -> Path:
+    folder = tmp_path / name
+    folder.mkdir()
+    return folder
+
+
+def test_insecure_state_path_rejected():
+    with pytest.raises(ValueError, match="Insecure InboxState path"):
+        InboxState(Path("/tmp/inbox_state.json"))
+
+
+def test_scan_returns_new_file(tmp_path: Path):
+    inbox = _make_inbox(tmp_path)
+    (inbox / "sales.csv").write_text("a,b\n1,2\n")
+    state = InboxState(tmp_path / "target/heartbeat/inbox_state.json")
+    changed = state.scan([inbox])
+    assert len(changed) == 1
+    assert changed[0].name == "sales.csv"
+
+
+def test_scan_skips_unchanged(tmp_path: Path):
+    inbox = _make_inbox(tmp_path)
+    f = inbox / "sales.csv"
+    f.write_text("a,b\n1,2\n")
+    state = InboxState(tmp_path / "target/heartbeat/inbox_state.json")
+    changed = state.scan([inbox])
+    state.mark_ingested(changed[0], target_table="ingested.sales")
+    state.save()
+
+    state2 = InboxState.load(state.state_path)
+    assert state2.scan([inbox]) == []
+
+
+def test_scan_detects_modified_file(tmp_path: Path):
+    inbox = _make_inbox(tmp_path)
+    f = inbox / "sales.csv"
+    f.write_text("a,b\n1,2\n")
+    state = InboxState(tmp_path / "target/heartbeat/inbox_state.json")
+    changed = state.scan([inbox])
+    state.mark_ingested(changed[0], target_table="ingested.sales")
+    state.save()
+
+    f.write_text("a,b\n1,2\n3,4\n")
+    state2 = InboxState.load(state.state_path)
+    new = state2.scan([inbox])
+    assert len(new) == 1
+
+
+def test_scan_ignores_hidden_files(tmp_path: Path):
+    inbox = _make_inbox(tmp_path)
+    (inbox / ".DS_Store").write_text("x")
+    state = InboxState(tmp_path / "target/heartbeat/inbox_state.json")
+    assert state.scan([inbox]) == []
+
+
+def test_scan_missing_folder_no_error(tmp_path: Path):
+    state = InboxState(tmp_path / "target/heartbeat/inbox_state.json")
+    assert state.scan([tmp_path / "nope"]) == []
+
+
+def test_atomic_save_round_trip(tmp_path: Path):
+    inbox = _make_inbox(tmp_path)
+    (inbox / "a.csv").write_text("a\n1\n")
+    state = InboxState(tmp_path / "target/heartbeat/inbox_state.json")
+    paths = state.scan([inbox])
+    state.mark_ingested(paths[0], target_table="ingested.a")
+    state.save()
+
+    raw = json.loads(state.state_path.read_text())
+    assert len(raw) == 1
+    first = next(iter(raw.values()))
+    assert first["target_table"] == "ingested.a"
+    assert first["last_status"] == "ok"
+
+
+def test_record_invalid_status_rejected():
+    with pytest.raises(ValueError, match="Invalid last_status"):
+        InboxFileRecord(
+            path="/x",
+            checksum_sha256="0",
+            size_bytes=0,
+            mtime=0.0,
+            ingested_at="2026-05-15T00:00:00Z",
+            target_table="t",
+            last_status="weird",
+        )
+
+
+def test_mark_quarantined_persists(tmp_path: Path):
+    inbox = _make_inbox(tmp_path)
+    (inbox / "bad.csv").write_text("malformed")
+    state = InboxState(tmp_path / "target/heartbeat/inbox_state.json")
+    paths = state.scan([inbox])
+    state.mark_quarantined(paths[0], reason="bad")
+    state.save()
+    state2 = InboxState.load(state.state_path)
+    rec = state2.get(paths[0])
+    assert rec is not None
+    assert rec.last_status == "quarantined"
+
+
+def test_load_corrupt_file_starts_empty(tmp_path: Path):
+    state_path = tmp_path / "target/heartbeat/inbox_state.json"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text("{not json")
+    state = InboxState.load(state_path)
+    assert state.all_records() == []
+
+
+def test_compute_sha256_deterministic(tmp_path: Path):
+    f = tmp_path / "data.bin"
+    f.write_bytes(b"hello world")
+    h1, s1 = _compute_sha256(f)
+    h2, s2 = _compute_sha256(f)
+    assert h1 == h2
+    assert s1 == s2 == 11

--- a/tests/heartbeat/test_ingest.py
+++ b/tests/heartbeat/test_ingest.py
@@ -1,0 +1,129 @@
+"""Tests for the heartbeat IngestWriter (parquet backend)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from seeknal.heartbeat.ingest import (
+    IngestWriter,
+    ParquetWriter,
+    derive_table_name,
+    quarantine_file,
+)
+
+
+def test_derive_table_name_basic():
+    assert derive_table_name(Path("sales.csv")) == "sales"
+    assert derive_table_name(Path("Orders-2024.csv")) == "orders_2024"
+
+
+def test_derive_table_name_rejects_reserved():
+    with pytest.raises(ValueError, match="reserved"):
+        derive_table_name(Path("select.csv"))
+
+
+def test_derive_table_name_rejects_leading_digit():
+    with pytest.raises(ValueError):
+        derive_table_name(Path("9items.csv"))
+
+
+def test_parquet_writer_csv_to_parquet(tmp_path: Path):
+    src = tmp_path / "sales.csv"
+    src.write_text("a,b\n1,2\n3,4\n")
+    writer = ParquetWriter(tmp_path)
+    res = writer.write(source_path=src, table_name="sales", checksum="deadbeef")
+    assert res.status == "ok"
+    assert res.rows == 2
+    out = tmp_path / "target/ingested/sales/data.parquet"
+    meta = tmp_path / "target/ingested/sales/_meta.json"
+    assert out.exists()
+    assert meta.exists()
+    payload = json.loads(meta.read_text())
+    assert payload["rows"] == 2
+    assert payload["checksum_sha256"] == "deadbeef"
+    assert payload["table"] == "sales"
+
+
+def test_parquet_writer_jsonl_to_parquet(tmp_path: Path):
+    src = tmp_path / "events.jsonl"
+    src.write_text('{"a":1,"b":2}\n{"a":3,"b":4}\n')
+    writer = ParquetWriter(tmp_path)
+    res = writer.write(source_path=src, table_name="events")
+    assert res.status == "ok"
+    assert res.rows == 2
+
+
+def test_parquet_writer_malformed_csv_quarantined(tmp_path: Path):
+    src = tmp_path / "bad.csv"
+    # Mismatched columns trigger DuckDB read_csv_auto failure with strict=true default.
+    src.write_text("\x00\xff\xfe garbage data")
+    writer = ParquetWriter(tmp_path)
+    res = writer.write(source_path=src, table_name="bad")
+    # Either DuckDB swallows it (status=ok) or it errors out.
+    # The contract: never raise; produce an IngestResult.
+    assert res.status in {"ok", "quarantined"}
+
+
+def test_parquet_writer_unsupported_suffix(tmp_path: Path):
+    src = tmp_path / "x.bin"
+    src.write_bytes(b"\x00\x01\x02")
+    writer = ParquetWriter(tmp_path)
+    res = writer.write(source_path=src, table_name="x")
+    assert res.status == "quarantined"
+    assert "Unsupported" in (res.error or "")
+
+
+def test_ingest_writer_dispatch_parquet(tmp_path: Path):
+    src = tmp_path / "sales.csv"
+    src.write_text("x,y\n1,2\n")
+    writer = IngestWriter(tmp_path, target="parquet")
+    res = writer.write(src)
+    assert res.status == "ok"
+    assert res.table == "sales"
+
+
+def test_ingest_writer_unknown_target():
+    with pytest.raises(ValueError, match="Unknown target"):
+        IngestWriter(Path("."), target="cassandra")
+
+
+def test_ingest_writer_iceberg_requires_config():
+    with pytest.raises(ValueError, match="catalog_uri"):
+        IngestWriter(Path("."), target="iceberg")
+
+
+def test_ingest_writer_invalid_filename(tmp_path: Path):
+    src = tmp_path / "select.csv"
+    src.write_text("a\n1\n")
+    writer = IngestWriter(tmp_path, target="parquet")
+    res = writer.write(src)
+    assert res.status == "quarantined"
+    assert "reserved" in (res.error or "")
+
+
+def test_quarantine_file_moves(tmp_path: Path):
+    inbox = tmp_path / "inbox"
+    inbox.mkdir()
+    bad = inbox / "bad.csv"
+    bad.write_text("x")
+    quarantine = tmp_path / "target/heartbeat/quarantine"
+    dest = quarantine_file(bad, quarantine)
+    assert dest.exists()
+    assert not bad.exists()
+
+
+def test_quarantine_file_collision_suffix(tmp_path: Path):
+    inbox = tmp_path / "inbox"
+    inbox.mkdir()
+    bad = inbox / "bad.csv"
+    bad.write_text("x")
+    quarantine = tmp_path / "target/heartbeat/quarantine"
+    first = quarantine_file(bad, quarantine)
+    bad.write_text("y")
+    second = quarantine_file(bad, quarantine)
+    assert first != second
+    assert first.exists()
+    assert second.exists()

--- a/tests/heartbeat/test_init_scaffolding.py
+++ b/tests/heartbeat/test_init_scaffolding.py
@@ -1,0 +1,54 @@
+"""Test that `seeknal init` scaffolds a HEARTBEAT.md."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+
+def test_init_creates_heartbeat_md(tmp_path: Path, monkeypatch):
+    """`seeknal init --name demo` writes a HEARTBEAT.md at the project root."""
+    from seeknal.cli.main import app
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SEEKNAL_BASE_CONFIG_PATH", str(tmp_path / ".seeknal"))
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["init", "--name", "demo", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+
+    heartbeat_path = tmp_path / "HEARTBEAT.md"
+    assert heartbeat_path.exists()
+    text = heartbeat_path.read_text()
+    assert "interval:" in text
+    assert "inbox_folders" in text
+
+
+def test_init_scaffolds_inbox_folder(tmp_path: Path, monkeypatch):
+    from seeknal.cli.main import app
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SEEKNAL_BASE_CONFIG_PATH", str(tmp_path / ".seeknal"))
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["init", "--name", "demo", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "inbox").exists() and (tmp_path / "inbox").is_dir()
+
+
+def test_heartbeat_md_template_parses(tmp_path: Path, monkeypatch):
+    from seeknal.cli.main import app
+    from seeknal.heartbeat.config import HeartbeatConfig
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SEEKNAL_BASE_CONFIG_PATH", str(tmp_path / ".seeknal"))
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["init", "--name", "demo", "--path", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+
+    cfg = HeartbeatConfig.load(tmp_path)
+    assert cfg.interval_seconds == 60
+    assert cfg.enabled is True
+    assert cfg.inbox_folders == [Path("inbox")]

--- a/tests/heartbeat/test_quarantine.py
+++ b/tests/heartbeat/test_quarantine.py
@@ -1,0 +1,64 @@
+"""Quarantine path tests — files that can't be ingested are moved aside."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from seeknal.heartbeat.config import HeartbeatConfig
+from seeknal.heartbeat.recorder import DagResult
+from seeknal.heartbeat.runner import HeartbeatRunner
+
+
+def _no_dag():
+    return patch.multiple(
+        HeartbeatRunner,
+        _run_dag=lambda self, errors: DagResult(),
+        _run_exposures=lambda self, errors: [],
+    )
+
+
+@pytest.mark.asyncio
+async def test_reserved_keyword_file_quarantined(
+    config: HeartbeatConfig, temp_project: Path
+):
+    bad = temp_project / "inbox" / "select.csv"
+    bad.write_text("a\n1\n")
+    runner = HeartbeatRunner(config, temp_project)
+    with _no_dag():
+        run = await runner.tick_once(reason="manual")
+    assert any(r.status == "quarantined" for r in run.ingested)
+    assert not bad.exists()
+    moved = list((temp_project / config.quarantine_dir).iterdir())
+    assert moved, "Quarantined file should exist in quarantine_dir"
+
+
+@pytest.mark.asyncio
+async def test_unsupported_suffix_quarantined(
+    config: HeartbeatConfig, temp_project: Path
+):
+    bad = temp_project / "inbox" / "weird.bin"
+    bad.write_bytes(b"\x00\x01\x02")
+    runner = HeartbeatRunner(config, temp_project)
+    with _no_dag():
+        run = await runner.tick_once(reason="manual")
+    assert any(r.status == "quarantined" for r in run.ingested)
+
+
+@pytest.mark.asyncio
+async def test_daemon_continues_after_quarantine(
+    config: HeartbeatConfig, temp_project: Path
+):
+    """Verifies daemon never exits on data errors (AC7)."""
+    bad = temp_project / "inbox" / "weird.bin"
+    bad.write_bytes(b"\x00")
+    good = temp_project / "inbox" / "sales.csv"
+    good.write_text("a,b\n1,2\n")
+    runner = HeartbeatRunner(config, temp_project)
+    with _no_dag():
+        run = await runner.tick_once(reason="manual")
+    statuses = sorted(r.status for r in run.ingested)
+    assert "ok" in statuses
+    assert "quarantined" in statuses

--- a/tests/heartbeat/test_quarantine_review.py
+++ b/tests/heartbeat/test_quarantine_review.py
@@ -1,0 +1,189 @@
+"""Tests for the quarantine subsystem (Step 14)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from seeknal.cli.heartbeat import app as heartbeat_app
+from seeknal.heartbeat.quarantine.callback_map import CallbackMap, _from_base36
+from seeknal.heartbeat.quarantine.notifier import (
+    build_notice,
+    render_callback,
+)
+from seeknal.heartbeat.quarantine.review import (
+    QuarantineSidecar,
+    apply_review_decision,
+    list_pending_reviews,
+    parse_edit_input,
+)
+
+
+def _make_sidecar(tmp_path: Path, run_id: str = "abc123") -> Path:
+    needs = tmp_path / "target/heartbeat/quarantine/needs_review" / run_id
+    needs.mkdir(parents=True)
+    # Data file
+    data = needs / "novel.csv"
+    data.write_text("a,b\n1,2\n")
+    sidecar_path = needs / "novel.csv.review.yml"
+    sc = QuarantineSidecar(
+        run_id=run_id,
+        file=str(data),
+        target_table="bronze.maybe",
+        confidence=0.55,
+        concerns=["weak match"],
+        column_mapping={"a": "x", "b": "y"},
+        status="pending_review",
+    )
+    sc.save(sidecar_path)
+    return sidecar_path
+
+
+def test_callback_map_token_allocation(tmp_path: Path):
+    cmap = CallbackMap(tmp_path / "_callback_map.json")
+    t1 = cmap.allocate("run-1")
+    t2 = cmap.allocate("run-2")
+    assert t1 != t2
+    assert cmap.lookup(t1) == "run-1"
+    assert cmap.lookup(t2) == "run-2"
+
+
+def test_callback_map_persists_and_resumes(tmp_path: Path):
+    path = tmp_path / "_callback_map.json"
+    a = CallbackMap(path)
+    t1 = a.allocate("r1")
+    b = CallbackMap(path)
+    assert b.lookup(t1) == "r1"
+    # Counter should resume from existing max — no collision.
+    t2 = b.allocate("r2")
+    assert _from_base36(t2) > _from_base36(t1)
+
+
+def test_callback_map_remove(tmp_path: Path):
+    cmap = CallbackMap(tmp_path / "_callback_map.json")
+    t = cmap.allocate("r1")
+    cmap.remove(t)
+    assert cmap.lookup(t) is None
+
+
+def test_callback_payload_fits_in_64_bytes():
+    payload = render_callback("confirm", "zzzz", 99)
+    assert len(payload.encode()) < 64
+
+
+def test_apply_review_confirm(tmp_path: Path):
+    sidecar = _make_sidecar(tmp_path)
+    result = apply_review_decision(sidecar, decision="confirm", resolved_by="bob")
+    assert result["ok"]
+    sc = QuarantineSidecar.load(sidecar)
+    assert sc.status == "confirmed"
+    assert sc.resolved_by == "bob"
+
+
+def test_apply_review_reject_moves_file(tmp_path: Path):
+    sidecar = _make_sidecar(tmp_path)
+    data = sidecar.parent / "novel.csv"
+    assert data.exists()
+    rejected_dir = tmp_path / "target/heartbeat/quarantine/rejected/abc123"
+    result = apply_review_decision(
+        sidecar, decision="reject", rejected_dir=rejected_dir
+    )
+    assert result["ok"]
+    sc = QuarantineSidecar.load(sidecar)
+    assert sc.status == "rejected"
+    assert not data.exists()
+    assert (rejected_dir / "novel.csv").exists()
+
+
+def test_apply_review_edit_mapping(tmp_path: Path):
+    sidecar = _make_sidecar(tmp_path)
+    edit = "target=bronze.confirmed\nmode=upsert\nkey=a\na=order_id\n"
+    result = apply_review_decision(
+        sidecar, decision="edit", edit_text=edit, resolved_by="cli"
+    )
+    assert result["ok"], result
+    sc = QuarantineSidecar.load(sidecar)
+    assert sc.status == "edited"
+    assert sc.target_table == "bronze.confirmed"
+    assert sc.write_mode == "upsert"
+    assert sc.business_key == ["a"]
+    assert sc.column_mapping.get("a") == "order_id"
+
+
+def test_parse_edit_rejects_malformed_line():
+    column, meta, errors = parse_edit_input("not valid line\ntarget=ok\n")
+    assert errors  # at least one error
+    assert meta.get("target_table") == "ok"
+
+
+def test_parse_edit_unknown_mode():
+    column, meta, errors = parse_edit_input("mode=weird")
+    assert any("unknown mode" in e for e in errors)
+
+
+def test_parse_edit_cancel():
+    column, meta, errors = parse_edit_input("cancel\n")
+    assert meta.get("cancelled") is True
+
+
+def test_apply_review_idempotent(tmp_path: Path):
+    sidecar = _make_sidecar(tmp_path)
+    apply_review_decision(sidecar, decision="confirm")
+    result2 = apply_review_decision(sidecar, decision="confirm")
+    assert not result2["ok"]
+    assert "already" in result2["error"]
+
+
+def test_list_pending_reviews(tmp_path: Path):
+    sidecar = _make_sidecar(tmp_path, run_id="abc123")
+    pending = list_pending_reviews(tmp_path)
+    assert sidecar in pending
+    apply_review_decision(sidecar, decision="confirm")
+    pending2 = list_pending_reviews(tmp_path)
+    assert sidecar not in pending2
+
+
+def test_build_notice(tmp_path: Path):
+    sidecar = _make_sidecar(tmp_path)
+    notice = build_notice(
+        sidecar,
+        preview_text="row1,row2",
+        confirm_token="0001",
+        reject_token="0001",
+        edit_token="0001",
+    )
+    assert "needs review" in notice.summary()
+    assert "55%" in notice.summary()  # confidence
+    assert notice.callback_tokens["confirm"] == "0001"
+
+
+def test_cli_review_lists_pending(tmp_path: Path, monkeypatch):
+    sidecar = _make_sidecar(tmp_path, run_id="run1")
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(heartbeat_app, ["review", "run1"])
+    assert result.exit_code == 0
+    assert "Pending review" in result.output
+    assert "novel.csv.review.yml" in result.output
+
+
+def test_cli_review_confirm(tmp_path: Path, monkeypatch):
+    sidecar = _make_sidecar(tmp_path, run_id="run1")
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(heartbeat_app, ["review", "run1", "--confirm"])
+    assert result.exit_code == 0
+    sc = QuarantineSidecar.load(sidecar)
+    assert sc.status == "confirmed"
+
+
+def test_cli_review_edit_invalid_input(tmp_path: Path, monkeypatch):
+    _make_sidecar(tmp_path, run_id="run1")
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        heartbeat_app, ["review", "run1", "--edit", "garbage line here"]
+    )
+    assert result.exit_code != 0

--- a/tests/heartbeat/test_run_recorder.py
+++ b/tests/heartbeat/test_run_recorder.py
@@ -1,0 +1,159 @@
+"""Tests for RunRecorder + HeartbeatRun schema."""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+
+from seeknal.heartbeat.recorder import (
+    DagResult,
+    ExposureResult,
+    HeartbeatRun,
+    IngestResult,
+    RunRecorder,
+    make_run,
+)
+
+
+def _build(status="ok", ingested=None, dag=None, exposure=None, errors=None):
+    return HeartbeatRun(
+        run_id="abc",
+        started_at="2026-05-15T10:00:00Z",
+        finished_at="2026-05-15T10:00:01Z",
+        duration_ms=1000,
+        status=status,
+        ingested=ingested or [],
+        dag=dag or DagResult(),
+        exposure=exposure or [],
+        errors=errors or [],
+    )
+
+
+def test_compute_status_ok_no_data():
+    assert (
+        HeartbeatRun.compute_status([], DagResult(), [], []) == "ok"
+    )
+
+
+def test_compute_status_ok_one_ingest():
+    ingest = [IngestResult(file="a", table="t", rows=10, status="ok")]
+    assert HeartbeatRun.compute_status(ingest, DagResult(), [], []) == "ok"
+
+
+def test_compute_status_partial_on_error():
+    ingest = [IngestResult(file="a", table="t", status="ok")]
+    errs = ["DAG failed"]
+    assert HeartbeatRun.compute_status(ingest, DagResult(), [], errs) == "partial"
+
+
+def test_compute_status_partial_on_quarantine():
+    ingest = [IngestResult(file="a", table="t", status="quarantined")]
+    assert HeartbeatRun.compute_status(ingest, DagResult(), [], []) == "partial"
+
+
+def test_compute_status_failed_when_all_fail():
+    ingest = [IngestResult(file="a", table="t", status="failed")]
+    dag = DagResult(nodes_failed=2)
+    expo = [ExposureResult(node="x", target="t", status="failed")]
+    assert HeartbeatRun.compute_status(ingest, dag, expo, ["e"]) == "failed"
+
+
+def test_recorder_appends_line(tmp_path: Path):
+    rec = RunRecorder(tmp_path / "target/heartbeat")
+    run = _build()
+    rec.append(run)
+    text = rec.jsonl_path.read_text()
+    assert text.count("\n") == 1
+    parsed = json.loads(text.strip())
+    assert parsed["run_id"] == "abc"
+    assert parsed["status"] == "ok"
+    # Schema completeness — AC4
+    for key in (
+        "run_id",
+        "started_at",
+        "finished_at",
+        "duration_ms",
+        "status",
+        "ingested",
+        "dag",
+        "exposure",
+        "errors",
+    ):
+        assert key in parsed
+
+
+def test_recorder_writes_sidecar(tmp_path: Path):
+    rec = RunRecorder(tmp_path / "target/heartbeat")
+    run = _build()
+    rec.append(run)
+    sidecar = rec.sidecar_dir / "abc.json"
+    assert sidecar.exists()
+    parsed = json.loads(sidecar.read_text())
+    assert parsed["run_id"] == "abc"
+
+
+def test_recorder_atomic_append_concurrent(tmp_path: Path):
+    rec = RunRecorder(tmp_path / "target/heartbeat")
+
+    def worker(idx: int):
+        rec.append(_build())
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    lines = rec.jsonl_path.read_text().strip().split("\n")
+    assert len(lines) == 20
+    for ln in lines:
+        parsed = json.loads(ln)  # must each parse cleanly — no torn lines
+        assert parsed["run_id"] == "abc"
+
+
+def test_tail_returns_last_n(tmp_path: Path):
+    rec = RunRecorder(tmp_path / "target/heartbeat")
+    for i in range(5):
+        run = _build()
+        run.run_id = f"run-{i}"
+        rec.append(run)
+    last = rec.tail(limit=3)
+    assert len(last) == 3
+    assert last[-1]["run_id"] == "run-4"
+
+
+def test_tail_empty(tmp_path: Path):
+    rec = RunRecorder(tmp_path / "target/heartbeat")
+    assert rec.tail() == []
+
+
+def test_make_run_resolves_status():
+    run = make_run(
+        run_id="x",
+        started_at="2026-05-15T10:00:00Z",
+        finished_at="2026-05-15T10:00:01Z",
+        duration_ms=500,
+        ingested=[IngestResult(file="a", table="t", status="ok")],
+        dag=DagResult(),
+        exposure=[],
+        errors=[],
+    )
+    assert run.status == "ok"
+
+
+def test_make_run_skipped_status():
+    run = make_run(
+        run_id="x",
+        started_at="t",
+        finished_at="t",
+        duration_ms=0,
+        ingested=[],
+        dag=DagResult(),
+        exposure=[],
+        errors=[],
+        reason="tick-in-flight",
+        status="skipped",
+    )
+    assert run.status == "skipped"
+    assert run.reason == "tick-in-flight"

--- a/tests/heartbeat/test_runner.py
+++ b/tests/heartbeat/test_runner.py
@@ -1,0 +1,152 @@
+"""Tests for HeartbeatRunner."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from seeknal.heartbeat.config import HeartbeatConfig
+from seeknal.heartbeat.recorder import DagResult, ExposureResult
+from seeknal.heartbeat.runner import HeartbeatRunner
+
+
+def _patch_no_project_artifacts():
+    """Patch DAG/exposure subsystems to make the heartbeat work in a bare temp project.
+
+    The temp project has no YAML pipelines, so DAGBuilder().build() would fail.
+    Patches force _run_dag and _run_exposures into no-ops.
+    """
+    return patch.multiple(
+        HeartbeatRunner,
+        _run_dag=lambda self, errors: DagResult(),
+        _run_exposures=lambda self, errors: [],
+    )
+
+
+@pytest.mark.asyncio
+async def test_tick_empty_inbox_records_ok(config: HeartbeatConfig, temp_project: Path):
+    runner = HeartbeatRunner(config, temp_project)
+    with _patch_no_project_artifacts():
+        run = await runner.tick_once(reason="manual")
+    assert run.status in {"ok", "partial"}
+    lines = runner.recorder.jsonl_path.read_text().strip().split("\n")
+    assert len(lines) == 1
+
+
+@pytest.mark.asyncio
+async def test_tick_ingests_new_file(config: HeartbeatConfig, temp_project: Path):
+    (temp_project / "inbox" / "sales.csv").write_text("a,b\n1,2\n3,4\n")
+    runner = HeartbeatRunner(config, temp_project)
+    with _patch_no_project_artifacts():
+        run = await runner.tick_once(reason="manual")
+    assert len(run.ingested) == 1
+    assert run.ingested[0].table == "sales"
+    assert run.ingested[0].status == "ok"
+    assert (temp_project / "target/ingested/sales/data.parquet").exists()
+
+
+@pytest.mark.asyncio
+async def test_tick_idempotent(config: HeartbeatConfig, temp_project: Path):
+    (temp_project / "inbox" / "sales.csv").write_text("a,b\n1,2\n")
+    runner = HeartbeatRunner(config, temp_project)
+    with _patch_no_project_artifacts():
+        await runner.tick_once(reason="interval")
+        run2 = await runner.tick_once(reason="interval")
+    assert run2.ingested == []  # AC5: idempotent re-tick
+    assert run2.reason == "interval"
+
+
+@pytest.mark.asyncio
+async def test_tick_in_flight_records_skipped(config: HeartbeatConfig, temp_project: Path):
+    runner = HeartbeatRunner(config, temp_project)
+
+    async def slow_tick(self, run_id, started_at, t0, reason):
+        await asyncio.sleep(0.2)
+        return await HeartbeatRunner._tick_locked.__wrapped__(self, run_id, started_at, t0, reason) if False else await asyncio.sleep(0)  # noqa
+
+    with _patch_no_project_artifacts():
+        # Hold the lock by starting one tick, then issue a second concurrently.
+        async def runner_with_delay():
+            await runner._asyncio_lock.acquire()
+            await asyncio.sleep(0.1)
+            runner._asyncio_lock.release()
+
+        slow_task = asyncio.create_task(runner_with_delay())
+        await asyncio.sleep(0.01)
+        skipped = await runner.tick_once(reason="manual")
+        await slow_task
+
+    assert skipped.status == "skipped"
+    assert skipped.reason == "tick-in-flight"
+
+
+@pytest.mark.asyncio
+async def test_tick_dag_failure_records_but_continues(
+    config: HeartbeatConfig, temp_project: Path
+):
+    (temp_project / "inbox" / "x.csv").write_text("a\n1\n")
+    runner = HeartbeatRunner(config, temp_project)
+
+    def boom(self, errors):
+        errors.append("simulated DAG crash")
+        return DagResult(nodes_failed=2)
+
+    with patch.object(HeartbeatRunner, "_run_dag", boom), patch.object(
+        HeartbeatRunner, "_run_exposures", lambda self, errors: []
+    ):
+        run = await runner.tick_once(reason="manual")
+    assert run.dag.nodes_failed == 2
+    assert any("simulated DAG crash" in e for e in run.errors)
+    assert run.status in {"partial", "failed"}
+
+
+@pytest.mark.asyncio
+async def test_tick_exposure_failure_recorded(
+    config: HeartbeatConfig, temp_project: Path
+):
+    (temp_project / "inbox" / "y.csv").write_text("a\n1\n")
+    runner = HeartbeatRunner(config, temp_project)
+
+    def fail_expo(self, errors):
+        errors.append("expo crash")
+        return [ExposureResult(node="e1", target="t", status="failed", error="boom")]
+
+    with patch.object(HeartbeatRunner, "_run_dag", lambda self, errors: DagResult()), patch.object(
+        HeartbeatRunner, "_run_exposures", fail_expo
+    ):
+        run = await runner.tick_once(reason="manual")
+    assert run.exposure[0].status == "failed"
+    assert run.status in {"partial", "failed"}
+
+
+@pytest.mark.asyncio
+async def test_run_forever_exits_when_disabled(disabled_project: Path):
+    cfg = HeartbeatConfig.load(disabled_project)
+    runner = HeartbeatRunner(cfg, disabled_project)
+    # Should exit immediately.
+    await asyncio.wait_for(runner.run_forever(), timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_run_forever_exits_when_interval_zero(temp_project: Path):
+    cfg = HeartbeatConfig.load(temp_project)
+    assert cfg.interval_seconds == 0
+    runner = HeartbeatRunner(cfg, temp_project)
+    await asyncio.wait_for(runner.run_forever(), timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_quarantined_file_moved(config: HeartbeatConfig, temp_project: Path):
+    bad = temp_project / "inbox" / "select.csv"  # reserved keyword → quarantine
+    bad.write_text("a\n1\n")
+    runner = HeartbeatRunner(config, temp_project)
+    with _patch_no_project_artifacts():
+        run = await runner.tick_once(reason="manual")
+    assert any(r.status == "quarantined" for r in run.ingested)
+    assert not bad.exists()
+    quarantine_dir = temp_project / config.quarantine_dir
+    assert any(quarantine_dir.iterdir())

--- a/tests/heartbeat/test_telegram_bridge.py
+++ b/tests/heartbeat/test_telegram_bridge.py
@@ -1,0 +1,132 @@
+"""Tests for the Telegram → inbox bridge (Step 7) and the lint contract that
+forbids heartbeat code from importing telegram code (Principle 5)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+
+def test_no_telegram_imports_in_heartbeat():
+    """Heartbeat code must not import from the telegram channel module
+    (Principle 1: deterministic core; Principle 5: file boundary).
+    """
+    heartbeat_root = (
+        Path(__file__).resolve().parents[2] / "src" / "seeknal" / "heartbeat"
+    )
+    bad: list[str] = []
+    for py in heartbeat_root.rglob("*.py"):
+        text = py.read_text(encoding="utf-8")
+        if "seeknal.ask.gateway.channels" in text or "from telegram" in text:
+            bad.append(str(py))
+    assert not bad, (
+        "Heartbeat must not import telegram. Offending files: "
+        + ", ".join(bad)
+    )
+
+
+def test_inbox_drop_disabled_no_copy(tmp_path: Path, monkeypatch):
+    """When inbox_drop is disabled, _copy_to_inbox is a no-op."""
+    from seeknal.ask.gateway.channels.telegram import TelegramChannel
+
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    staged = project / "target/ask_ingest/_staging/sales.csv"
+    staged.parent.mkdir(parents=True)
+    staged.write_text("a,b\n1,2\n")
+
+    channel = TelegramChannel(project, token="t")
+    with patch.object(
+        TelegramChannel,
+        "_inbox_drop_settings",
+        return_value={"enabled": False, "folder": None},
+    ):
+        dest = channel._copy_to_inbox(staged)
+    assert dest is None
+
+
+def test_inbox_drop_enabled_copies_into_default_inbox(tmp_path: Path):
+    from seeknal.ask.gateway.channels.telegram import TelegramChannel
+
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    staged = project / "target/ask_ingest/_staging/sales.csv"
+    staged.parent.mkdir(parents=True)
+    staged.write_text("a,b\n1,2\n")
+
+    channel = TelegramChannel(project, token="t")
+    with patch.object(
+        TelegramChannel,
+        "_inbox_drop_settings",
+        return_value={"enabled": True, "folder": None},
+    ):
+        dest = channel._copy_to_inbox(staged)
+    assert dest is not None
+    assert dest.exists()
+    assert dest.parent == project / "inbox"
+    assert dest.read_text() == staged.read_text()
+
+
+def test_inbox_drop_filename_collision_appends_timestamp(tmp_path: Path):
+    from seeknal.ask.gateway.channels.telegram import TelegramChannel
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "inbox").mkdir()
+    (project / "inbox" / "sales.csv").write_text("x")
+
+    staged = project / "target/ask_ingest/_staging/sales.csv"
+    staged.parent.mkdir(parents=True)
+    staged.write_text("a,b\n1,2\n")
+
+    channel = TelegramChannel(project, token="t")
+    with patch.object(
+        TelegramChannel,
+        "_inbox_drop_settings",
+        return_value={"enabled": True, "folder": "inbox"},
+    ):
+        dest = channel._copy_to_inbox(staged)
+    assert dest is not None
+    assert dest.name != "sales.csv"
+    assert dest.name.startswith("sales.") and dest.suffix == ".csv"
+
+
+def test_inbox_drop_resolves_inbox_from_heartbeat_md(tmp_path: Path):
+    from seeknal.ask.gateway.channels.telegram import TelegramChannel
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "HEARTBEAT.md").write_text(
+        """```yaml
+interval: 30s
+inbox_folders:
+  - my_drop_zone
+```
+"""
+    )
+    staged = project / "target/ask_ingest/_staging/x.csv"
+    staged.parent.mkdir(parents=True)
+    staged.write_text("a\n1\n")
+
+    channel = TelegramChannel(project, token="t")
+    with patch.object(
+        TelegramChannel,
+        "_inbox_drop_settings",
+        return_value={"enabled": True, "folder": None},
+    ):
+        dest = channel._copy_to_inbox(staged)
+    assert dest is not None
+    assert dest.parent.name == "my_drop_zone"
+
+
+def test_inbox_drop_settings_reader_defaults(tmp_path: Path):
+    from seeknal.ask.gateway.channels.telegram import TelegramChannel
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    channel = TelegramChannel(project, token="t")
+    settings = channel._inbox_drop_settings()
+    assert settings["enabled"] is False

--- a/tests/integrations/test_atlas_catalog.py
+++ b/tests/integrations/test_atlas_catalog.py
@@ -268,6 +268,33 @@ def test_factory_reads_portal_url(monkeypatch):
     assert client is not None and client._portal_url == "http://portal:4200"
 
 
+def test_dataset_from_portal_carries_schema_columns():
+    row = {
+        **PORTAL_ICEBERG,
+        "schemaFields": [
+            {"name": "sale_id", "type": "long"},
+            {"name": "region", "type": "string"},
+        ],
+    }
+    d = Dataset.from_portal(row)
+    assert d.columns == (("sale_id", "long"), ("region", "string"))
+
+
+def test_columns_from_schema_fields_tolerates_shapes():
+    from seeknal.integrations.atlas_catalog import _columns_from_schema_fields
+
+    assert _columns_from_schema_fields(None) == ()
+    assert _columns_from_schema_fields("nope") == ()
+    # {name,type} | {fieldPath,nativeDataType} (DataHub) | {name,dataType}; no-name dropped.
+    assert _columns_from_schema_fields(
+        [
+            {"fieldPath": "a", "nativeDataType": "int"},
+            {"name": "b", "dataType": "varchar"},
+            {"type": "x"},
+        ]
+    ) == (("a", "int"), ("b", "varchar"))
+
+
 def test_post_path_also_refreshes_on_401():
     """The shared sender covers POST (annotate) too, not just GET."""
 

--- a/tests/integrations/test_atlas_catalog.py
+++ b/tests/integrations/test_atlas_catalog.py
@@ -1,0 +1,118 @@
+"""Tests for the Atlas data-catalog client (AtlasCatalogClient)."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+from seeknal.integrations.atlas_catalog import (
+    AtlasCatalogClient,
+    Dataset,
+    create_catalog_client_from_env,
+)
+from seeknal.integrations.atlas_client import AtlasContractConfig
+
+ASSET = {
+    "id": "abc-123",
+    "asset_type": "source",
+    "name": "sales",
+    "namespace": "retail_demo",
+    "source_system": "lakekeeper",
+    "source_id": "source:sales",
+    "metadata": {
+        "description": "Retail sales",
+        "tags": ["gold"],
+        "canonical_asset_id": "atlas.retail_demo.sales",
+    },
+}
+
+
+def _client(handler) -> AtlasCatalogClient:
+    transport = httpx.MockTransport(handler)
+    return AtlasCatalogClient(
+        AtlasContractConfig(base_url="http://atlas", token="tok"),
+        client=httpx.Client(transport=transport),
+    )
+
+
+def test_list_datasets_maps_assets_and_params():
+    seen: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["url"] = str(request.url)
+        assert request.headers["Authorization"] == "Bearer tok"
+        return httpx.Response(200, json=[ASSET])
+
+    datasets = _client(handler).list_datasets(query="sales", asset_type="source", limit=5)
+    assert seen["path"] == "/api/assets"
+    assert "q=sales" in seen["url"] and "type=source" in seen["url"] and "limit=5" in seen["url"]
+    assert len(datasets) == 1
+    d = datasets[0]
+    assert d.name == "sales" and d.namespace == "retail_demo"
+    assert d.tags == ("gold",) and d.description == "Retail sales"
+    assert d.fqn == "atlas.retail_demo.sales"
+
+
+def test_get_dataset_hits_id_path():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/assets/abc-123"
+        return httpx.Response(200, json=ASSET)
+
+    assert _client(handler).get_dataset("abc-123").name == "sales"
+
+
+def test_search_handles_dict_and_list_shapes():
+    assert len(_client(lambda r: httpx.Response(200, json={"results": [ASSET]})).search("x")) == 1
+    assert len(_client(lambda r: httpx.Response(200, json={"items": [ASSET]})).search("x")) == 1
+    assert len(_client(lambda r: httpx.Response(200, json=[ASSET])).search("x")) == 1
+
+
+def test_sample_requires_identifier_param():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/sample"
+        assert request.url.params.get("identifier") == "retail_demo.sales"
+        assert request.url.params.get("limit") == "3"
+        return httpx.Response(200, json={"columns": ["a"], "rows": [[1]]})
+
+    out = _client(handler).sample("retail_demo.sales", limit=3)
+    assert out["rows"] == [[1]]
+
+
+def test_annotate_merges_tags_then_registers():
+    calls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.url.path)
+        if request.url.path == "/api/assets/abc-123":
+            return httpx.Response(200, json=ASSET)
+        if request.url.path == "/api/contracts/assets/register":
+            body = json.loads(request.content)
+            asset = body["asset"]
+            assert "pii" in asset["tags"] and "gold" in asset["tags"]  # union with existing
+            assert asset["description"] == "new desc"
+            return httpx.Response(200, json={"asset": asset})
+        return httpx.Response(404)
+
+    _client(handler).annotate("abc-123", tags=["pii"], description="new desc")
+    assert calls == ["/api/assets/abc-123", "/api/contracts/assets/register"]
+
+
+def test_dataset_from_api_is_tolerant_of_missing_fields():
+    d = Dataset.from_api({"id": "1", "name": "n"})
+    assert d.namespace == "" and d.tags == () and d.description == ""
+    assert d.fqn == "n"
+
+
+def test_factory_returns_none_without_atlas_api_url(monkeypatch):
+    monkeypatch.delenv("ATLAS_API_URL", raising=False)
+    assert create_catalog_client_from_env() is None
+
+
+def test_factory_builds_client_with_env(monkeypatch):
+    monkeypatch.setenv("ATLAS_API_URL", "http://atlas:8000/")
+    monkeypatch.setenv("ATLAS_API_TOKEN", "svc")
+    client = create_catalog_client_from_env()
+    assert client is not None
+    assert client.config.base_url == "http://atlas:8000" and client.config.token == "svc"

--- a/tests/integrations/test_atlas_catalog.py
+++ b/tests/integrations/test_atlas_catalog.py
@@ -268,6 +268,27 @@ def test_factory_reads_portal_url(monkeypatch):
     assert client is not None and client._portal_url == "http://portal:4200"
 
 
+def test_lineage_hits_portal_lineage_route():
+    seen: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["host"] = request.url.host
+        seen["path"] = request.url.path
+        return httpx.Response(
+            200,
+            json={
+                "upstreamLineage": [{"name": "raw.x", "type": "DATASET"}],
+                "downstreamLineage": [],
+            },
+        )
+
+    urn = "urn:li:dataset:(urn:li:dataPlatform:iceberg,retail_demo.sales,PROD)"
+    data = _portal_client(handler).lineage(urn)
+    assert seen["host"] == "portal"
+    assert seen["path"].startswith("/api/datasets/") and seen["path"].endswith("/lineage")
+    assert data["upstreamLineage"][0]["name"] == "raw.x"
+
+
 def test_dataset_from_portal_carries_schema_columns():
     row = {
         **PORTAL_ICEBERG,

--- a/tests/integrations/test_atlas_catalog.py
+++ b/tests/integrations/test_atlas_catalog.py
@@ -160,6 +160,114 @@ def test_raises_auth_error_when_refresh_unavailable():
         raise AssertionError("expected AtlasAuthError")
 
 
+PORTAL_ICEBERG = {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:iceberg,retail_demo.sales,PROD)",
+    "name": "retail_demo.sales",
+    "displayName": "sales",
+    "namespace": "retail_demo",
+    "platform": "iceberg",
+    "type": "table",
+    "tags": ["Restricted"],
+}
+PORTAL_CUBE = {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:cube,cube.public.Orders,PROD)",
+    "name": "cube.public.Orders",
+    "displayName": "Orders",
+    "namespace": "public",
+    "platform": "cube",
+    "type": "cube",
+    "tags": [],
+}
+
+
+def _portal_client(handler) -> AtlasCatalogClient:
+    transport = httpx.MockTransport(handler)
+    return AtlasCatalogClient(
+        AtlasContractConfig(base_url="http://atlas", token="tok"),
+        client=httpx.Client(transport=transport),
+        portal_url="http://portal",
+    )
+
+
+def test_dataset_from_portal_iceberg_recomposes_fqn_without_doubling():
+    d = Dataset.from_portal(PORTAL_ICEBERG)
+    assert d.name == "sales" and d.namespace == "retail_demo"
+    assert d.asset_type == "table" and d.source_system == "iceberg"
+    assert d.tags == ("Restricted",)
+    assert d.fqn == "retail_demo.sales"  # not retail_demo.retail_demo.sales
+
+
+def test_dataset_from_portal_cube_shape():
+    d = Dataset.from_portal(PORTAL_CUBE)
+    assert d.name == "Orders" and d.namespace == "public"
+    assert d.asset_type == "cube" and d.source_system == "cube"
+    assert d.fqn == "public.Orders"
+
+
+def test_dataset_from_portal_strips_namespace_when_no_display_name():
+    d = Dataset.from_portal(
+        {"name": "retail_demo.sales", "namespace": "retail_demo", "platform": "iceberg", "type": "table"}
+    )
+    assert d.name == "sales" and d.fqn == "retail_demo.sales"
+
+
+def test_list_from_portal_targets_portal_and_maps_rows():
+    seen: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["host"] = request.url.host
+        seen["path"] = request.url.path
+        seen["url"] = str(request.url)
+        assert request.headers["Authorization"] == "Bearer tok"
+        return httpx.Response(200, json={"datasets": [PORTAL_ICEBERG, PORTAL_CUBE], "total": 2})
+
+    datasets = _portal_client(handler).list_datasets(query="sa", namespace="retail_demo", limit=5)
+    assert seen["host"] == "portal" and seen["path"] == "/api/datasets"
+    assert "q=sa" in seen["url"] and "namespace=retail_demo" in seen["url"] and "limit=5" in seen["url"]
+    assert [d.fqn for d in datasets] == ["retail_demo.sales", "public.Orders"]
+
+
+def test_list_from_portal_forwards_platform_and_filters_type_client_side():
+    seen: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        return httpx.Response(200, json={"datasets": [PORTAL_ICEBERG, PORTAL_CUBE]})
+
+    # source_system -> portal ?platform=; asset_type filtered client-side.
+    datasets = _portal_client(handler).list_datasets(source_system="cube", asset_type="cube")
+    assert "platform=cube" in seen["url"]
+    assert [d.fqn for d in datasets] == ["public.Orders"]
+
+
+def test_list_from_portal_tolerates_bare_array():
+    datasets = _portal_client(
+        lambda r: httpx.Response(200, json=[PORTAL_ICEBERG])
+    ).list_datasets()
+    assert [d.fqn for d in datasets] == ["retail_demo.sales"]
+
+
+def test_list_uses_assets_registry_when_portal_unset():
+    """Without ATLAS_PORTAL_URL the registry path (/api/assets) is used (backward compat)."""
+
+    seen: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        return httpx.Response(200, json=[ASSET])
+
+    datasets = _client(handler).list_datasets()  # _client has no portal_url
+    assert seen["path"] == "/api/assets"
+    assert datasets[0].fqn == "atlas.retail_demo.sales"
+
+
+def test_factory_reads_portal_url(monkeypatch):
+    monkeypatch.setenv("ATLAS_API_URL", "http://atlas:8000")
+    monkeypatch.setenv("ATLAS_PORTAL_URL", "http://portal:4200/")
+    client = create_catalog_client_from_env()
+    assert client is not None and client._portal_url == "http://portal:4200"
+
+
 def test_post_path_also_refreshes_on_401():
     """The shared sender covers POST (annotate) too, not just GET."""
 

--- a/tests/integrations/test_atlas_catalog.py
+++ b/tests/integrations/test_atlas_catalog.py
@@ -11,7 +11,7 @@ from seeknal.integrations.atlas_catalog import (
     Dataset,
     create_catalog_client_from_env,
 )
-from seeknal.integrations.atlas_client import AtlasContractConfig
+from seeknal.integrations.atlas_client import AtlasAuthError, AtlasContractConfig
 
 ASSET = {
     "id": "abc-123",
@@ -116,3 +116,68 @@ def test_factory_builds_client_with_env(monkeypatch):
     client = create_catalog_client_from_env()
     assert client is not None
     assert client.config.base_url == "http://atlas:8000" and client.config.token == "svc"
+
+
+def test_refreshes_token_on_401_and_retries():
+    """A 401 triggers a single refresh + retry with the new bearer, transparently."""
+
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            assert request.headers["Authorization"] == "Bearer tok"
+            return httpx.Response(401, json={"detail": "Token has expired"})
+        assert request.headers["Authorization"] == "Bearer refreshed"
+        return httpx.Response(200, json=[ASSET])
+
+    client = AtlasCatalogClient(
+        AtlasContractConfig(base_url="http://atlas", token="tok"),
+        client=httpx.Client(transport=httpx.MockTransport(handler)),
+        token_refresher=lambda: "refreshed",
+    )
+    datasets = client.list_datasets(query="sales")
+    assert calls["n"] == 2
+    assert len(datasets) == 1 and datasets[0].name == "sales"
+
+
+def test_raises_auth_error_when_refresh_unavailable():
+    """When the session cannot be refreshed, raise AtlasAuthError with a login hint."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"detail": "Token has expired"})
+
+    client = AtlasCatalogClient(
+        AtlasContractConfig(base_url="http://atlas", token="tok"),
+        client=httpx.Client(transport=httpx.MockTransport(handler)),
+        token_refresher=lambda: None,
+    )
+    try:
+        client.list_datasets(query="sales")
+    except AtlasAuthError as exc:
+        assert "seeknal auth login" in str(exc)
+    else:  # pragma: no cover - explicit failure if no error raised
+        raise AssertionError("expected AtlasAuthError")
+
+
+def test_post_path_also_refreshes_on_401():
+    """The shared sender covers POST (annotate) too, not just GET."""
+
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if request.url.path == "/api/assets/abc-123":
+            return httpx.Response(200, json=ASSET)  # get_dataset inside annotate()
+        # /api/contracts/assets/register (the POST)
+        if calls["n"] <= 2:
+            return httpx.Response(401, json={"detail": "expired"})
+        return httpx.Response(200, json={"ok": True})
+
+    client = AtlasCatalogClient(
+        AtlasContractConfig(base_url="http://atlas", token="tok"),
+        client=httpx.Client(transport=httpx.MockTransport(handler)),
+        token_refresher=lambda: "refreshed",
+    )
+    result = client.annotate("abc-123", tags=["pii"])
+    assert result == {"ok": True}

--- a/tests/integrations/test_atlas_client.py
+++ b/tests/integrations/test_atlas_client.py
@@ -1,0 +1,208 @@
+"""Tests for the apply-time Atlas contract client's authentication plumbing.
+
+These pin the fix for the "Missing authentication token" apply failure: the
+contract client must pick up the logged-in user's token from the credentials
+file (like the governance gate and catalog client already do), transparently
+refresh it once on a 401, and otherwise surface an actionable
+"run `seeknal auth login`" hint instead of the raw backend error.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from seeknal.integrations.atlas_client import (
+    NOT_LOGGED_IN_HINT,
+    SESSION_EXPIRED_HINT,
+    AtlasAuthError,
+    AtlasContractClient,
+    AtlasContractConfig,
+    AtlasContractError,
+    create_atlas_contract_client_from_env,
+)
+
+BASE_URL = "http://atlas.test"
+
+
+def _write_creds(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, access_token: str) -> Path:
+    """Write a credentials file and point SEEKNAL_CREDENTIALS_PATH at it."""
+
+    creds = tmp_path / "credentials.json"
+    creds.write_text(
+        json.dumps({"access_token": access_token, "refresh_token": "refresh-1"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(creds))
+    return creds
+
+
+def _isolate_atlas_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep factory tests away from the developer's real config/credentials."""
+
+    monkeypatch.setenv("SEEKNAL_ATLAS_CONFIG_PATH", str(tmp_path / "no-atlas.json"))
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(tmp_path / "no-credentials.json"))
+    monkeypatch.delenv("ATLAS_API_URL", raising=False)
+    monkeypatch.delenv("ATLAS_API_TOKEN", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Token resolution in create_atlas_contract_client_from_env
+# ---------------------------------------------------------------------------
+
+
+def test_client_from_env_uses_credentials_token_after_login(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _isolate_atlas_env(tmp_path, monkeypatch)
+    monkeypatch.setenv("ATLAS_API_URL", BASE_URL)
+    _write_creds(tmp_path, monkeypatch, "user-token")
+
+    client = create_atlas_contract_client_from_env()
+
+    assert client is not None
+    assert client.config.token == "user-token"
+
+
+def test_client_from_env_prefers_explicit_service_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _isolate_atlas_env(tmp_path, monkeypatch)
+    monkeypatch.setenv("ATLAS_API_URL", BASE_URL)
+    monkeypatch.setenv("ATLAS_API_TOKEN", "service-token")
+    _write_creds(tmp_path, monkeypatch, "user-token")
+
+    client = create_atlas_contract_client_from_env()
+
+    assert client is not None
+    assert client.config.token == "service-token"
+
+
+def test_client_from_env_has_no_token_when_logged_out(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _isolate_atlas_env(tmp_path, monkeypatch)
+    monkeypatch.setenv("ATLAS_API_URL", BASE_URL)
+
+    client = create_atlas_contract_client_from_env()
+
+    assert client is not None
+    assert client.config.token is None
+
+
+def test_client_from_env_inactive_without_atlas_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _isolate_atlas_env(tmp_path, monkeypatch)
+
+    assert create_atlas_contract_client_from_env() is None
+
+
+# ---------------------------------------------------------------------------
+# Bearer header + 401 refresh/retry in _post
+# ---------------------------------------------------------------------------
+
+
+def _client(
+    handler,
+    *,
+    token: str | None,
+    token_refresher=None,
+) -> AtlasContractClient:
+    """Build a contract client whose HTTP calls are served via MockTransport."""
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handler))
+    config = AtlasContractConfig(base_url=BASE_URL, token=token, timeout_seconds=5.0)
+    return AtlasContractClient(config, client=http_client, token_refresher=token_refresher)
+
+
+def test_post_sends_bearer_token() -> None:
+    seen_auth: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_auth.append(request.headers.get("Authorization"))
+        return httpx.Response(200, json={"allowed": True})
+
+    client = _client(handler, token="user-token")
+    result = client._post("/api/contracts/policy-check", {"operation": "apply"})
+
+    assert result == {"allowed": True}
+    assert seen_auth == ["Bearer user-token"]
+
+
+def test_post_refreshes_token_once_on_401_and_retries() -> None:
+    seen_auth: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_auth.append(request.headers.get("Authorization"))
+        if request.headers.get("Authorization") == "Bearer fresh-token":
+            return httpx.Response(200, json={"allowed": True})
+        return httpx.Response(401, json={"detail": "Missing authentication token"})
+
+    client = _client(handler, token="stale-token", token_refresher=lambda: "fresh-token")
+    result = client._post("/api/contracts/policy-check", {"operation": "apply"})
+
+    assert result == {"allowed": True}
+    assert seen_auth == ["Bearer stale-token", "Bearer fresh-token"]
+
+
+def test_post_raises_session_expired_when_refresh_fails() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"detail": "Missing authentication token"})
+
+    client = _client(handler, token="stale-token", token_refresher=lambda: None)
+
+    with pytest.raises(AtlasAuthError) as excinfo:
+        client._post("/api/contracts/policy-check", {"operation": "apply"})
+    assert str(excinfo.value) == SESSION_EXPIRED_HINT
+
+
+def test_post_raises_login_hint_when_no_token_at_all() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"detail": "Missing authentication token"})
+
+    client = _client(handler, token=None, token_refresher=lambda: None)
+
+    with pytest.raises(AtlasAuthError) as excinfo:
+        client._post("/api/contracts/policy-check", {"operation": "apply"})
+    assert str(excinfo.value) == NOT_LOGGED_IN_HINT
+
+
+def test_post_non_401_errors_keep_generic_contract_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    client = _client(handler, token="user-token")
+
+    with pytest.raises(AtlasContractError) as excinfo:
+        client._post("/api/contracts/policy-check", {"operation": "apply"})
+    assert not isinstance(excinfo.value, AtlasAuthError)
+    assert "boom" in str(excinfo.value)
+
+
+def test_preflight_apply_authenticates_with_refreshed_token(tmp_path: Path) -> None:
+    """End-to-end: a stale session is refreshed mid-preflight and apply proceeds."""
+
+    seen: list[tuple[str, str | None]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append((request.url.path, request.headers.get("Authorization")))
+        if request.headers.get("Authorization") != "Bearer fresh-token":
+            return httpx.Response(401, json={"detail": "Missing authentication token"})
+        return httpx.Response(200, json={"allowed": True, "reason": "ok"})
+
+    client = _client(handler, token="stale-token", token_refresher=lambda: "fresh-token")
+    context = client.preflight_apply(
+        node_type="source",
+        name="raw_orders",
+        yaml_data={"kind": "source", "name": "raw_orders"},
+        target_path=tmp_path / "seeknal" / "sources" / "raw_orders.yml",
+        project_path=tmp_path,
+    )
+
+    assert context.asset["name"] == "raw_orders"
+    assert seen[0] == ("/api/contracts/policy-check", "Bearer stale-token")
+    assert seen[1] == ("/api/contracts/policy-check", "Bearer fresh-token")

--- a/tests/integrations/test_atlas_config.py
+++ b/tests/integrations/test_atlas_config.py
@@ -1,0 +1,83 @@
+"""Tests for the persisted Atlas connection config (atlas_config) + precedence."""
+
+from __future__ import annotations
+
+import json
+
+import seeknal.integrations.atlas_catalog as catalog_mod
+import seeknal.integrations.atlas_governance as gov_mod
+from seeknal.integrations.atlas_config import (
+    AtlasConfig,
+    atlas_config,
+    derive_config,
+    save_atlas_config,
+)
+
+
+def _point_at(monkeypatch, tmp_path):
+    path = tmp_path / "atlas.json"
+    monkeypatch.setenv("SEEKNAL_ATLAS_CONFIG_PATH", str(path))
+    return path
+
+
+def test_absent_config_is_empty(monkeypatch, tmp_path):
+    _point_at(monkeypatch, tmp_path)
+    assert atlas_config() == AtlasConfig()
+
+
+def test_save_load_roundtrip_is_0600(monkeypatch, tmp_path):
+    path = _point_at(monkeypatch, tmp_path)
+    save_atlas_config(derive_config(host="atlas-dev-server"))
+    assert oct(path.stat().st_mode & 0o777) == "0o600"
+    loaded = atlas_config()
+    assert loaded.api_url == "http://atlas-dev-server:8000"
+    assert loaded.portal_url == "http://atlas-dev-server:4200"
+    assert loaded.keycloak_issuer == "http://atlas-dev-server:8080/realms/atlas"
+    assert loaded.oidc_client_id == "seeknal-cli"
+
+
+def test_derive_explicit_overrides_win():
+    cfg = derive_config(host="h", portal_url="http://portal:9999", realm="custom")
+    assert cfg.api_url == "http://h:8000"
+    assert cfg.portal_url == "http://portal:9999"  # explicit wins
+    assert cfg.keycloak_issuer == "http://h:8080/realms/custom"
+
+
+def test_derive_from_api_url_host():
+    cfg = derive_config(api_url="https://atlas.example:8000")
+    assert cfg.portal_url == "http://atlas.example:4200"
+    assert cfg.keycloak_issuer == "http://atlas.example:8080/realms/atlas"
+
+
+def test_garbled_config_yields_empty(monkeypatch, tmp_path):
+    path = _point_at(monkeypatch, tmp_path)
+    path.write_text("not json", encoding="utf-8")
+    assert atlas_config() == AtlasConfig()
+    path.write_text(json.dumps(["not", "a", "dict"]), encoding="utf-8")
+    assert atlas_config() == AtlasConfig()
+
+
+def test_catalog_factory_uses_config_when_env_unset(monkeypatch, tmp_path):
+    _point_at(monkeypatch, tmp_path)
+    save_atlas_config(derive_config(host="cfg-host"))
+    for var in ("ATLAS_API_URL", "ATLAS_PORTAL_URL", "ATLAS_API_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    client = catalog_mod.create_catalog_client_from_env()
+    assert client is not None
+    assert client.config.base_url == "http://cfg-host:8000"
+    assert client._portal_url == "http://cfg-host:4200"
+
+
+def test_env_var_wins_over_config(monkeypatch, tmp_path):
+    _point_at(monkeypatch, tmp_path)
+    save_atlas_config(derive_config(host="cfg-host"))
+    monkeypatch.setenv("ATLAS_API_URL", "http://env-host:8000")
+    client = catalog_mod.create_catalog_client_from_env()
+    assert client is not None and client.config.base_url == "http://env-host:8000"
+
+
+def test_oidc_issuer_falls_back_to_config(monkeypatch, tmp_path):
+    _point_at(monkeypatch, tmp_path)
+    save_atlas_config(derive_config(host="kc-host"))
+    monkeypatch.delenv("KEYCLOAK_ISSUER", raising=False)
+    assert gov_mod._oidc_issuer() == "http://kc-host:8080/realms/atlas"

--- a/tests/integrations/test_atlas_config.py
+++ b/tests/integrations/test_atlas_config.py
@@ -49,6 +49,13 @@ def test_derive_from_api_url_host():
     assert cfg.keycloak_issuer == "http://atlas.example:8080/realms/atlas"
 
 
+def test_derive_honors_explicit_host_port():
+    cfg = derive_config(host="atlas:9000")
+    assert cfg.api_url == "http://atlas:9000"  # explicit port kept, not dropped to :8000
+    assert cfg.portal_url == "http://atlas:4200"  # portal/keycloak still standard on bare host
+    assert cfg.keycloak_issuer == "http://atlas:8080/realms/atlas"
+
+
 def test_garbled_config_yields_empty(monkeypatch, tmp_path):
     path = _point_at(monkeypatch, tmp_path)
     path.write_text("not json", encoding="utf-8")

--- a/tests/integrations/test_atlas_governance.py
+++ b/tests/integrations/test_atlas_governance.py
@@ -8,7 +8,7 @@ it is fail-closed by default, and audit logging can never break a read.
 
 from __future__ import annotations
 
-from typing import Callable
+from typing import Any, Callable
 
 import httpx
 import pytest
@@ -17,7 +17,12 @@ import base64
 import json
 from pathlib import Path
 
-from seeknal.integrations.atlas_client import AtlasContractConfig, AtlasPolicyDenied
+from seeknal.integrations.atlas_client import (
+    AtlasAuthError,
+    AtlasContractConfig,
+    AtlasPolicyDenied,
+    SESSION_EXPIRED_HINT,
+)
 from seeknal.integrations.atlas_governance import (
     MASK_TOKEN,
     AccessDecision,
@@ -29,6 +34,7 @@ from seeknal.integrations.atlas_governance import (
     mask_rows,
     mask_value,
     referenced_tables,
+    refresh_access_token,
     user_sub_from_credentials,
     user_token_from_credentials,
 )
@@ -469,3 +475,181 @@ def test_user_sub_from_credentials_none_when_absent(
 ) -> None:
     monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(tmp_path / "missing.json"))
     assert user_sub_from_credentials() is None
+
+
+# ---------------------------------------------------------------------------
+# refresh_access_token
+# ---------------------------------------------------------------------------
+
+
+def _write_creds_with_refresh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    access_token: str = "old-access",
+    refresh_token: str | None = "rt-1",
+) -> Path:
+    """Write a credentials file (optionally without a refresh token) and point env at it."""
+
+    payload: dict[str, Any] = {"access_token": access_token, "expires_in": 300}
+    if refresh_token is not None:
+        payload["refresh_token"] = refresh_token
+        payload["refresh_expires_in"] = 1800
+    creds = tmp_path / "credentials.json"
+    creds.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(creds))
+    return creds
+
+
+def test_refresh_access_token_success_persists_rotation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("KEYCLOAK_ISSUER", "http://kc.test/realms/atlas")
+    monkeypatch.delenv("SEEKNAL_OIDC_CLIENT_ID", raising=False)
+    creds = _write_creds_with_refresh(tmp_path, monkeypatch)
+
+    seen: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["body"] = request.content.decode()
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "new-access",
+                "refresh_token": "rt-2",
+                "expires_in": 300,
+                "refresh_expires_in": 1800,
+            },
+        )
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    token = refresh_access_token(client=client)
+
+    assert token == "new-access"
+    assert seen["path"] == "/realms/atlas/protocol/openid-connect/token"
+    assert "grant_type=refresh_token" in seen["body"]
+    assert "refresh_token=rt-1" in seen["body"]
+    assert "client_id=seeknal-cli" in seen["body"]
+    # Rotated tokens are persisted (mode 0600) for the next call.
+    saved = json.loads(creds.read_text(encoding="utf-8"))
+    assert saved["access_token"] == "new-access"
+    assert saved["refresh_token"] == "rt-2"
+    # The refreshed credentials file must be owner-only (no world/group read window).
+    assert (creds.stat().st_mode & 0o777) == 0o600
+
+
+def test_refresh_access_token_none_without_refresh_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_creds_with_refresh(tmp_path, monkeypatch, refresh_token=None)
+    client = httpx.Client(transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})))
+    assert refresh_access_token(client=client) is None
+
+
+def test_refresh_access_token_none_on_rejected_grant(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("KEYCLOAK_ISSUER", "http://kc.test/realms/atlas")
+    _write_creds_with_refresh(tmp_path, monkeypatch)
+    client = httpx.Client(
+        transport=httpx.MockTransport(lambda r: httpx.Response(401, json={"error": "invalid_grant"}))
+    )
+    # An expired/invalid refresh token yields None (never raises).
+    assert refresh_access_token(client=client) is None
+
+
+def test_refresh_access_token_none_when_no_credentials(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(tmp_path / "missing.json"))
+    assert refresh_access_token() is None
+
+
+# ---------------------------------------------------------------------------
+# Gate token-refresh on 401
+# ---------------------------------------------------------------------------
+
+
+def test_gate_refreshes_token_on_401_and_retries() -> None:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            assert request.headers["Authorization"] == "Bearer t0ken"
+            return httpx.Response(401, json={"detail": "Token has expired"})
+        assert request.headers["Authorization"] == "Bearer fresh"
+        return httpx.Response(200, json={"allowed": True, "reason": "ok"})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    config = AtlasContractConfig(base_url=BASE_URL, token="t0ken", timeout_seconds=5.0)
+    gate = GovernanceGate(config, client=client, token_refresher=lambda: "fresh")
+
+    decision = gate.check_access(resource="retail_demo.sales", action="read")
+    assert decision.allowed is True
+    assert calls["n"] == 2
+
+
+def test_gate_fail_closed_when_refresh_unavailable() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"detail": "expired"})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    config = AtlasContractConfig(base_url=BASE_URL, token="t0ken", timeout_seconds=5.0)
+    gate = GovernanceGate(config, client=client, token_refresher=lambda: None)
+
+    # Unrecoverable 401 keeps the fail-closed contract (a denied decision, no raise),
+    # and the reason is the actionable re-auth hint, not "Atlas unreachable".
+    decision = gate.check_access(resource="retail_demo.sales", action="read")
+    assert decision.allowed is False
+    assert decision.reason == SESSION_EXPIRED_HINT
+
+
+def test_gate_post_raises_auth_error_on_unrecoverable_401() -> None:
+    """The low-level sender raises AtlasAuthError (not a generic error) on a dead 401,
+    mirroring AtlasCatalogClient._send so the exception type is consistent."""
+
+    client = httpx.Client(
+        transport=httpx.MockTransport(lambda r: httpx.Response(401, json={"detail": "expired"}))
+    )
+    config = AtlasContractConfig(base_url=BASE_URL, token="t0ken", timeout_seconds=5.0)
+    gate = GovernanceGate(config, client=client, token_refresher=lambda: None)
+
+    with pytest.raises(AtlasAuthError) as excinfo:
+        gate._post("/api/contracts/access-check", {"operation": "access-check"})
+    assert "seeknal auth login" in str(excinfo.value)
+
+
+def test_gate_fail_open_still_denies_on_expired_session() -> None:
+    """Security: fail-open trades availability for enforcement on *transport* errors,
+    but an expired session is an auth failure and must never be waved through."""
+
+    client = httpx.Client(
+        transport=httpx.MockTransport(lambda r: httpx.Response(401, json={"detail": "expired"}))
+    )
+    config = AtlasContractConfig(base_url=BASE_URL, token="t0ken", timeout_seconds=5.0)
+    gate = GovernanceGate(config, fail_open=True, client=client, token_refresher=lambda: None)
+
+    decision = gate.check_access(resource="retail_demo.sales", action="read")
+    assert decision.allowed is False  # NOT allowed, despite fail_open=True
+    assert decision.reason == SESSION_EXPIRED_HINT
+
+
+def test_enforce_access_on_expired_session_raises_policy_denied_not_auth_error() -> None:
+    """Run-safety contract: even though _post raises AtlasAuthError internally, the
+    public enforce_access() must still surface AtlasPolicyDenied (carrying the re-auth
+    hint as the reason). `seeknal run` catches only AtlasPolicyDenied, so raising
+    AtlasAuthError here would regress it into an uncaught traceback."""
+
+    client = httpx.Client(
+        transport=httpx.MockTransport(lambda r: httpx.Response(401, json={"detail": "expired"}))
+    )
+    config = AtlasContractConfig(base_url=BASE_URL, token="t0ken", timeout_seconds=5.0)
+    gate = GovernanceGate(config, client=client, token_refresher=lambda: None)
+
+    with pytest.raises(AtlasPolicyDenied) as excinfo:
+        gate.enforce_access(resource="retail_demo.sales", action="read")
+    # Not an AtlasAuthError (sibling type that `seeknal run` would not catch).
+    assert not isinstance(excinfo.value, AtlasAuthError)
+    assert str(excinfo.value) == SESSION_EXPIRED_HINT

--- a/tests/integrations/test_atlas_governance.py
+++ b/tests/integrations/test_atlas_governance.py
@@ -1,0 +1,288 @@
+"""Tests for the runtime Atlas governance gate.
+
+These exercise the gate in isolation using an injected ``httpx.MockTransport`` so no
+real Atlas backend is required. The behaviours under test are the ones that make the
+gate trustworthy: it is inactive unless configured, it delegates decisions to Atlas,
+it is fail-closed by default, and audit logging can never break a read.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import httpx
+import pytest
+
+from seeknal.integrations.atlas_client import AtlasContractConfig, AtlasPolicyDenied
+from seeknal.integrations.atlas_governance import (
+    MASK_TOKEN,
+    AccessDecision,
+    GovernanceGate,
+    apply_column_masks,
+    create_governance_gate_from_env,
+    govern_read,
+    mask_rows,
+    mask_value,
+)
+
+BASE_URL = "http://atlas.test"
+
+
+def _gate(
+    handler: Callable[[httpx.Request], httpx.Response],
+    *,
+    fail_open: bool = False,
+) -> GovernanceGate:
+    """Build a gate whose HTTP calls are served by ``handler`` via MockTransport."""
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    config = AtlasContractConfig(base_url=BASE_URL, token="t0ken", timeout_seconds=5.0)
+    return GovernanceGate(config, fail_open=fail_open, client=client)
+
+
+# ---------------------------------------------------------------------------
+# Activation
+# ---------------------------------------------------------------------------
+
+
+def test_gate_inactive_without_atlas_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ATLAS_API_URL", raising=False)
+    assert create_governance_gate_from_env() is None
+
+
+def test_gate_active_when_atlas_url_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAS_API_URL", "https://atlas.example.com/")
+    monkeypatch.setenv("ATLAS_API_TOKEN", "abc")
+    gate = create_governance_gate_from_env()
+    assert isinstance(gate, GovernanceGate)
+    # trailing slash trimmed
+    assert gate.config.base_url == "https://atlas.example.com"
+    assert gate.config.token == "abc"
+
+
+# ---------------------------------------------------------------------------
+# check_access / enforce_access
+# ---------------------------------------------------------------------------
+
+
+def test_check_access_allowed() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/contracts/access-check"
+        assert request.headers["Authorization"] == "Bearer t0ken"
+        return httpx.Response(200, json={"allowed": True, "classification": "internal"})
+
+    decision = _gate(handler).check_access(resource="prod.gold.sales", actor="alice")
+    assert decision == AccessDecision(
+        allowed=True, reason="", masked_columns=(), classification="internal"
+    )
+    assert decision.has_masking is False
+
+
+def test_check_access_denied_with_reason() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"allowed": False, "reason": "no grant"})
+
+    decision = _gate(handler).check_access(resource="prod.gold.finance", actor="bob")
+    assert decision.allowed is False
+    assert decision.reason == "no grant"
+
+
+def test_check_access_returns_masked_columns() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "allowed": True,
+                "masked_columns": ["nik", "npwp"],
+                "classification": "restricted",
+            },
+        )
+
+    decision = _gate(handler).check_access(resource="prod.gold.customer", actor="carol")
+    assert decision.allowed is True
+    assert decision.masked_columns == ("nik", "npwp")
+    assert decision.classification == "restricted"
+    assert decision.has_masking is True
+
+
+def test_enforce_access_returns_decision_when_allowed() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"allowed": True, "masked_columns": ["nik"]})
+
+    decision = _gate(handler).enforce_access(resource="prod.gold.customer", actor="carol")
+    assert decision.allowed is True
+    assert decision.masked_columns == ("nik",)
+
+
+def test_enforce_access_raises_when_denied() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/contracts/access-check":
+            return httpx.Response(200, json={"allowed": False, "reason": "denied by policy"})
+        return httpx.Response(200, json={})  # audit endpoint
+
+    with pytest.raises(AtlasPolicyDenied, match="denied by policy"):
+        _gate(handler).enforce_access(resource="prod.gold.finance", actor="bob")
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed / fail-open on transport errors
+# ---------------------------------------------------------------------------
+
+
+def test_fail_closed_on_transport_error_by_default() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("atlas down", request=request)
+
+    decision = _gate(handler).check_access(resource="prod.gold.sales")
+    assert decision.allowed is False
+    assert "fail-closed" in decision.reason
+
+
+def test_enforce_access_raises_when_atlas_unreachable() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("atlas down", request=request)
+
+    with pytest.raises(AtlasPolicyDenied):
+        _gate(handler).enforce_access(resource="prod.gold.sales")
+
+
+def test_fail_open_when_explicitly_enabled() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("atlas down", request=request)
+
+    decision = _gate(handler, fail_open=True).check_access(resource="prod.gold.sales")
+    assert decision.allowed is True
+    assert "fail-open" in decision.reason
+
+
+def test_server_5xx_is_fail_closed() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="unavailable")
+
+    decision = _gate(handler).check_access(resource="prod.gold.sales")
+    assert decision.allowed is False
+
+
+# ---------------------------------------------------------------------------
+# Audit never raises
+# ---------------------------------------------------------------------------
+
+
+def test_audit_never_raises_on_server_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    # Must not raise.
+    assert _gate(handler).audit(action="read", resource="prod.gold.sales", status="success") is None
+
+
+def test_audit_never_raises_on_connect_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("atlas down", request=request)
+
+    assert _gate(handler).audit(action="read", resource="prod.gold.sales") is None
+
+
+# ---------------------------------------------------------------------------
+# Pure masking helpers
+# ---------------------------------------------------------------------------
+
+
+def test_mask_value_variants() -> None:
+    assert mask_value(None) is None
+    assert mask_value("3201011234567") == MASK_TOKEN
+    assert mask_value("3201011234567", keep=6) == f"320101{MASK_TOKEN}"
+    # value shorter than keep is returned unchanged
+    assert mask_value("ab", keep=6) == "ab"
+    assert mask_value(12345, keep=0) == MASK_TOKEN
+
+
+def test_apply_column_masks_redacts_only_listed_columns() -> None:
+    rows = [
+        {"customer_id": "C-001", "nik": "3201011234567", "arpu": 152000},
+        {"customer_id": "C-002", "nik": "3273010000000", "arpu": 98000},
+    ]
+    masked = apply_column_masks(rows, ["nik"], keep=6)
+    assert masked == [
+        {"customer_id": "C-001", "nik": f"320101{MASK_TOKEN}", "arpu": 152000},
+        {"customer_id": "C-002", "nik": f"327301{MASK_TOKEN}", "arpu": 98000},
+    ]
+    # original rows untouched
+    assert rows[0]["nik"] == "3201011234567"
+
+
+def test_apply_column_masks_no_columns_is_passthrough_copy() -> None:
+    rows = [{"a": 1, "b": 2}]
+    out = apply_column_masks(rows, [])
+    assert out == rows
+    assert out is not rows
+    assert out[0] is not rows[0]
+
+
+def test_apply_column_masks_ignores_absent_columns() -> None:
+    rows = [{"a": 1}]
+    out = apply_column_masks(rows, ["nik"], keep=4)
+    assert out == [{"a": 1}]
+
+
+# ---------------------------------------------------------------------------
+# Positional masking (execute_oneshot shape) + govern_read
+# ---------------------------------------------------------------------------
+
+
+def test_mask_rows_masks_named_columns() -> None:
+    columns = ["customer_id", "nik", "arpu"]
+    rows = [("C-001", "3201011234567", 152000), ("C-002", "3273010000000", 98000)]
+    out = mask_rows(columns, rows, ["nik"], keep=6)
+    assert out == [
+        ("C-001", f"320101{MASK_TOKEN}", 152000),
+        ("C-002", f"327301{MASK_TOKEN}", 98000),
+    ]
+    # input not mutated
+    assert rows[0] == ("C-001", "3201011234567", 152000)
+
+
+def test_mask_rows_ignores_absent_and_empty() -> None:
+    columns = ["a", "b"]
+    rows = [(1, 2)]
+    assert mask_rows(columns, rows, []) == [(1, 2)]
+    assert mask_rows(columns, rows, ["nik"]) == [(1, 2)]
+
+
+def test_mask_rows_preserves_none() -> None:
+    assert mask_rows(["nik"], [(None,)], ["nik"], keep=4) == [(None,)]
+
+
+def test_govern_read_passthrough_when_gate_none() -> None:
+    rows = [("3201011234567",)]
+    out = govern_read(None, resource="prod.t", columns=["nik"], rows=rows)
+    assert out == [("3201011234567",)]
+
+
+def test_govern_read_masks_when_allowed() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"allowed": True, "masked_columns": ["nik"]})
+
+    out = govern_read(
+        _gate(handler),
+        resource="prod.gold.customer",
+        columns=["customer_id", "nik"],
+        rows=[("C-001", "3201011234567")],
+        keep=6,
+    )
+    assert out == [("C-001", f"320101{MASK_TOKEN}")]
+
+
+def test_govern_read_raises_when_denied() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/contracts/access-check":
+            return httpx.Response(200, json={"allowed": False, "reason": "no grant"})
+        return httpx.Response(200, json={})
+
+    with pytest.raises(AtlasPolicyDenied):
+        govern_read(
+            _gate(handler),
+            resource="prod.gold.finance",
+            columns=["x"],
+            rows=[("v",)],
+        )

--- a/tests/integrations/test_atlas_governance.py
+++ b/tests/integrations/test_atlas_governance.py
@@ -20,9 +20,11 @@ from seeknal.integrations.atlas_governance import (
     GovernanceGate,
     apply_column_masks,
     create_governance_gate_from_env,
+    govern_query,
     govern_read,
     mask_rows,
     mask_value,
+    referenced_tables,
 )
 
 BASE_URL = "http://atlas.test"
@@ -286,3 +288,75 @@ def test_govern_read_raises_when_denied() -> None:
             columns=["x"],
             rows=[("v",)],
         )
+
+
+# ---------------------------------------------------------------------------
+# referenced_tables + govern_query (ad-hoc SQL reads)
+# ---------------------------------------------------------------------------
+
+
+def test_referenced_tables_from_and_join() -> None:
+    sql = "SELECT a.id FROM prod.gold.customer a JOIN prod.gold.orders b ON a.id = b.cid"
+    assert referenced_tables(sql) == ["prod.gold.customer", "prod.gold.orders"]
+
+
+def test_referenced_tables_excludes_ctes() -> None:
+    sql = "WITH recent AS (SELECT * FROM prod.gold.orders) SELECT * FROM recent"
+    assert referenced_tables(sql) == ["prod.gold.orders"]
+
+
+def test_referenced_tables_tableless_is_empty() -> None:
+    assert referenced_tables("SELECT 1 AS one") == []
+
+
+def test_govern_query_passthrough_when_gate_none() -> None:
+    rows = [("C-001", "3201011234567")]
+    out = govern_query(
+        None,
+        sql="SELECT * FROM prod.gold.customer",
+        columns=["customer_id", "nik"],
+        rows=rows,
+    )
+    assert out == [("C-001", "3201011234567")]
+
+
+def test_govern_query_masks_referenced_table_columns() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"allowed": True, "masked_columns": ["nik"]})
+
+    out = govern_query(
+        _gate(handler),
+        sql="SELECT customer_id, nik FROM prod.gold.customer",
+        columns=["customer_id", "nik"],
+        rows=[("C-001", "3201011234567")],
+        keep=6,
+    )
+    assert out == [("C-001", f"320101{MASK_TOKEN}")]
+
+
+def test_govern_query_raises_when_a_table_denied() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/contracts/access-check":
+            return httpx.Response(200, json={"allowed": False, "reason": "no grant"})
+        return httpx.Response(200, json={})
+
+    with pytest.raises(AtlasPolicyDenied):
+        govern_query(
+            _gate(handler),
+            sql="SELECT * FROM prod.gold.finance",
+            columns=["x"],
+            rows=[("v",)],
+        )
+
+
+def test_govern_query_tableless_does_not_call_atlas() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("Atlas must not be called for a tableless query")
+
+    out = govern_query(
+        _gate(handler),
+        sql="SELECT 1 AS one",
+        columns=["one"],
+        rows=[(1,)],
+    )
+    assert out == [(1,)]

--- a/tests/integrations/test_atlas_governance.py
+++ b/tests/integrations/test_atlas_governance.py
@@ -13,6 +13,10 @@ from typing import Callable
 import httpx
 import pytest
 
+import base64
+import json
+from pathlib import Path
+
 from seeknal.integrations.atlas_client import AtlasContractConfig, AtlasPolicyDenied
 from seeknal.integrations.atlas_governance import (
     MASK_TOKEN,
@@ -25,6 +29,8 @@ from seeknal.integrations.atlas_governance import (
     mask_rows,
     mask_value,
     referenced_tables,
+    user_sub_from_credentials,
+    user_token_from_credentials,
 )
 
 BASE_URL = "http://atlas.test"
@@ -360,3 +366,106 @@ def test_govern_query_tableless_does_not_call_atlas() -> None:
         rows=[(1,)],
     )
     assert out == [(1,)]
+
+
+# ---------------------------------------------------------------------------
+# Credentials-backed user token + JWT claim extraction
+# ---------------------------------------------------------------------------
+
+
+def _b64url(data: dict[str, object]) -> str:
+    """Base64url-encode a dict as a JWT segment (no padding)."""
+
+    raw = json.dumps(data).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _unsigned_jwt(payload: dict[str, object]) -> str:
+    """Build an unsigned JWT (header.payload.sig) carrying ``payload``."""
+
+    header = _b64url({"alg": "none", "typ": "JWT"})
+    return f"{header}.{_b64url(payload)}.sig"
+
+
+def _write_creds(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, access_token: str) -> Path:
+    """Write a credentials file and point SEEKNAL_CREDENTIALS_PATH at it."""
+
+    creds = tmp_path / "credentials.json"
+    creds.write_text(
+        json.dumps(
+            {
+                "access_token": access_token,
+                "refresh_token": "r",
+                "expires_in": 3600,
+                "refresh_expires_in": 7200,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(creds))
+    return creds
+
+
+def test_gate_token_from_credentials_when_api_token_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ATLAS_API_URL", "https://atlas.example.com")
+    monkeypatch.delenv("ATLAS_API_TOKEN", raising=False)
+    _write_creds(tmp_path, monkeypatch, "user-access-token")
+
+    gate = create_governance_gate_from_env()
+    assert isinstance(gate, GovernanceGate)
+    assert gate.config.token == "user-access-token"
+
+
+def test_gate_api_token_takes_precedence_over_credentials(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ATLAS_API_URL", "https://atlas.example.com")
+    monkeypatch.setenv("ATLAS_API_TOKEN", "service-token")
+    _write_creds(tmp_path, monkeypatch, "user-access-token")
+
+    gate = create_governance_gate_from_env()
+    assert isinstance(gate, GovernanceGate)
+    assert gate.config.token == "service-token"
+
+
+def test_gate_token_none_when_credentials_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ATLAS_API_URL", "https://atlas.example.com")
+    monkeypatch.delenv("ATLAS_API_TOKEN", raising=False)
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(tmp_path / "missing.json"))
+
+    gate = create_governance_gate_from_env()
+    assert isinstance(gate, GovernanceGate)
+    assert gate.config.token is None
+
+
+def test_user_token_from_credentials_reads_access_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_creds(tmp_path, monkeypatch, "abc.def.ghi")
+    assert user_token_from_credentials() == "abc.def.ghi"
+
+
+def test_user_token_from_credentials_none_when_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(tmp_path / "missing.json"))
+    assert user_token_from_credentials() is None
+
+
+def test_user_sub_from_credentials_decodes_jwt_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    token = _unsigned_jwt({"sub": "abc-123"})
+    _write_creds(tmp_path, monkeypatch, token)
+    assert user_sub_from_credentials() == "abc-123"
+
+
+def test_user_sub_from_credentials_none_when_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(tmp_path / "missing.json"))
+    assert user_sub_from_credentials() is None

--- a/tests/workflow/test_atlas_apply_integration.py
+++ b/tests/workflow/test_atlas_apply_integration.py
@@ -11,7 +11,21 @@ from typing import Any
 import pytest
 import typer
 
+from seeknal.integrations.atlas_client import NOT_LOGGED_IN_HINT
 from seeknal.workflow.apply import apply_command
+
+
+@pytest.fixture(autouse=True)
+def _isolated_atlas_session(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the contract client away from the developer's real login session.
+
+    create_atlas_contract_client_from_env now falls back to the credentials file
+    written by `seeknal auth login`; tests must not pick up a real token.
+    """
+
+    monkeypatch.setenv("SEEKNAL_CREDENTIALS_PATH", str(tmp_path / "no-credentials.json"))
+    monkeypatch.setenv("SEEKNAL_ATLAS_CONFIG_PATH", str(tmp_path / "no-atlas.json"))
+    monkeypatch.delenv("ATLAS_API_TOKEN", raising=False)
 
 
 class _AtlasStubServer(ThreadingHTTPServer):
@@ -203,3 +217,34 @@ def test_apply_reports_local_failure_after_preflight(
     assert atlas.requests[-1]["body"]["status"] == "failed"
     assert atlas.requests[-1]["body"]["details"]["phase"] == "local-apply"
     assert atlas.requests[-1]["body"]["details"]["local_apply_completed"] is False
+
+
+def test_apply_unauthenticated_shows_login_hint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A 401 from policy-check (logged out) must tell the user to `seeknal auth login`."""
+
+    project_dir = _secure_project_dir(tmp_path)
+    draft = _write_draft(project_dir)
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setattr("seeknal.workflow.apply.update_manifest", lambda _: True)
+
+    with _atlas_stub(
+        {
+            "/api/contracts/policy-check": [
+                (401, {"detail": "Missing authentication token"}),
+            ],
+        }
+    ) as atlas:
+        monkeypatch.setenv("ATLAS_API_URL", f"http://127.0.0.1:{atlas.server_port}")
+
+        with pytest.raises(typer.Exit) as exc_info:
+            apply_command(str(draft), force=False, no_parse=False)
+
+    assert exc_info.value.exit_code == 1
+    assert not (project_dir / "seeknal" / "transforms" / "orders_enriched.yml").exists()
+    assert [request["path"] for request in atlas.requests] == ["/api/contracts/policy-check"]
+    captured = capsys.readouterr()
+    assert NOT_LOGGED_IN_HINT in captured.err + captured.out


### PR DESCRIPTION
## Summary

Consolidated 2.10.0 branch. Supersedes #74 (governance gate + gov/auth CLI) and #75 (dataset catalog CLI) — both branches are contained here in full — and adds the fixes found during real-project usage plus the gateway/Ask features.

### Atlas data-access governance (from #74)
- Config-activated runtime governance gate: with `ATLAS_API_URL` set, every governed read is access-checked (OpenFGA-backed) before data is read; fails closed. Unset → no-op, fully backward compatible.
- `seeknal auth login/status/logout` (Keycloak PKCE loopback), `seeknal gov request-access`, governed Ask SQL with column masking.

### Dataset catalog CLI (from #75)
- `seeknal dataset list/show/query/lineage/use/annotate` backed by the Atlas portal catalog, REPL integration, governed browse/preview, one-command setup (`auth config` / `login --host`).

### New on top of the closed PRs
- **fix(atlas): apply preflight authenticates with the logged-in user's token** — `seeknal apply` no longer fails with `{"detail":"Missing authentication token"}` after a successful login. The contract client now resolves the token like the governance gate (explicit `ATLAS_API_TOKEN` wins, else the stored user token), transparently refreshes once on HTTP 401 and retries, persists rotated tokens, and surfaces an actionable `seeknal auth login` hint when logged out / expired.
- **fix(packaging): heartbeat module now ships** — `src/seeknal/cli/heartbeat.py` and most of `src/seeknal/heartbeat/` were never committed, so published wheels crashed (`ModuleNotFoundError: seeknal.cli.heartbeat` on v2.9.7) or silently lacked the feature. Also tracks the lazily-imported `workflow/manifest_builder.py` and `iceberg/ingest_writer.py`; optional command groups are import-guarded.
- **feat(atlas)**: DataHub-backed `atlas lineage show`, `dataset annotate --term/--domain`, owners/column metadata forwarded at apply time, standalone `publish_lineage`.
- **feat(ask)**: access policy package + `seeknal admin` approval queue, `extract_finance_document` / `write_seeknal_project_asset` agent tools, `prepare-seeknal-project` builtin skill.
- **feat(gateway)**: image attachments on `/ask` for vision OCR; generic file ingestion with tabular staging.
- Changelog updated under `[2.10.0]`.

## Verification
- 202 tests passing across the touched suites (atlas client/governance/catalog, apply integration, dataset CLI, admin/access, ask tools); 142 heartbeat tests; 11 new tests pin the auth fix.
- Release-build simulation: wheel built from `git archive` (tracked files only) contains the heartbeat modules; `seeknal --version` and `seeknal heartbeat --help` work from a clean venv install.
- Real-project E2E in tmux on the committed code:
  - **Without Atlas (majority case)**: init → draft → dry-run → apply → plan → run → heartbeat tick, all green with zero Atlas involvement — including when a leftover credentials file exists.
  - **With Atlas** (stub backend enforcing bearer auth): logged-out apply exits 1 with the login hint; logged-in apply succeeds; expired-token apply transparently refreshes, retries, and rotates the on-disk credentials; governed `seeknal run` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)