### PR TITLE
feat(upload-to-s3): CSV export tool + gateway no-return wiring

### DIFF
--- a/src/seeknal/ask/agents/hooks.py
+++ b/src/seeknal/ask/agents/hooks.py
@@ -9,6 +9,7 @@ wires it into pydantic-deep's hook lifecycle.
 
 import json
 import logging
+import os
 import re
 
 from pydantic_deep.capabilities.hooks import Hook, HookEvent, HookInput, HookResult
@@ -151,6 +152,63 @@ def _enrich_syntax_hint(message: str, existing_hint: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# POST_TOOL_USE: CSV upload reminder (FC2d)
+# ---------------------------------------------------------------------------
+
+# Reminder threshold (module-level — HookInput carries no config object).
+_CSV_REMINDER_MIN_ROWS = int(os.environ.get("SEEKNAL_CSV_REMINDER_MIN_ROWS", "20"))
+
+# Count markdown-table data rows: lines like "| 123 | ..." (skip separators).
+_TABLE_ROW_RE = re.compile(r"^\|\s*[^:\-][^|]*\|", re.MULTILINE)
+
+
+def _count_result_rows(tool_result: str) -> int:
+    """Best-effort row count from an execute_sql markdown table result.
+
+    execute_sql returns a markdown table; data rows match the pattern while
+    separator rows (``|---|``) and the "N rows" footer do not. The header row
+    DOES match the pattern, so when a separator is present (the standard
+    execute_sql shape) we subtract it. Returns 0 on any parse trouble — the
+    hook then no-ops (safe default).
+    """
+    if not tool_result:
+        return 0
+    try:
+        matches = _TABLE_ROW_RE.findall(tool_result)
+        has_separator = bool(re.search(r"^\|[\s:\-]+\|", tool_result, re.MULTILINE))
+        count = len(matches)
+        if has_separator and count > 0:
+            count -= 1  # exclude the header row
+        return max(0, count)
+    except TypeError:
+        return 0
+
+
+async def _csv_upload_reminder_handler(hook_input: HookInput) -> HookResult:
+    """Nudge the agent to offer upload_to_s3 when execute_sql returns many rows.
+
+    Reminder ONLY — never enforces. Appends a short hint to the tool result via
+    ``modified_result``; the agent decides whether to act on it. Triggers on
+    ``execute_sql`` exclusively. Independent of ``_sql_self_correction_handler``
+    (different condition; both run).
+    """
+    try:
+        if hook_input.tool_name != "execute_sql" or not hook_input.tool_result:
+            return HookResult()
+        rows = _count_result_rows(hook_input.tool_result)
+        if rows < _CSV_REMINDER_MIN_ROWS:
+            return HookResult()
+        nudge = (
+            f"\n\n_({rows} rows returned — consider offering "
+            f"`upload_to_s3(filename=..., sql=...)` if the user wants a CSV export.)_"
+        )
+        return HookResult(modified_result=hook_input.tool_result + nudge)
+    except Exception:  # noqa: BLE001 - a hook must never propagate failures
+        logger.exception("[csv_reminder_hook] unexpected error; passing through")
+        return HookResult()
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -161,6 +219,7 @@ def get_ask_hooks(config: dict | None = None) -> list[Hook]:
     Includes:
     - PRE_TOOL_USE: SQL security validation
     - POST_TOOL_USE: SQL self-correction hints
+    - POST_TOOL_USE: CSV upload reminder (FC2d, execute_sql only)
     """
     cfg = config or {}
     if cfg.get("enabled", True) is False:
@@ -180,6 +239,14 @@ def get_ask_hooks(config: dict | None = None) -> list[Hook]:
             Hook(
                 event=HookEvent.POST_TOOL_USE,
                 handler=_sql_self_correction_handler,
+                matcher="execute_sql",
+            )
+        )
+    if cfg.get("csv_upload_reminder", True):
+        hooks.append(
+            Hook(
+                event=HookEvent.POST_TOOL_USE,
+                handler=_csv_upload_reminder_handler,
                 matcher="execute_sql",
             )
         )

--- a/src/seeknal/ask/agents/tools/_context.py
+++ b/src/seeknal/ask/agents/tools/_context.py
@@ -91,6 +91,11 @@ class ToolContext:
     # mode. The gateway streaming layer emits these prompts as an ``ask_user``
     # event and ends the turn. ``None`` means no clarification is pending.
     pending_clarification: list[dict[str, Any]] | None = None
+    # FC2d: pending CSV download. Set by upload_to_s3 (and run_forecast's
+    # optional CSV step). The gateway streaming layer emits an
+    # ``upload_complete`` event and CONTINUES the turn — unlike
+    # pending_clarification which ends it. ``None`` means no upload is pending.
+    pending_upload: dict[str, Any] | None = None
 
 
 def _make_registry():
@@ -412,6 +417,7 @@ def reset_turn_governor(question: str | None = None) -> None:
     ctx.authoritative_drift_attempts_this_turn = 0
     ctx.timing_events_this_turn.clear()
     ctx.pending_clarification = None
+    ctx.pending_upload = None
 
 
 def get_discovery_cache_value(key: str) -> Any | None:

--- a/src/seeknal/ask/agents/tools/upload_to_s3.py
+++ b/src/seeknal/ask/agents/tools/upload_to_s3.py
@@ -1,0 +1,129 @@
+"""upload_to_s3 — export a query result to a downloadable CSV.
+
+Generic SQL→CSV export via the IBA object store (SeaweedFS through iba-storage's
+v26.7.0 presigned-URL flow). The agent provides Raw SQL only; the tool executes
+it internally, serializes the result set to CSV, uploads it, and registers a
+``pending_upload`` so the gateway streaming layer emits an ``upload_complete``
+event (the frontend renders a Download button).
+
+``expires_at`` is sourced VERBATIM from the server response
+(``download_url_expires_at``, a Unix int, via the W13-B update PR #154) and
+converted to ISO 8601. The tool holds no local TTL constant.
+
+Domain-neutral (``AGENTS.md``): the SQL is the agent's responsibility; the tool
+contains no domain-specific strings.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+_IBA_STORAGE_URL = os.environ.get("IBA_STORAGE_URL", "http://iba-storage:8000")
+_IBA_STORAGE_API_KEY = os.environ.get("IBA_STORAGE_API_KEY", "")
+
+
+def upload_to_s3(filename: str, sql: str) -> str:
+    """Export a query result to a downloadable CSV via the IBA object store.
+
+    Executes the caller-supplied SQL via ``ctx.repl.execute_oneshot``,
+    serializes the result set to CSV, uploads it to SeaweedFS through the
+    v26.7.0 presigned-URL flow (iba-storage), and registers the download link
+    so the gateway can emit an ``upload_complete`` event (the frontend renders
+    a Download button).
+
+    The agent provides Raw SQL only — the tool does the execution internally.
+    Column names become the CSV header.
+
+    Args:
+        filename: Download filename, e.g. ``"registrations-2026.csv"``. The
+            storage key is namespaced ``csv-exports/{uuid}/{filename}``;
+            collisions are impossible.
+        sql: SELECT to execute and export. Column names become the CSV header.
+            Keep the result set reasonable (the presigned PUT has an 8h TTL but
+            very large uploads hurt latency).
+
+    Returns:
+        ``"Upload complete. Download (valid 8h): https://..."`` on success.
+        On storage-unreachable / PUT-failure, an error string describing the
+        failure (the agent should surface it, not retry silently).
+    """
+    from seeknal.ask.agents.tools._context import get_tool_context, record_tool_result
+    from seeknal.ask.agents.tools.execute_sql import _execute_oneshot_with_timeout
+
+    ctx = get_tool_context()
+
+    # STEP 1: EXECUTE the caller's SQL (tool does SQL internally — agent
+    # provides Raw SQL only).
+    columns, rows = _execute_oneshot_with_timeout(ctx, sql, limit=ctx.request_limit)
+
+    # STEP 2: BUILD CSV (header from columns; no metadata rows mixed in).
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(columns)
+    writer.writerows(rows)
+    csv_bytes = buf.getvalue().encode("utf-8")
+    if not rows:
+        record_tool_result("upload_to_s3", "empty", args={"filename": filename})
+        return "No rows to export."
+
+    # STEP 3: presigned URLs + server-computed expiry (W13-B update, PR #154).
+    # NOTE: iba-storage mounts the internal router under ``/api`` (main.py:
+    # ``app.include_router(internal_router, prefix="/api")``), so the full path
+    # is ``/api/v1/internal/get-upload-url`` — not ``/v1/...``.
+    try:
+        resp = httpx.post(
+            f"{_IBA_STORAGE_URL}/api/v1/internal/get-upload-url",
+            json={"filename": filename, "content_type": "text/csv"},
+            headers={"X-API-Key": _IBA_STORAGE_API_KEY},
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        urls = resp.json()
+    except httpx.RequestError:
+        record_tool_result("upload_to_s3", "error", args={"filename": filename})
+        return "Storage unavailable (timeout or connection failed)."
+    except httpx.HTTPStatusError as exc:
+        record_tool_result("upload_to_s3", "error", args={"filename": filename})
+        return f"Failed to obtain presigned URL: HTTP {exc.response.status_code}."
+
+    # STEP 4: PUT the CSV to SeaweedFS via the presigned URL (do this promptly
+    # — the upload_url expires at urls["upload_url_expires_at"]).
+    try:
+        put = httpx.put(
+            urls["upload_url"],
+            content=csv_bytes,
+            headers={"Content-Type": "text/csv"},
+            timeout=60.0,
+        )
+        put.raise_for_status()
+    except httpx.HTTPError:
+        record_tool_result("upload_to_s3", "error", args={"filename": filename})
+        return "CSV upload failed (SeaweedFS rejected the write)."
+
+    # STEP 5: register pending_upload — gateway loop emits upload_complete.
+    # expires_at is sourced VERBATIM from the server response
+    # (download_url_expires_at, a Unix int) and converted to ISO 8601 because
+    # the frontend types `expires_at: string`. No local `now + 8h` computation.
+    try:
+        expires_at = datetime.fromtimestamp(
+            int(urls["download_url_expires_at"]), tz=timezone.utc
+        ).isoformat()
+    except (KeyError, TypeError, ValueError):
+        expires_at = ""
+
+    ctx.pending_upload = {
+        "download_url": urls.get("download_url", ""),
+        "file_name": filename,
+        "file_size": len(csv_bytes),
+        "expires_at": expires_at,
+        "object_name": urls.get("object_name", ""),
+    }
+
+    record_tool_result("upload_to_s3", urls.get("download_url", ""), args={"filename": filename})
+    return f"Upload complete. Download (valid 8h): {urls.get('download_url', '')}"

--- a/src/seeknal/ask/gateway/server.py
+++ b/src/seeknal/ask/gateway/server.py
@@ -549,6 +549,16 @@ async def _run_agent_inner(
                     yield {"type": "ask_user", "data": {"prompts": _prompts}}
                     return
 
+                # CSV upload emission (FC2d). Unlike pending_clarification
+                # (which ends the turn with `return`), this MUST NOT return —
+                # the agent still has to present its answer after the upload.
+                # Emit + clear + fall through so the turn continues.
+                if ctx.pending_upload:
+                    _upload = ctx.pending_upload
+                    ctx.pending_upload = None
+                    yield {"type": "upload_complete", "data": _upload}
+                    # deliberately NO return — continue the turn
+
                 if isinstance(node, UserPromptNode):
                     continue
 

--- a/tests/ask/test_csv_reminder_hook.py
+++ b/tests/ask/test_csv_reminder_hook.py
@@ -1,0 +1,64 @@
+"""Tests for the POST_TOOL_USE CSV upload reminder hook (FC2d)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from seeknal.ask.agents.hooks import (
+    _count_result_rows,
+    _csv_upload_reminder_handler,
+    get_ask_hooks,
+)
+
+
+def _make_result(rows: int) -> str:
+    header = "| id | value |\n|---|---|\n"
+    body = "".join(f"| {i} | {i * 10} |\n" for i in range(rows))
+    return header + body
+
+
+class _HI:
+    def __init__(self, tool_name: str, tool_result: str):
+        self.tool_name = tool_name
+        self.tool_result = tool_result
+
+
+def test_count_rows_parses_markdown_table():
+    assert _count_result_rows(_make_result(25)) == 25
+    assert _count_result_rows(_make_result(5)) == 5
+    assert _count_result_rows("") == 0
+
+
+def test_reminder_appended_when_above_threshold():
+    result = asyncio.run(_csv_upload_reminder_handler(_HI("execute_sql", _make_result(30))))
+    assert result.modified_result is not None
+    assert "upload_to_s3" in result.modified_result
+    assert "30 rows" in result.modified_result
+
+
+def test_no_reminder_below_threshold():
+    result = asyncio.run(_csv_upload_reminder_handler(_HI("execute_sql", _make_result(10))))
+    assert result.modified_result is None
+
+
+def test_no_reminder_for_non_execute_sql():
+    result = asyncio.run(_csv_upload_reminder_handler(_HI("preview_query", _make_result(100))))
+    assert result.modified_result is None
+
+
+def test_hook_registered_in_get_ask_hooks():
+    from seeknal.ask.agents.hooks import _csv_upload_reminder_handler
+
+    hooks = get_ask_hooks({"enabled": True})
+    handlers = [h.handler for h in hooks]
+    assert _csv_upload_reminder_handler in handlers
+
+
+def test_hook_gated_by_config():
+    from seeknal.ask.agents.hooks import _csv_upload_reminder_handler
+
+    hooks = get_ask_hooks({"enabled": True, "csv_upload_reminder": False})
+    handlers = [h.handler for h in hooks]
+    assert _csv_upload_reminder_handler not in handlers

--- a/tests/ask/test_hooks.py
+++ b/tests/ask/test_hooks.py
@@ -292,9 +292,10 @@ class TestSqlSelfCorrectionHook:
 
 
 class TestGetAskHooks:
-    def test_returns_two_hooks(self):
+    def test_returns_three_hooks(self):
+        # PRE sql_security + POST sql_self_correction + POST csv_upload_reminder
         hooks = get_ask_hooks()
-        assert len(hooks) == 2
+        assert len(hooks) == 3
 
     def test_first_hook_is_pre_tool_use(self):
         hooks = get_ask_hooks()

--- a/tests/ask/test_pending_upload_gateway.py
+++ b/tests/ask/test_pending_upload_gateway.py
@@ -1,0 +1,163 @@
+"""Tests for the pending_upload ToolContext field + reset (FC2d gateway contract).
+
+The gateway streaming loop emits ``upload_complete`` when ``ctx.pending_upload``
+is set and CONTINUES the turn (no ``return``), unlike ``pending_clarification``
+which ends the turn. The most important testable property is the anti-leak
+guarantee: ``reset_turn_governor`` must clear ``pending_upload`` between turns
+so a stale upload from turn N does not re-emit in turn N+1.
+
+The gateway no-return behavior itself is verified by code inspection in
+``gateway/server.py`` (deliberate comment + absence of ``return`` after the
+emit-and-clear block); a full streaming integration test is out of scope here
+because it would require standing up the complete gateway request path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import duckdb
+import pytest
+
+from seeknal.ask.agents.tools._context import (
+    ToolContext,
+    reset_turn_governor,
+    set_tool_context,
+)
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+class _REPLStub:
+    def __init__(self) -> None:
+        self.conn = duckdb.connect(":memory:")
+
+    def execute_oneshot(self, sql, limit=None):
+        return [], []
+
+
+def _ctx(tmp_path: Path) -> ToolContext:
+    ctx = ToolContext(
+        repl=_REPLStub(),
+        artifact_discovery=MagicMock(),
+        project_path=tmp_path,
+        sql_timeout_seconds=0,
+    )
+    set_tool_context(ctx)
+    return ctx
+
+
+def test_reset_turn_governor_clears_pending_upload(tmp_path: Path):
+    ctx = _ctx(tmp_path)
+    ctx.pending_upload = {"download_url": "http://x/file.csv", "file_name": "f.csv"}
+    assert ctx.pending_upload is not None  # set in turn N
+
+    reset_turn_governor(question="next question")  # turn N+1 begins
+
+    assert ctx.pending_upload is None  # anti-leak: stale upload cleared
+
+
+def test_reset_turn_governor_clears_pending_clarification_too(tmp_path: Path):
+    ctx = _ctx(tmp_path)
+    ctx.pending_clarification = [{"question": "q?"}]
+    ctx.pending_upload = {"download_url": "http://x/f.csv"}
+
+    reset_turn_governor(question="next")
+
+    assert ctx.pending_clarification is None
+    assert ctx.pending_upload is None
+
+
+def test_pending_upload_field_defaults_none(tmp_path: Path):
+    ctx = _ctx(tmp_path)
+    assert ctx.pending_upload is None
+
+
+# ---------------------------------------------------------------------------
+# No-return control-flow contract (FC2d gateway block).
+#
+# The gateway streaming loop yields ``upload_complete`` when
+# ``ctx.pending_upload`` is set and CONTINUES the turn (deliberate absence of
+# ``return``), unlike ``pending_clarification`` which ends the turn. A full
+# streaming integration needs a real LLM agent; this test exercises the actual
+# control-flow structure (a faithful replica of the gateway block in
+# ``server.py``) to prove the contract: BOTH upload_complete AND a subsequent
+# answer event are yielded from the same turn.
+# ---------------------------------------------------------------------------
+
+
+async def _gateway_loop_replica(ctx, nodes):
+    """Faithful replica of the server.py pending_* block inside the run loop.
+
+    Mirrors ``seeknal/ask/gateway/server.py``: pending_clarification ends the
+    turn with ``return``; pending_upload emits and falls through.
+    """
+    for node in nodes:
+        # A tool executed during this node may have set pending state.
+        node_hook = node.get("on_enter")
+        if node_hook:
+            node_hook(ctx)
+
+        if ctx.pending_clarification:
+            _prompts = ctx.pending_clarification
+            ctx.pending_clarification = None
+            yield {"type": "ask_user", "data": {"prompts": _prompts}}
+            return  # clarification ENDS the turn
+
+        if ctx.pending_upload:
+            _upload = ctx.pending_upload
+            ctx.pending_upload = None
+            yield {"type": "upload_complete", "data": _upload}
+            # deliberately NO return — continue the turn
+
+        if node.get("answer"):
+            yield {"type": "message", "data": {"text": node["answer"]}}
+
+        if node.get("final"):
+            yield {"type": "done", "data": {}}
+
+
+@pytest.mark.asyncio
+async def test_upload_complete_does_not_end_turn(tmp_path: Path):
+    """upload_complete is yielded AND the answer still follows (no-return)."""
+    import asyncio
+
+    ctx = _ctx(tmp_path)
+
+    def set_upload(ctx):
+        ctx.pending_upload = {"download_url": "http://x/f.csv", "file_name": "f.csv"}
+
+    nodes = [
+        {"on_enter": set_upload},          # tool sets pending_upload here
+        {"answer": "Here is the forecast."},  # agent presents its answer
+        {"final": True},
+    ]
+
+    events = [ev async for ev in _gateway_loop_replica(ctx, nodes)]
+
+    types = [ev["type"] for ev in events]
+    assert types == ["upload_complete", "message", "done"], types
+    # The answer survived — proving upload_complete did NOT end the turn.
+    assert events[1]["data"]["text"] == "Here is the forecast."
+    # pending_upload cleared after emit (anti-double-emit).
+    assert ctx.pending_upload is None
+
+
+@pytest.mark.asyncio
+async def test_clarification_still_ends_turn(tmp_path: Path):
+    """Regression guard: pending_clarification must keep ending the turn."""
+    ctx = _ctx(tmp_path)
+
+    def set_clar(ctx):
+        ctx.pending_clarification = [{"question": "q?"}]
+
+    nodes = [
+        {"on_enter": set_clar},
+        {"answer": "this must NOT be reached"},  # turn ended above
+        {"final": True},
+    ]
+
+    events = [ev async for ev in _gateway_loop_replica(ctx, nodes)]
+    types = [ev["type"] for ev in events]
+    assert types == ["ask_user"], types  # message + done NOT yielded

--- a/tests/ask/test_upload_to_s3_tool.py
+++ b/tests/ask/test_upload_to_s3_tool.py
@@ -1,0 +1,111 @@
+"""Tests for the upload_to_s3 tool — CSV build, presigned-URL flow, pending_upload.
+
+httpx calls are mocked so the tests run without iba-storage / SeaweedFS.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import duckdb
+import pytest
+
+from seeknal.ask.agents.tools._context import ToolContext, set_tool_context
+from seeknal.ask.agents.tools.upload_to_s3 import upload_to_s3
+
+
+class _REPLStub:
+    def __init__(self) -> None:
+        self.conn = duckdb.connect(":memory:")
+
+    def execute_oneshot(self, sql: str, limit=None):
+        if limit is not None:
+            sql = f"SELECT * FROM ({sql}) AS _q LIMIT {int(limit)}"
+        result = self.conn.execute(sql)
+        if not result.description:
+            return [], []
+        cols = [d[0] for d in result.description]
+        return cols, result.fetchall()
+
+
+@pytest.fixture
+def ctx(tmp_path: Path) -> ToolContext:
+    repl = _REPLStub()
+    repl.conn.execute("CREATE TABLE data AS SELECT i AS id, 'n' || i AS v FROM generate_series(0, 4) AS t(i)")
+    ctx = ToolContext(
+        repl=repl,
+        artifact_discovery=MagicMock(),
+        project_path=tmp_path,
+        sql_timeout_seconds=0,
+        request_limit=100,
+    )
+    set_tool_context(ctx)
+    return ctx
+
+
+def _presign_response() -> dict:
+    return {
+        "upload_url": "http://storage/put/abc",
+        "upload_url_expires_at": 1900000000,
+        "download_url": "http://storage/get/abc/file.csv",
+        "download_url_expires_at": 1900000000,
+        "object_name": "csv-exports/abc/file.csv",
+    }
+
+
+def _mock_response(json_body: dict):
+    resp = MagicMock()
+    resp.json.return_value = json_body
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+SQL = "SELECT id, v FROM data"
+
+
+def test_upload_sets_pending_upload_with_server_expiry(ctx):
+    presign = _mock_response(_presign_response())
+    put = MagicMock()
+    put.raise_for_status.return_value = None
+    with patch("seeknal.ask.agents.tools.upload_to_s3.httpx.post", return_value=presign), patch(
+        "seeknal.ask.agents.tools.upload_to_s3.httpx.put", return_value=put
+    ):
+        out = upload_to_s3("file.csv", SQL)
+    assert "Upload complete" in out
+    assert ctx.pending_upload is not None
+    # expires_at must be sourced from the server's download_url_expires_at (ISO).
+    assert ctx.pending_upload["file_name"] == "file.csv"
+    assert ctx.pending_upload["object_name"] == "csv-exports/abc/file.csv"
+    assert ctx.pending_upload["expires_at"].startswith("2030")  # 1900000000 ~ 2030-03
+
+
+def test_upload_storage_unreachable_returns_error(ctx):
+    import httpx as _httpx
+
+    with patch("seeknal.ask.agents.tools.upload_to_s3.httpx.post", side_effect=_httpx.RequestError("boom")):
+        out = upload_to_s3("file.csv", SQL)
+    assert "Storage unavailable" in out
+    assert ctx.pending_upload is None
+
+
+def test_upload_empty_result_returns_nothing(ctx):
+    repl = ctx.repl
+    repl.conn.execute("CREATE TABLE empty AS SELECT * FROM data WHERE 1=0")
+    out = upload_to_s3("file.csv", "SELECT * FROM empty")
+    assert "No rows" in out
+    assert ctx.pending_upload is None
+
+
+def test_upload_no_domain_strings():
+    # Grep contract: the tool must contain no BPOM/domain terms as standalone
+    # words. (Word boundaries avoid false positives like "erba" inside "verbatim".)
+    import re
+
+    import seeknal.ask.agents.tools.upload_to_s3 as m
+
+    src = open(m.__file__).read()
+    for bad in ("bpom", "erba", "trader_id", "tanggal_bayar"):
+        assert not re.search(rf"\b{re.escape(bad)}\b", src, re.IGNORECASE), (
+            f"domain term {bad!r} found in upload_to_s3.py"
+        )


### PR DESCRIPTION
## Summary
- New `upload_to_s3(filename, sql)` tool: generic SQL→CSV export via SeaweedFS presigned URLs
- Gateway `upload_complete` emission with NO-RETURN semantics (turn continues after upload)
- POST_TOOL_USE reminder hook (nudges agent to offer CSV on large query results)
- Tool registration wiring (`include_upload_to_s3` kwarg, `get_upload_to_s3_enabled`)

## Why
After a forecast or analytical query, users often want raw numbers as a spreadsheet. The v26.7.0 W13-B plumbing exists (presigned URLs, `upload_complete` event type, frontend Download button), but nothing produces the event. This tool activates the dormant CSV export infrastructure. Also fixes a real bug discovered during testing: the presigned-URL path in the spec (`/v1/...`) was wrong — iba-storage mounts under `/api` (`/api/v1/...`).

## Changes
- `agents/tools/upload_to_s3.py` — `upload_to_s3(filename, sql)`: EXECUTE SQL → BUILD CSV → POST presign → PUT SeaweedFS → set `ctx.pending_upload`
- `agents/tools/_context.py` — add `pending_upload` field + reset in `reset_turn_governor` (anti-leak)
- `gateway/server.py` — no-return `upload_complete` block (emit + clear + continue, unlike clarification which `return`s)
- `agents/hooks.py` — `_csv_upload_reminder_handler` (POST_TOOL_USE, regex row count, append nudge when ≥20 rows)
- `tests/ask/test_upload_to_s3_tool.py` — 4 tests (round-trip mock, storage unreachable, empty result, no domain strings)
- `tests/ask/test_csv_reminder_hook.py` — 6 tests (row count, above/below threshold, non-execute_sql, registration, gating)
- `tests/ask/test_pending_upload_gateway.py` — 5 tests (reset anti-leak, no-return control-flow, clarification regression)
- `tests/ask/test_hooks.py` — update to expect 3 hooks (added csv_upload_reminder)

## Spec
- `iba-deploy-runbook/specs/2026-07-01-spec-fc2d-seeknal-s3-tool.md`