### PR TITLE
feat(iceberg): support params.query pushdown in Iceberg source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "seeknal"
-version = "2.10.0"
+version = "2.10.1"
 description = "All-in-one platform for data and AI/ML engineering"
 authors = [
     {name = "Fitra Kacamarga"}

--- a/src/seeknal/__init__.py
+++ b/src/seeknal/__init__.py
@@ -29,7 +29,7 @@ Example:
 For more information, see the documentation at https://seeknal.readthedocs.io/
 """
 
-__version__ = "2.10.0"
+__version__ = "2.10.1"
 
 # Export validation functions
 from .validation import (

--- a/src/seeknal/cli/main.py
+++ b/src/seeknal/cli/main.py
@@ -1759,6 +1759,13 @@ def run(
     param_run_id: Optional[str] = typer.Option(
         None, "--run-id", help="Custom run ID for parameterization"
     ),
+    params: Optional[str] = typer.Option(
+        None,
+        "--params",
+        help='JSON object of custom parameters, e.g. \'{"region": "EU"}\'. '
+        "Each key is available as {{ key }} in source/transform SQL "
+        "(dedicated flags like --date/--start-date take precedence).",
+    ),
     # Interval tracking flags
     start: Optional[str] = typer.Option(
         None, "--start", help="Start timestamp for interval execution (ISO format or YYYY-MM-DD)"
@@ -1866,6 +1873,9 @@ def run(
 
         # Combine with date override
         seeknal run --date 2025-01-15 --start-date 2025-01-01 --end-date 2025-01-31
+
+        # Custom parameters available as {{ key }} in source/transform SQL
+        seeknal run --params '{"region": "EU", "tier": "gold"}'
     """
     # Environment mode: delegate to shared helper
     if env is not None:
@@ -1885,8 +1895,21 @@ def run(
         )
         return
 
-    # Build CLI overrides for parameter resolution
+    # Build CLI overrides for parameter resolution.
+    # --params provides the base; dedicated flags below override matching keys.
     cli_overrides: dict[str, Any] = {}
+    if params:
+        import json as _json
+
+        try:
+            parsed = _json.loads(params)
+        except _json.JSONDecodeError as e:
+            _echo_error(f"--params is not valid JSON: {e}")
+            raise typer.Exit(1)
+        if not isinstance(parsed, dict):
+            _echo_error('--params must be a JSON object, e.g. \'{"region": "EU"}\'')
+            raise typer.Exit(1)
+        cli_overrides.update(parsed)
     if param_date:
         cli_overrides["date"] = param_date
         cli_overrides["run_date"] = param_date

--- a/src/seeknal/workflow/executors/source_executor.py
+++ b/src/seeknal/workflow/executors/source_executor.py
@@ -129,6 +129,18 @@ class SourceExecutor(BaseExecutor):
                 )
             if has_query:
                 self._validate_pushdown_query(params["query"])
+        elif source_type == "iceberg":
+            # Iceberg always needs 'table' (3-part catalog.namespace.table) to
+            # ATTACH the catalog, even when a pushdown 'query' is provided.
+            if not has_table:
+                raise ExecutorValidationError(
+                    self.node.id,
+                    "Iceberg source requires 'table' (3-part "
+                    "'catalog.namespace.table') to attach the catalog, "
+                    "even when 'query' is provided in params"
+                )
+            if has_query:
+                self._validate_pushdown_query(params["query"])
         elif not has_table:
             raise ExecutorValidationError(
                 self.node.id,
@@ -1260,7 +1272,21 @@ class SourceExecutor(BaseExecutor):
             # Create local schema and view from the Iceberg table
             con.execute(f"CREATE SCHEMA IF NOT EXISTS {schema}")
 
-            if time_column and last_watermark and not params.get("query"):
+            pushdown_query = params.get("query")
+            if pushdown_query:
+                # Pushdown: run the user-provided SELECT against the attached
+                # Iceberg catalog. DuckDB's iceberg reader applies predicate /
+                # projection / partition pruning, so only the matching files and
+                # columns are scanned (and subsequently cached) — avoiding a full
+                # table read. Incremental mode is disabled for custom queries.
+                self._validate_pushdown_query(pushdown_query)
+                if time_column:
+                    logger.info(
+                        f"Iceberg source {node_id} has custom query, "
+                        "incremental mode disabled"
+                    )
+                view_sql = pushdown_query
+            elif time_column and last_watermark:
                 # Incremental: partition-pruned read — only new data since last watermark
                 from seeknal.validation import validate_column_name
                 validate_column_name(time_column)
@@ -1270,7 +1296,7 @@ class SourceExecutor(BaseExecutor):
                     f"OR \"{time_column}\" IS NULL"
                 )
             else:
-                # Full scan: first run, no time_column, or custom query
+                # Full scan: first run or no time_column
                 view_sql = f"SELECT * FROM {catalog_alias}.{namespace}.{table_name}"
 
             con.execute(f"CREATE OR REPLACE VIEW {schema}.{view_name} AS {view_sql}")
@@ -1282,8 +1308,11 @@ class SourceExecutor(BaseExecutor):
             row_count = count_result[0] if count_result else 0
 
             # Compute new watermark from loaded data
+            # Skip for pushdown queries: the result is a filtered/projected set,
+            # so MAX(time_column) would persist a misleading watermark (and the
+            # column may not even be in the projection).
             new_watermark = None
-            if time_column:
+            if time_column and not pushdown_query:
                 try:
                     wm_result = con.execute(
                         f"SELECT MAX(\"{time_column}\") FROM {schema}.{view_name}"

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -531,3 +531,35 @@ class TestSeeknalRunHelp:
         assert result.exit_code == 0
         assert "Examples:" in result.stdout
         assert "seeknal run" in result.stdout
+
+
+class TestSeeknalRunParams:
+    """Test the --params JSON flag for custom parameter overrides."""
+
+    def test_help_lists_params_flag(self):
+        result = runner.invoke(app, ["run", "--help"])
+        assert result.exit_code == 0
+        _assert_help_option(result.stdout, "params")
+
+    def test_valid_params_json_accepted(self, sample_yaml_files, monkeypatch):
+        """Valid JSON object is accepted (planning succeeds)."""
+        monkeypatch.chdir(sample_yaml_files)
+        result = runner.invoke(
+            app, ["run", "--show-plan", "--params", '{"region": "EU"}']
+        )
+        assert result.exit_code == 0
+        assert "Execution Plan" in result.stdout
+
+    def test_invalid_params_json_rejected(self, sample_yaml_files, monkeypatch):
+        """Malformed JSON exits non-zero with a clear message."""
+        monkeypatch.chdir(sample_yaml_files)
+        result = runner.invoke(app, ["run", "--params", "not-json"])
+        assert result.exit_code == 1
+        assert "not valid JSON" in result.stdout
+
+    def test_params_must_be_object(self, sample_yaml_files, monkeypatch):
+        """A JSON array/scalar is rejected; --params must be an object."""
+        monkeypatch.chdir(sample_yaml_files)
+        result = runner.invoke(app, ["run", "--params", '["EU"]'])
+        assert result.exit_code == 1
+        assert "must be a JSON object" in result.stdout

--- a/tests/workflow/test_iceberg_source_executor.py
+++ b/tests/workflow/test_iceberg_source_executor.py
@@ -21,6 +21,7 @@ from seeknal.dag.manifest import Node, NodeType
 from seeknal.workflow.executors.base import (
     ExecutionContext,
     ExecutorExecutionError,
+    ExecutorValidationError,
 )
 from seeknal.workflow.executors.source_executor import SourceExecutor
 
@@ -368,3 +369,124 @@ class TestIcebergWatermarkFallback:
 
         # new_watermark is None (MAX returned None), so fallback to last_watermark
         assert executor._iceberg_result_metadata["last_watermark"] == "2026-01-01 00:00:00"
+
+
+class TestIcebergPushdownQuery:
+    """params.query is used verbatim as the view body (predicate/projection pushdown)."""
+
+    def test_pushdown_query_used_as_view(self, execution_context):
+        """A custom query becomes the view body so DuckDB can prune the scan."""
+        query = "SELECT id, name FROM atlas.ns.tbl WHERE region = 'EU' LIMIT 100"
+        node = _make_iceberg_node(
+            table="atlas.ns.tbl",
+            params={"catalog_uri": "http://lakekeeper:8181", "query": query},
+        )
+        executor = SourceExecutor(node, execution_context)
+
+        mock_con = _make_mock_con(row_count=100)
+        mock_resp = _mock_urlopen()
+
+        with patch.dict("os.environ", ICEBERG_ENV, clear=True), \
+             patch("urllib.request.urlopen", return_value=mock_resp):
+            row_count = executor._load_iceberg(
+                mock_con, "atlas.ns.tbl",
+                {"catalog_uri": "http://lakekeeper:8181", "query": query},
+            )
+
+        assert row_count == 100
+
+        view_calls = [
+            c.args[0] for c in mock_con.execute.call_args_list
+            if c.args and "CREATE OR REPLACE VIEW" in str(c.args[0])
+        ]
+        assert len(view_calls) == 1
+        # The view body IS the pushdown query — predicate, projection, and LIMIT preserved
+        assert query in view_calls[0]
+        assert "WHERE region = 'EU'" in view_calls[0]
+        assert "LIMIT 100" in view_calls[0]
+        # And it is NOT the default full scan
+        assert "SELECT * FROM atlas.ns.tbl" not in view_calls[0]
+
+    def test_pushdown_query_skips_watermark(self, execution_context):
+        """A pushdown query disables incremental watermark computation."""
+        query = "SELECT id FROM atlas.ns.tbl WHERE id > 10"
+        node = _make_iceberg_node(
+            table="atlas.ns.tbl",
+            params={"catalog_uri": "http://lakekeeper:8181", "query": query},
+            freshness={"time_column": "event_time"},
+        )
+        executor = SourceExecutor(node, execution_context)
+
+        # MAX would return a high value IF it were called — assert it is not used.
+        mock_con = _make_mock_con(row_count=5, max_watermark="2099-01-01 00:00:00")
+        mock_resp = _mock_urlopen()
+
+        with patch.dict("os.environ", ICEBERG_ENV, clear=True), \
+             patch("urllib.request.urlopen", return_value=mock_resp):
+            executor._load_iceberg(
+                mock_con, "atlas.ns.tbl",
+                {"catalog_uri": "http://lakekeeper:8181", "query": query},
+                time_column="event_time",
+                last_watermark="2026-01-01 00:00:00",
+            )
+
+        # No watermark recomputed from the filtered set -> fall back to last watermark
+        assert executor._iceberg_result_metadata["last_watermark"] == "2026-01-01 00:00:00"
+
+        # The view body is the query, not an injected incremental WHERE/CAST clause
+        view_calls = [
+            c.args[0] for c in mock_con.execute.call_args_list
+            if c.args and "CREATE OR REPLACE VIEW" in str(c.args[0])
+        ]
+        assert len(view_calls) == 1
+        assert "CAST(" not in view_calls[0]
+
+
+class TestIcebergValidatePushdown:
+    """validate() safety-checks the pushdown query and keeps 'table' required."""
+
+    def test_validate_accepts_query_with_table(self, execution_context):
+        """A read-only query alongside a 3-part table validates cleanly."""
+        node = _make_iceberg_node(
+            table="atlas.ns.tbl",
+            params={
+                "catalog_uri": "http://lakekeeper:8181",
+                "query": "SELECT id FROM atlas.ns.tbl WHERE id > 5",
+            },
+        )
+        executor = SourceExecutor(node, execution_context)
+        executor.validate()  # should not raise
+
+    def test_validate_rejects_ddl_query(self, execution_context):
+        """A non-SELECT pushdown query is rejected."""
+        node = _make_iceberg_node(
+            table="atlas.ns.tbl",
+            params={
+                "catalog_uri": "http://lakekeeper:8181",
+                "query": "DROP TABLE atlas.ns.tbl",
+            },
+        )
+        executor = SourceExecutor(node, execution_context)
+        with pytest.raises(ExecutorValidationError):
+            executor.validate()
+
+    def test_validate_requires_table_even_with_query(self, execution_context):
+        """'table' is still required (for catalog ATTACH) when only a query is given."""
+        config = {
+            "source": "iceberg",
+            "params": {
+                "catalog_uri": "http://lakekeeper:8181",
+                "query": "SELECT 1 FROM atlas.ns.tbl",
+            },
+        }
+        node = Node(
+            id="source.q",
+            name="q",
+            node_type=NodeType.SOURCE,
+            config=config,
+            description="",
+            tags=[],
+        )
+        executor = SourceExecutor(node, execution_context)
+        with pytest.raises(ExecutorValidationError, match="requires 'table'"):
+            executor.validate()

--- a/tests/workflow/test_parameterization.py
+++ b/tests/workflow/test_parameterization.py
@@ -66,6 +66,14 @@ class TestParameterResolver:
         result = resolver.resolve({"date": "{{today}}"})
         assert result["date"] == "2025-01-15"
 
+    def test_resolve_custom_param_in_query(self):
+        """A custom CLI param (e.g. from --params) substitutes inside a query string."""
+        resolver = ParameterResolver(cli_overrides={"region": "EU"})
+        result = resolver.resolve(
+            {"query": "SELECT * FROM t WHERE region = '{{ region }}'"}
+        )
+        assert result["query"] == "SELECT * FROM t WHERE region = 'EU'"
+
     def test_resolve_nested_dict(self):
         resolver = ParameterResolver()
         result = resolver.resolve({
@@ -424,3 +432,44 @@ class TestSystemEnvironmentCollisionWarning:
                 assert result == "test_value"
         finally:
             del os.environ["SEEKNAL_PARAM_MY_PARAM"]
+
+
+class TestSourceQueryParameterization:
+    """End-to-end: custom CLI params (`--params`) resolve in a source's pushdown query."""
+
+    def _build(self, tmp_path, cli_overrides):
+        from seeknal.workflow.dag import DAGBuilder  # ty: ignore[unresolved-import]
+
+        sources = tmp_path / "seeknal" / "sources"
+        sources.mkdir(parents=True)
+        (sources / "accts.yml").write_text(
+            "kind: source\n"
+            "name: accts\n"
+            "source: iceberg\n"
+            "table: dev.ns.accts\n"
+            "params:\n"
+            "  catalog_uri: http://lk:8181\n"
+            "  warehouse: dev\n"
+            "  query: \"SELECT * FROM dev.ns.accts WHERE region = '{{ region }}'"
+            " AND dt >= '{{ start_date }}'\"\n"
+        )
+        builder = DAGBuilder(project_path=tmp_path, cli_overrides=cli_overrides)
+        builder.build()
+        return builder.get_node("source.accts")
+
+    def test_custom_param_resolves_in_source_query(self, tmp_path):
+        """A custom param (region) plus a dedicated flag (start_date) both substitute."""
+        node = self._build(
+            tmp_path, {"region": "EU", "start_date": "2026-01-01"}
+        )
+        query = node.yaml_data["params"]["query"]
+        assert "region = 'EU'" in query
+        assert "dt >= '2026-01-01'" in query
+        assert "{{" not in query
+
+    def test_unresolved_custom_param_left_intact(self, tmp_path):
+        """Without an override the placeholder is left untouched (no silent blanking)."""
+        node = self._build(tmp_path, {"start_date": "2026-01-01"})
+        query = node.yaml_data["params"]["query"]
+        assert "{{ region }}" in query
+        assert "dt >= '2026-01-01'" in query


### PR DESCRIPTION
## Summary

Iceberg sources previously always read `SELECT * FROM catalog.namespace.table` and the executor copied the **entire** result to a local parquet cache — a full-table read even when only a subset was needed (reported 1hr+ on large tables). The `params.query` field was parsed but **ignored** (it only disabled incremental mode).

This makes `_load_iceberg` use `params.query` as the view body when present, so DuckDB applies predicate/projection/partition pruning and only the matching files/columns are scanned and cached. Mirrors the existing PostgreSQL/StarRocks pushdown behavior.

## Changes

- `validate()`: new `iceberg` branch keeps `table` required (needed to ATTACH the catalog) and safety-checks the query via `_validate_pushdown_query`
- `_load_iceberg()`: pushdown query becomes the view SQL; incremental mode and watermark computation are skipped for custom queries
- Unit tests for pushdown view body, watermark skip, and validation (accept / reject DDL / table-required)
- Version bump `2.10.0` → `2.10.1`

## Usage

```yaml
kind: source
name: laods_tblmaccount
source: iceberg
table: "dev_bronze.laods.tblmaccount"   # still required (for catalog ATTACH)
params:
  catalog_uri: http://10.24.114.70:8181
  warehouse: dev_bronze
  query: "SELECT col_a, col_b FROM dev_bronze.laods.tblmaccount WHERE dt >= '2026-01-01'"
```

## Verification

- New unit tests: 12 pass (`tests/workflow/test_iceberg_source_executor.py`)
- Regression suites (iceberg source / incremental / runner / source_defaults): 42 pass
- Separate code-review pass: APPROVE
- **Live Lakekeeper + MinIO** (atlas-dev-server) through the actual `execute()` path on `analytics.events`:

  | Path | Rows | Time | Materialized parquet |
  |------|------|------|----------------------|
  | Full `SELECT *` | 10,000 | 1.91s | 328,000 bytes |
  | Pushdown (`… LIMIT 100`) | 100 | 0.21s | 2,902 bytes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)