### PR TITLE
FC2 r4: forecast SQL policy + s3 dual-mode + auto-upload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pygments>=2.20.0",
     # Core AI features shipped by default
     "pydantic-deep>=0.3.17,<0.4.0",
-    "pydantic-ai-slim[google,openai]>=1.71.0",
+    "pydantic-ai-slim[google,openai]>=1.71.0,<2.0.0",
     "ruamel.yaml>=0.18.0",
     "ddgs>=9.0",
     "starlette>=0.40.0",
@@ -88,7 +88,7 @@ spark = [
 # Kept as an extra for backwards-compatible `seeknal[ask]` installs.
 ask = [
     "pydantic-deep>=0.3.17,<0.4.0",
-    "pydantic-ai-slim[google,openai]>=1.71.0",
+    "pydantic-ai-slim[google,openai]>=1.71.0,<2.0.0",
     "ruamel.yaml>=0.18.0",
     "ddgs>=9.0",
     "starlette>=0.40.0",

--- a/src/seeknal/ask/agents/agent.py
+++ b/src/seeknal/ask/agents/agent.py
@@ -223,6 +223,7 @@ def create_agent(
         get_background_threshold,
         get_context_budget,
         get_ask_toolset_mode,
+        get_request_clarification_enabled,
         get_auto_summarization_config,
         get_cost_tracking_config,
         get_hooks_config,
@@ -406,7 +407,10 @@ in the final response.
         create_ask_toolset(
             mode=ask_toolset_mode,
             include_ask_user=(environment == "interactive"),
-            include_request_clarification=environment in ("gateway", "telegram"),
+            include_request_clarification=(
+                environment in ("gateway", "telegram")
+                and get_request_clarification_enabled(agent_config)
+            ),
         ),
         context_toolset,
     ]

--- a/src/seeknal/ask/agents/agent.py
+++ b/src/seeknal/ask/agents/agent.py
@@ -367,9 +367,11 @@ read tools, SQL-pair read tools, project-memory tools, and `execute_python`.
 
 ## Headless read-only channel
 
-The `ask_user` tool is not available in gateway, telegram, or exposure mode.
-If a question is broad or ambiguous, give a concise best-effort answer and ask
-a plain-language follow-up in the final response; do not call `ask_user`.
+The interactive `ask_user` menu is not available in gateway, telegram, or
+exposure mode; do not call `ask_user`. When a `request_clarification` tool is
+present in your toolset, use it to present a structured clarification form for
+genuinely ambiguous requests; otherwise ask a concise plain-language follow-up
+in the final response.
 """
         connected_context = _build_connected_source_context(repl)
         if connected_context:
@@ -404,6 +406,7 @@ a plain-language follow-up in the final response; do not call `ask_user`.
         create_ask_toolset(
             mode=ask_toolset_mode,
             include_ask_user=(environment == "interactive"),
+            include_request_clarification=environment in ("gateway", "telegram"),
         ),
         context_toolset,
     ]

--- a/src/seeknal/ask/agents/agent.py
+++ b/src/seeknal/ask/agents/agent.py
@@ -224,6 +224,8 @@ def create_agent(
         get_context_budget,
         get_ask_toolset_mode,
         get_request_clarification_enabled,
+        get_forecast_enabled,
+        get_upload_to_s3_enabled,
         get_auto_summarization_config,
         get_cost_tracking_config,
         get_hooks_config,
@@ -410,6 +412,14 @@ in the final response.
             include_request_clarification=(
                 environment in ("gateway", "telegram")
                 and get_request_clarification_enabled(agent_config)
+            ),
+            include_forecast=(
+                environment in ("gateway", "telegram")
+                and get_forecast_enabled(agent_config)
+            ),
+            include_upload_to_s3=(
+                environment in ("gateway", "telegram")
+                and get_upload_to_s3_enabled(agent_config)
             ),
         ),
         context_toolset,

--- a/src/seeknal/ask/agents/hooks.py
+++ b/src/seeknal/ask/agents/hooks.py
@@ -9,6 +9,7 @@ wires it into pydantic-deep's hook lifecycle.
 
 import json
 import logging
+import os
 import re
 
 from pydantic_deep.capabilities.hooks import Hook, HookEvent, HookInput, HookResult
@@ -151,6 +152,63 @@ def _enrich_syntax_hint(message: str, existing_hint: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# POST_TOOL_USE: CSV upload reminder (FC2d)
+# ---------------------------------------------------------------------------
+
+# Reminder threshold (module-level — HookInput carries no config object).
+_CSV_REMINDER_MIN_ROWS = int(os.environ.get("SEEKNAL_CSV_REMINDER_MIN_ROWS", "20"))
+
+# Count markdown-table data rows: lines like "| 123 | ..." (skip separators).
+_TABLE_ROW_RE = re.compile(r"^\|\s*[^:\-][^|]*\|", re.MULTILINE)
+
+
+def _count_result_rows(tool_result: str) -> int:
+    """Best-effort row count from an execute_sql markdown table result.
+
+    execute_sql returns a markdown table; data rows match the pattern while
+    separator rows (``|---|``) and the "N rows" footer do not. The header row
+    DOES match the pattern, so when a separator is present (the standard
+    execute_sql shape) we subtract it. Returns 0 on any parse trouble — the
+    hook then no-ops (safe default).
+    """
+    if not tool_result:
+        return 0
+    try:
+        matches = _TABLE_ROW_RE.findall(tool_result)
+        has_separator = bool(re.search(r"^\|[\s:\-]+\|", tool_result, re.MULTILINE))
+        count = len(matches)
+        if has_separator and count > 0:
+            count -= 1  # exclude the header row
+        return max(0, count)
+    except TypeError:
+        return 0
+
+
+async def _csv_upload_reminder_handler(hook_input: HookInput) -> HookResult:
+    """Nudge the agent to offer upload_to_s3 when execute_sql returns many rows.
+
+    Reminder ONLY — never enforces. Appends a short hint to the tool result via
+    ``modified_result``; the agent decides whether to act on it. Triggers on
+    ``execute_sql`` exclusively. Independent of ``_sql_self_correction_handler``
+    (different condition; both run).
+    """
+    try:
+        if hook_input.tool_name != "execute_sql" or not hook_input.tool_result:
+            return HookResult()
+        rows = _count_result_rows(hook_input.tool_result)
+        if rows < _CSV_REMINDER_MIN_ROWS:
+            return HookResult()
+        nudge = (
+            f"\n\n_({rows} rows returned — consider offering "
+            f"`upload_to_s3(filename=..., sql=...)` if the user wants a CSV export.)_"
+        )
+        return HookResult(modified_result=hook_input.tool_result + nudge)
+    except Exception:  # noqa: BLE001 - a hook must never propagate failures
+        logger.exception("[csv_reminder_hook] unexpected error; passing through")
+        return HookResult()
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -161,6 +219,7 @@ def get_ask_hooks(config: dict | None = None) -> list[Hook]:
     Includes:
     - PRE_TOOL_USE: SQL security validation
     - POST_TOOL_USE: SQL self-correction hints
+    - POST_TOOL_USE: CSV upload reminder (FC2d, execute_sql only)
     """
     cfg = config or {}
     if cfg.get("enabled", True) is False:
@@ -180,6 +239,14 @@ def get_ask_hooks(config: dict | None = None) -> list[Hook]:
             Hook(
                 event=HookEvent.POST_TOOL_USE,
                 handler=_sql_self_correction_handler,
+                matcher="execute_sql",
+            )
+        )
+    if cfg.get("csv_upload_reminder", True):
+        hooks.append(
+            Hook(
+                event=HookEvent.POST_TOOL_USE,
+                handler=_csv_upload_reminder_handler,
                 matcher="execute_sql",
             )
         )

--- a/src/seeknal/ask/agents/hooks.py
+++ b/src/seeknal/ask/agents/hooks.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import re
+import time
 
 from pydantic_deep.capabilities.hooks import Hook, HookEvent, HookInput, HookResult
 
@@ -152,11 +153,25 @@ def _enrich_syntax_hint(message: str, existing_hint: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# POST_TOOL_USE: CSV upload reminder (FC2d)
+# POST_TOOL_USE: CSV auto-upload (FC2d r4)
 # ---------------------------------------------------------------------------
+#
+# Design (r4): the hook AUTOMATICALLY calls upload_to_s3 when execute_sql
+# returns a substantial result. The agent does NOT decide — from the user's
+# perspective, every substantial data answer comes with a Download button
+# without asking. This is the "tools csv otomatis upload" behavior.
+#
+# For run_forecast the hook cannot auto-upload (forecast.points are computed
+# in the engine, not re-extractable from the markdown tool_result), so it
+# falls back to a strong nudge that tells the agent to call upload_to_s3 in
+# data mode with the projection rows.
 
-# Reminder threshold (module-level — HookInput carries no config object).
-_CSV_REMINDER_MIN_ROWS = int(os.environ.get("SEEKNAL_CSV_REMINDER_MIN_ROWS", "20"))
+# Auto-upload threshold. Below this row count the result is considered trivial
+# (fits in chat, no Download button needed). Above this threshold the hook
+# auto-uploads via upload_to_s3. Default lowered from 20 → 5 in r4 — the
+# previous default was too restrictive for the "always offer CSV" UX goal.
+# Override via the SEEKNAL_CSV_REMINDER_MIN_ROWS env var.
+_CSV_REMINDER_MIN_ROWS = int(os.environ.get("SEEKNAL_CSV_REMINDER_MIN_ROWS", "5"))
 
 # Count markdown-table data rows: lines like "| 123 | ..." (skip separators).
 _TABLE_ROW_RE = re.compile(r"^\|\s*[^:\-][^|]*\|", re.MULTILINE)
@@ -184,28 +199,141 @@ def _count_result_rows(tool_result: str) -> int:
         return 0
 
 
-async def _csv_upload_reminder_handler(hook_input: HookInput) -> HookResult:
-    """Nudge the agent to offer upload_to_s3 when execute_sql returns many rows.
+def _derive_filename_from_sql(sql: str) -> str:
+    """Best-effort CSV filename derived from the SQL query.
 
-    Reminder ONLY — never enforces. Appends a short hint to the tool result via
-    ``modified_result``; the agent decides whether to act on it. Triggers on
-    ``execute_sql`` exclusively. Independent of ``_sql_self_correction_handler``
-    (different condition; both run).
+    Falls back to a timestamped generic name when introspection fails. The
+    name only affects the user-facing Download label, not storage — the
+    object key is namespaced under ``csv-exports/{uuid}/{filename}`` so
+    collisions are impossible regardless.
+    """
+    table = "result"
+    try:
+        # Capture the full FROM target (e.g. "warehouse.public.t_produk_3_erba"),
+        # then split on dots to get the bare table name. Word boundaries +
+        # greedy [\w.]+ ensure we don't stop at the first segment.
+        m = re.search(r"\bFROM\s+([\w\.]+)", sql, re.IGNORECASE)
+        if m:
+            table_full = m.group(1).strip("`\"'")
+            table = table_full.split(".")[-1].lower()
+            # Strip common table-name prefixes for tidier filenames. The hook
+            # is generic; these patterns just produce cleaner names when present.
+            table = re.sub(r"^(t_|tbl_|table_|ft_)", "", table) or "result"
+    except Exception:
+        table = "result"
+    ts = time.strftime("%Y%m%d-%H%M%S", time.gmtime())
+    return f"{table}-{ts}.csv"
+
+
+async def _csv_upload_reminder_handler(hook_input: HookInput) -> HookResult:
+    """Auto-upload substantial query results to S3; nudge for forecast points.
+
+    Two branches (matcher=``execute_sql|run_forecast``):
+
+    **execute_sql (Mode 1, AUTO-UPLOAD):** when the result has ≥
+    ``_CSV_REMINDER_MIN_ROWS`` rows, the hook DIRECTLY calls
+    ``upload_to_s3(filename, sql=<the agent's SQL>)``. No agent decision —
+    the upload is automatic. ``ctx.pending_upload`` is set inside
+    ``upload_to_s3``; the gateway then emits ``upload_complete`` and a
+    Download button appears alongside the answer. The hook appends a short
+    note to ``tool_result`` so the agent knows the CSV was uploaded (and
+    can mention the download URL in its answer).
+
+    **run_forecast (Mode 2, NUDGE):** the projection points live only in the
+    tool_result markdown — they are computed by the engine, not SQL-queryable.
+    The hook cannot re-execute them. It therefore nudges the agent to call
+    ``upload_to_s3(filename, data=points, columns=[...])`` (Mode 2). Nudge
+    only fires on forecast success (``## Ringkasan``); ``## Kesalahan`` and
+    ``## Ditolak`` produce no exportable data and are skipped.
+
+    Failures (storage unreachable, PUT rejected) are swallowed — the hook
+    must never crash the agent turn. The agent is told via the modified
+    result so it can mention the failure or retry.
     """
     try:
-        if hook_input.tool_name != "execute_sql" or not hook_input.tool_result:
+        tool_name = hook_input.tool_name
+        result = hook_input.tool_result or ""
+        if not result:
             return HookResult()
-        rows = _count_result_rows(hook_input.tool_result)
-        if rows < _CSV_REMINDER_MIN_ROWS:
-            return HookResult()
-        nudge = (
-            f"\n\n_({rows} rows returned — consider offering "
-            f"`upload_to_s3(filename=..., sql=...)` if the user wants a CSV export.)_"
-        )
-        return HookResult(modified_result=hook_input.tool_result + nudge)
-    except Exception:  # noqa: BLE001 - a hook must never propagate failures
-        logger.exception("[csv_reminder_hook] unexpected error; passing through")
+
+        if tool_name == "execute_sql":
+            return await _auto_upload_sql_result(hook_input, result)
+
+        if tool_name == "run_forecast":
+            return _nudge_forecast_data_export(result)
+
         return HookResult()
+    except Exception:  # noqa: BLE001 - hooks must never propagate failures
+        logger.exception("[csv_upload_hook] unexpected error; passing through")
+        return HookResult()
+
+
+async def _auto_upload_sql_result(
+    hook_input: HookInput, result: str
+) -> HookResult:
+    """Auto-upload Mode 1: re-execute the SQL via upload_to_s3.
+
+    Called by ``_csv_upload_reminder_handler`` when execute_sql returns a
+    substantial result. Imports upload_to_s3 lazily to avoid an import cycle
+    (hooks.py is imported early in agent construction).
+    """
+    rows = _count_result_rows(result)
+    if rows < _CSV_REMINDER_MIN_ROWS:
+        return HookResult()
+
+    # The SQL the agent used for this execute_sql call. Re-execute it inside
+    # upload_to_s3 (Mode 1) to build the CSV — most queries hit PostgreSQL's
+    # page cache on the second run, so the latency cost is acceptable.
+    tool_input = hook_input.tool_input or {}
+    sql = tool_input.get("sql") or tool_input.get("query") or ""
+    if not sql:
+        # No SQL captured (defensive) — fall back to a soft nudge so the agent
+        # can offer the upload manually.
+        nudge = (
+            f"\n\n_({rows} rows returned — auto-upload skipped (no SQL captured). "
+            f"Offer `upload_to_s3(filename=..., sql=...)` if the user wants a CSV.)_"
+        )
+        return HookResult(modified_result=result + nudge)
+
+    filename = _derive_filename_from_sql(sql)
+    try:
+        # Lazy import to keep hooks.py import-time light and avoid any cycle.
+        from seeknal.ask.agents.tools.upload_to_s3 import upload_to_s3
+
+        upload_outcome = upload_to_s3(filename, sql=sql)
+    except Exception as exc:
+        # Storage unreachable / PUT rejected / etc — surface to agent, but
+        # never crash the turn. The user still gets the query answer.
+        nudge = (
+            f"\n\n_({rows} rows returned — auto-upload failed: "
+            f"{type(exc).__name__}. The user can still request CSV manually.)_"
+        )
+        return HookResult(modified_result=result + nudge)
+
+    # Upload succeeded — tell the agent so it can mention the Download button.
+    nudge = (
+        f"\n\n_(Auto-uploaded {rows} rows to S3. {upload_outcome} "
+        f"— a Download button is rendered alongside your answer.)_"
+    )
+    return HookResult(modified_result=result + nudge)
+
+
+def _nudge_forecast_data_export(result: str) -> HookResult:
+    """Mode 2 nudge for run_forecast (cannot auto-upload — points are computed).
+
+    Forecast success is marked by ``## Ringkasan``. ``## Kesalahan`` and
+    ``## Ditolak`` produce no exportable data — skip the nudge so the agent
+    focuses on the error/reason instead of offering CSV.
+    """
+    if "## Ringkasan" not in result:
+        return HookResult()
+    nudge = (
+        "\n\n_(Forecast complete — automatically offer "
+        "`upload_to_s3(filename=..., data=points, columns="
+        "[\"period\",\"point\",\"lower_80\",\"upper_80\",\"lower_95\",\"upper_95\"])` "
+        "so the user gets a Download button for the projection points.)_"
+    )
+    return HookResult(modified_result=result + nudge)
 
 
 # ---------------------------------------------------------------------------
@@ -217,9 +345,12 @@ def get_ask_hooks(config: dict | None = None) -> list[Hook]:
     """Return all hooks for the seeknal ask agent.
 
     Includes:
-    - PRE_TOOL_USE: SQL security validation
-    - POST_TOOL_USE: SQL self-correction hints
-    - POST_TOOL_USE: CSV upload reminder (FC2d, execute_sql only)
+    - PRE_TOOL_USE: SQL security validation (execute_sql only)
+    - POST_TOOL_USE: SQL self-correction hints (execute_sql only)
+    - POST_TOOL_USE: CSV upload reminder (FC2d) — fires after both
+      ``execute_sql`` and ``run_forecast``; matcher is the regex
+      ``"execute_sql|run_forecast"`` so pydantic_deep routes both tools to the
+      single handler, which dispatches internally on ``tool_name``.
     """
     cfg = config or {}
     if cfg.get("enabled", True) is False:
@@ -247,7 +378,10 @@ def get_ask_hooks(config: dict | None = None) -> list[Hook]:
             Hook(
                 event=HookEvent.POST_TOOL_USE,
                 handler=_csv_upload_reminder_handler,
-                matcher="execute_sql",
+                # Regex matched against tool_name by pydantic_deep._match_hooks.
+                # Extending to new data-producing tools = extend this regex,
+                # then add a branch in _csv_upload_reminder_handler.
+                matcher="execute_sql|run_forecast",
             )
         )
     return hooks

--- a/src/seeknal/ask/agents/tools/_context.py
+++ b/src/seeknal/ask/agents/tools/_context.py
@@ -87,6 +87,10 @@ class ToolContext:
     # RETRYABLE nudge so the agent can override with allow_sql_pair_drift;
     # only a second attempt without the override escalates to TERMINAL.
     authoritative_drift_attempts_this_turn: int = 0
+    # Model B clarification: set by request_clarification in headless/worker
+    # mode. The gateway streaming layer emits these prompts as an ``ask_user``
+    # event and ends the turn. ``None`` means no clarification is pending.
+    pending_clarification: list[dict[str, Any]] | None = None
 
 
 def _make_registry():
@@ -407,6 +411,7 @@ def reset_turn_governor(question: str | None = None) -> None:
     setattr(ctx.repl, "_seeknal_authoritative_sql_pair_result_this_turn", None)
     ctx.authoritative_drift_attempts_this_turn = 0
     ctx.timing_events_this_turn.clear()
+    ctx.pending_clarification = None
 
 
 def get_discovery_cache_value(key: str) -> Any | None:

--- a/src/seeknal/ask/agents/tools/_context.py
+++ b/src/seeknal/ask/agents/tools/_context.py
@@ -91,6 +91,11 @@ class ToolContext:
     # mode. The gateway streaming layer emits these prompts as an ``ask_user``
     # event and ends the turn. ``None`` means no clarification is pending.
     pending_clarification: list[dict[str, Any]] | None = None
+    # FC2d: pending CSV download. Set by upload_to_s3 (and run_forecast's
+    # optional CSV step). The gateway streaming layer emits an
+    # ``upload_complete`` event and CONTINUES the turn — unlike
+    # pending_clarification which ends it. ``None`` means no upload is pending.
+    pending_upload: dict[str, Any] | None = None
 
 
 def _make_registry():
@@ -412,6 +417,7 @@ def reset_turn_governor(question: str | None = None) -> None:
     ctx.authoritative_drift_attempts_this_turn = 0
     ctx.timing_events_this_turn.clear()
     ctx.pending_clarification = None
+    ctx.pending_upload = None
 
 
 def get_discovery_cache_value(key: str) -> Any | None:

--- a/src/seeknal/ask/agents/tools/forecast.py
+++ b/src/seeknal/ask/agents/tools/forecast.py
@@ -74,10 +74,22 @@ def run_forecast(sql: str, periods: int = 3) -> str:
         make_tool_signature,
         record_tool_result,
     )
-    from seeknal.ask.agents.tools.execute_sql import _execute_oneshot_with_timeout
+    from seeknal.ask.agents.tools.execute_sql import (
+        _execute_oneshot_with_timeout,
+        _repair_common_sql_before_execution,
+    )
 
     ctx = get_tool_context()
     periods = max(1, min(int(periods), _MAX_HORIZON))
+
+    # ── STEP 0: PREPARE SQL — same pipeline as execute_sql (r3) ────────────
+    # Strip trailing semicolons (LLMs include them, DuckDB rejects).
+    sql = str(sql).strip().rstrip(";").strip()
+    # Repair + rewrite: _rewrite_for_pg_pushdown converts EXTRACT(YEAR…) to
+    # date-range filters so DuckDB's postgres_scanner pushes the WHERE to
+    # PostgreSQL. Without this, DuckDB pulls the entire table and processes
+    # locally — different cast/NULL semantics → wrong results.
+    sql, _notices = _repair_common_sql_before_execution(sql)
 
     # ── STEP 1: EXECUTE the caller's SQL (no domain columns hardcoded) ─────
     columns, rows = _execute_oneshot_with_timeout(ctx, sql, limit=_FORECAST_PULL_LIMIT)
@@ -103,7 +115,17 @@ def run_forecast(sql: str, periods: int = 3) -> str:
             f"Data minimal {_MIN_ROWS} baris untuk dikirim ke engine; dapat {len(rows)}."
         )
 
+    # Coerce data + filter out rows with NULL/empty X or unparseable Y.
+    # DuckDB may return NULL for rows where a cast (e.g. tanggal_bayar::timestamp)
+    # failed — those rows must be excluded, not silently converted to 0.
     data = [[_coerce_x(r[0]), _coerce_y(r[1])] for r in rows]
+    data = [[x, y] for x, y in data if x is not None and y is not None]
+    if len(data) < _MIN_ROWS:
+        return _format_error(
+            f"Data minimal {_MIN_ROWS} baris valid untuk dikirim ke engine; "
+            f"dapat {len(data)} setelah filter NULL."
+        )
+
     freq = _infer_freq([row[0] for row in data])
     if freq is None:
         record_tool_result(
@@ -188,23 +210,34 @@ def _infer_freq(x_values: list[str]) -> str | None:
     return None
 
 
-def _coerce_x(v: Any) -> str:
-    """Normalise the X column to a YYYY-MM-DD string the engine can parse."""
+def _coerce_x(v: Any) -> str | None:
+    """Normalise the X column to a YYYY-MM-DD string the engine can parse.
+
+    Returns None for NULL/empty values so the caller can filter them out
+    before sending to the engine (NULL dates from failed casts must be
+    excluded, not silently converted to empty strings).
+    """
+    from datetime import date as _date
+
     if v is None:
-        return ""
+        return None
     if isinstance(v, datetime):
         return v.strftime("%Y-%m-%d")
-    text = str(v)
-    # DuckDB may return a date/datetime object or string; trim to date part.
-    return text[:10]
+    if isinstance(v, _date):  # DuckDB DATE type (not datetime.datetime)
+        return v.isoformat()
+    text = str(v)[:10]
+    return text if text.strip() else None
 
 
-def _coerce_y(v: Any) -> float:
-    """Normalise the Y column to a non-negative number."""
+def _coerce_y(v: Any) -> float | None:
+    """Normalise the Y column to a non-negative number.
+
+    Returns None for unparseable values so the caller can filter them out.
+    """
     try:
         n = float(v)
     except (TypeError, ValueError):
-        return 0.0
+        return None
     return max(0.0, n)
 
 

--- a/src/seeknal/ask/agents/tools/forecast.py
+++ b/src/seeknal/ask/agents/tools/forecast.py
@@ -1,0 +1,358 @@
+"""run_forecast — deterministic forecast trigger tool.
+
+Thin trigger that mirrors ``request_clarification`` (SEEK5): the agent
+constructs a 2-column SQL from project context, and this tool owns the
+deterministic EXECUTE → VALIDATE → INFER → POST → FORMAT pipeline. The IBA
+forecast engine (FC2b) owns the AutoETS compute. The LLM does no forecast
+arithmetic.
+
+The tool is domain-neutral (``AGENTS.md``: *"Never hardcode customer/domain
+SQL in the agent harness"*). All domain specifics live in project context and
+arrive as a single ``sql`` argument the agent assembles.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Any
+
+import httpx
+
+_IBA_FORECAST_URL = os.environ.get("IBA_FORECAST_URL", "http://iba-forecast:6705")
+_IBA_FORECAST_API_KEY = os.environ.get("IBA_FORECAST_API_KEY", "")
+
+_MIN_ROWS = 10          # tool sendability floor (engine eligibility ≥24 is separate)
+_MAX_HORIZON = 12       # hard cap; engine also enforces periods ≤ 12
+_FORECAST_PULL_LIMIT = 500  # well under execute_sql's row/byte budget
+
+
+def run_forecast(sql: str, periods: int = 3) -> str:
+    """Run a deterministic forecast via the IBA forecast engine.
+
+    Executes the caller-supplied SQL (which MUST return exactly two columns:
+    X = a time-grain timestamp, Y = a numeric value), validates the shape,
+    infers the frequency from the X-column spacing, sends the series to the
+    IBA forecast engine for AutoETS computation, and returns the result as a
+    7-blok structured markdown answer.
+
+    Construct the SQL from project context (``context/forecast_guide.md``):
+    the first column is the time grain (e.g. ``date_trunc('month', ...)``),
+    the second is the aggregate (e.g. ``COUNT(DISTINCT ...)``). Do NOT do
+    forecast arithmetic yourself, and do NOT pass domain column names as
+    separate tool arguments — they belong inside the SQL.
+
+    Args:
+        sql: A SELECT that returns exactly two columns: ``[x, y]`` where
+            ``x`` is a timestamp/DATE and ``y`` is a non-negative number.
+            Must be ordered by ``x`` ascending and aggregated to one row
+            per period. Example shape::
+
+                SELECT date_trunc('month', some_date::timestamp) AS x,
+                       COUNT(DISTINCT some_id)                AS y
+                FROM schema.table
+                WHERE some_date::timestamp >= '2022-09-01'
+                GROUP BY 1
+                ORDER BY 1
+
+        periods: Steps ahead to forecast (default 3). Clamped to a max of 12
+            (matching the engine's hard cap).
+
+    Returns:
+        A 7-blok markdown string: Ringkasan, Kualitas Proyeksi, Kondisi Data,
+        Historis & Proyeksi, Proyeksi Detail, Rentang Realistis, Tingkat
+        Keyakinan, Metodologi.
+
+        On local validation failure (wrong column count, <10 rows, irregular
+        spacing) returns a ``## Kesalahan`` block describing the problem.
+        If the engine refuses (insufficient history, event-driven series),
+        returns a single ``## Ditolak`` block with the reason.
+    """
+    # Late imports keep the module light and match request_clarification.
+    from seeknal.ask.agents.tools._context import (
+        get_tool_context,
+        make_tool_signature,
+        record_tool_result,
+    )
+    from seeknal.ask.agents.tools.execute_sql import _execute_oneshot_with_timeout
+
+    ctx = get_tool_context()
+    periods = max(1, min(int(periods), _MAX_HORIZON))
+
+    # ── STEP 1: EXECUTE the caller's SQL (no domain columns hardcoded) ─────
+    columns, rows = _execute_oneshot_with_timeout(ctx, sql, limit=_FORECAST_PULL_LIMIT)
+
+    # ── STEP 2: VALIDATE + INFER ───────────────────────────────────────────
+    if len(columns) != 2:
+        record_tool_result(
+            "run_forecast",
+            "error",
+            args={"sql_sig": make_tool_signature("run_forecast", {"sql": sql})},
+        )
+        return _format_error(
+            f"SQL harus mengembalikan tepat 2 kolom (X waktu, Y nilai); "
+            f"dapat {len(columns)}."
+        )
+    if len(rows) < _MIN_ROWS:
+        record_tool_result(
+            "run_forecast",
+            "error",
+            args={"sql_sig": make_tool_signature("run_forecast", {"sql": sql})},
+        )
+        return _format_error(
+            f"Data minimal {_MIN_ROWS} baris untuk dikirim ke engine; dapat {len(rows)}."
+        )
+
+    data = [[_coerce_x(r[0]), _coerce_y(r[1])] for r in rows]
+    freq = _infer_freq([row[0] for row in data])
+    if freq is None:
+        record_tool_result(
+            "run_forecast",
+            "error",
+            args={"sql_sig": make_tool_signature("run_forecast", {"sql": sql})},
+        )
+        return _format_error(
+            "Spacing X tidak konsisten; tidak bisa menentukan freq (MS/QS/YS)."
+        )
+
+    # ── STEP 3: POST → engine (generic payload) ────────────────────────────
+    try:
+        resp = httpx.post(
+            f"{_IBA_FORECAST_URL}/forecast",
+            json={"data": data, "periods": periods, "freq": freq},
+            headers={"X-API-Key": _IBA_FORECAST_API_KEY},
+            timeout=120.0,
+        )
+        resp.raise_for_status()
+        result: dict[str, Any] = resp.json()
+    except httpx.HTTPStatusError as exc:
+        record_tool_result(
+            "run_forecast",
+            "error",
+            args={"sql_sig": make_tool_signature("run_forecast", {"sql": sql})},
+        )
+        return _format_error(f"Engine error: HTTP {exc.response.status_code}.")
+    except (httpx.RequestError, httpx.HTTPError):
+        record_tool_result(
+            "run_forecast",
+            "error",
+            args={"sql_sig": make_tool_signature("run_forecast", {"sql": sql})},
+        )
+        return _format_error("Engine tidak tersedia (timeout atau koneksi gagal).")
+
+    status = result.get("status")
+    record_tool_result(
+        "run_forecast",
+        "ok" if status == "ok" else "refused",
+        args={"sql_sig": make_tool_signature("run_forecast", {"sql": sql, "periods": periods})},
+    )
+
+    if status != "ok":
+        return _format_refused(result.get("reason", "Ditolak engine."))
+
+    # ── STEP 4: FORMAT 7-blok markdown ─────────────────────────────────────
+    return _format_forecast_markdown(result, data)
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _infer_freq(x_values: list[str]) -> str | None:
+    """Infer MS/QS/YS from X spacing. Return None on irregular gaps.
+
+    Compares consecutive diffs in months. MS → all diffs ≈ 1 month;
+    QS → ≈ 3 months; YS → ≈ 12 months. Anything outside the three bands
+    (or mixed) → None (caller refuses locally; do not send garbage).
+    """
+    if len(x_values) < 2:
+        return None
+    try:
+        dates = [datetime.fromisoformat(str(v)[:10]) for v in x_values]
+    except (ValueError, TypeError):
+        return None
+
+    month_deltas: list[int] = []
+    for a, b in zip(dates[:-1], dates[1:]):
+        delta = (b.year - a.year) * 12 + (b.month - a.month)
+        if delta <= 0:
+            return None  # unsorted or duplicate period
+        month_deltas.append(delta)
+
+    unique = set(month_deltas)
+    if unique == {1}:
+        return "MS"
+    if unique == {3}:
+        return "QS"
+    if unique == {12}:
+        return "YS"
+    return None
+
+
+def _coerce_x(v: Any) -> str:
+    """Normalise the X column to a YYYY-MM-DD string the engine can parse."""
+    if v is None:
+        return ""
+    if isinstance(v, datetime):
+        return v.strftime("%Y-%m-%d")
+    text = str(v)
+    # DuckDB may return a date/datetime object or string; trim to date part.
+    return text[:10]
+
+
+def _coerce_y(v: Any) -> float:
+    """Normalise the Y column to a non-negative number."""
+    try:
+        n = float(v)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, n)
+
+
+def _format_error(message: str) -> str:
+    return f"## Kesalahan\n\n{message}"
+
+
+def _format_refused(reason: str) -> str:
+    return (
+        "## Ditolak\n\n"
+        f"{reason}\n\n"
+        "Tidak bisa membuat proyeksi untuk deret ini. "
+        "Tampilkan analisis historis sebagai gantinya."
+    )
+
+
+def _format_forecast_markdown(result: dict[str, Any], history: list[list[Any]]) -> str:
+    forecast = result.get("forecast") or {}
+    assessment = result.get("assessment") or {}
+    provenance = result.get("provenance") or {}
+
+    points = forecast.get("points") or []
+    metrics = assessment.get("metrics") or {}
+    elig = assessment.get("eligibility") or {}
+
+    # History → date→value lookup for year-over-year side-by-side.
+    actual_by_x = {str(x)[:10]: y for x, y in history}
+
+    def _prior_year(period: str) -> str | None:
+        try:
+            return str(int(period[:4]) - 1) + period[4:]
+        except (ValueError, IndexError):
+            return None
+
+    def _fmt(v: Any) -> str:
+        try:
+            return f"{int(v):,}"
+        except (TypeError, ValueError):
+            return "-"
+
+    quality_label = assessment.get("quality_label", "-")
+    mape = metrics.get("mape")
+    mae = metrics.get("mae")
+    mase = metrics.get("mase")
+
+    # Historis & Proyeksi — YoY side-by-side, 80% bounds as separate columns.
+    # The "Actual (thn lalu)" column shows the SAME CALENDAR PERIOD one year
+    # before the forecast period (e.g. forecast 2026-07 → actual 2025-07).
+    # Format: "Mon-YYYY: value" to avoid ambiguity about which year the
+    # actual belongs to.
+    yoy_lines = []
+    for p in points:
+        period = p.get("period", "")
+        prior = _prior_year(period)
+        actual = actual_by_x.get(prior) if prior else None
+        # Show prior year explicitly: "Jul-2025: 6,804" not just "6,804"
+        if actual is not None and prior:
+            try:
+                from datetime import datetime as _dt
+                _dtobj = _dt.fromisoformat(prior)
+                _mon = _dtobj.strftime("%b")  # e.g. "Jul"
+                _yr = _dtobj.year
+                actual_str = f"{_mon}-{_yr}: {_fmt(actual)}"
+            except (ValueError, TypeError):
+                actual_str = _fmt(actual)
+        else:
+            actual_str = "-"
+        yoy_lines.append(
+            f"| {period[:7]} | {actual_str} | {_fmt(p.get('point'))} | "
+            f"{_fmt(p.get('upper_80'))} | {_fmt(p.get('lower_80'))} |"
+        )
+
+    # Proyeksi Detail — full 80% + 95% bounds per period.
+    detail_lines = []
+    for p in points:
+        detail_lines.append(
+            f"| {p.get('period', '')[:7]} | {_fmt(p.get('point'))} | "
+            f"{_fmt(p.get('lower_80'))} | {_fmt(p.get('upper_80'))} | "
+            f"{_fmt(p.get('lower_95'))} | {_fmt(p.get('upper_95'))} |"
+        )
+
+    yoy_table = (
+        "\n".join(yoy_lines) if yoy_lines else "| - | - | - | - | - |"
+    )
+    detail_table = (
+        "\n".join(detail_lines) if detail_lines else "| - | - | - | - | - | - |"
+    )
+
+    return f"""## Ringkasan
+Forecast for the next {forecast.get('periods', '-')} periods using {provenance.get('model', '-')}.
+
+## Kualitas Proyeksi
+**{quality_label}** — MAPE {mape:.1f}% (avg error from 12-period backtest).
+- {_quality_explain(quality_label)}
+- MAE {(_fmt(mae) if mae is not None else '-')} (absolute error, in raw units) · MASE {(f'{mase:.3f}' if mase is not None else '-')} (<1 beats naive baseline)
+
+## Kondisi Data
+- Historical periods: {elig.get('n_months', '-')} (engine requires >= 24 to forecast)
+- Average per period: {_fmt(elig.get('avg_monthly'))}
+- Gap periods: {elig.get('gap_months', '-')} (missing periods in the series)
+- Eligibility: {'passed' if elig.get('passed') else 'refused — ' + str(elig.get('reason', ''))}
+
+## Historis & Proyeksi
+Actual tahun sebelumnya vs forecast, side by side (80% bounds).
+| Period  | Actual (thn lalu)  | Point  | Upper 80% | Lower 80% |
+|---------|---------------------|--------|-----------|-----------|
+{yoy_table}
+
+## Proyeksi Detail
+| Period | Point | Lower 80% | Upper 80% | Lower 95% | Upper 95% |
+|---|---|---|---|---|---|
+{detail_table}
+
+## Rentang Realistis
+Bounds widen with horizon (σ·√h). The Upper/Lower 80% columns in the
+Historis & Proyeksi table use the 80% confidence band; Proyeksi Detail
+adds the wider 95% band. Larger sigma (residual noise) = wider bounds.
+
+## Tingkat Keyakinan
+{quality_label} — {_confidence_explain(quality_label)}
+
+## Metodologi
+- Model: {provenance.get('model', '-')} → {provenance.get('sub_type', '-')} ({_subtype_explain(provenance.get('sub_type', ''))})
+- Training window: {provenance.get('training_window', '-')} (the historical range that set the forecast level)
+- Residual sigma: {(f'{provenance.get("sigma", 0):.1f}' if provenance.get('sigma') is not None else '-')} (drives the σ·√h bounds above)
+- Methodology: deterministic AutoETS via statsforecast; the LLM does no forecast arithmetic.
+"""
+
+
+def _quality_explain(label: str) -> str:
+    return {
+        "BAIK": "trustworthy for planning",
+        "CUKUP": "usable with caveats",
+        "LEMAH": "rough estimate, hedge it",
+        "TOLAK": "not reliable enough",
+    }.get(label, "-")
+
+
+def _confidence_explain(label: str) -> str:
+    return {
+        "BAIK": "MAPE ≤ 15% — high-confidence forecast.",
+        "CUKUP": "MAPE 15–25% — directionally reliable, expect ±20% noise.",
+        "LEMAH": "MAPE 25–35% — wide intervals, treat as a rough range.",
+        "TOLAK": "MAPE > 35% — not reliable for planning.",
+    }.get(label, "-")
+
+
+def _subtype_explain(sub_type: str) -> str:
+    if "ETS(A,N,N)" in str(sub_type):
+        return "Simple Exponential Smoothing — level-only, correct for stationary non-seasonal data"
+    return "AutoETS-selected flavor"

--- a/src/seeknal/ask/agents/tools/forecast.py
+++ b/src/seeknal/ask/agents/tools/forecast.py
@@ -14,6 +14,7 @@ arrive as a single ``sql`` argument the agent assembles.
 from __future__ import annotations
 
 import os
+import re
 from datetime import datetime
 from typing import Any
 
@@ -25,6 +26,31 @@ _IBA_FORECAST_API_KEY = os.environ.get("IBA_FORECAST_API_KEY", "")
 _MIN_ROWS = 10          # tool sendability floor (engine eligibility ≥24 is separate)
 _MAX_HORIZON = 12       # hard cap; engine also enforces periods ≤ 12
 _FORECAST_PULL_LIMIT = 500  # well under execute_sql's row/byte budget
+
+# ── SQL shape policy (structural, not error-text-based) ────────────────
+# The forecast tool accepts a flat single-table aggregate only. Detection is
+# regex-based on SQL keywords and independent of any runtime error message,
+# so it remains stable across DuckDB versions and error-wording changes.
+# Each entry maps a forbidden pattern to an actionable, OpenAI-style English
+# reason that explains WHY the pattern violates the contract and WHAT to do.
+_FORBIDDEN_SQL_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r"\bJOIN\b", re.IGNORECASE),
+        "JOIN clauses are not supported. Query a single table and aggregate "
+        "to one row per period — no year-over-year self-joins, no date-spine "
+        "joins, no joins to other tables.",
+    ),
+    (
+        re.compile(r"\bGENERATE_SERIES\b", re.IGNORECASE),
+        "GENERATE_SERIES is not supported. The forecast engine counts missing "
+        "periods (gap_months) internally from the X-column spacing — do not "
+        "pre-fill missing months in SQL.",
+    ),
+    (
+        re.compile(r"\bWITH\s+RECURSIVE\b", re.IGNORECASE),
+        "Recursive CTEs are not supported. Use a single flat SELECT.",
+    ),
+)
 
 
 def run_forecast(sql: str, periods: int = 3) -> str:
@@ -91,8 +117,39 @@ def run_forecast(sql: str, periods: int = 3) -> str:
     # locally — different cast/NULL semantics → wrong results.
     sql, _notices = _repair_common_sql_before_execution(sql)
 
+    # ── STEP 0.5: STRUCTURAL POLICY CHECK (r4) ────────────────────────────
+    # Fail fast on forbidden SQL patterns BEFORE calling DuckDB. This is
+    # structural detection (regex on SQL keywords) — independent of DuckDB's
+    # error wording, so it stays stable across upstream version bumps. The
+    # observed production crash ("Conversion Error: TIMESTAMP -> TIMESTAMP[]"
+    # on LEFT JOIN with date_trunc) is prevented here without coupling to the
+    # exact error text. See _FORBIDDEN_SQL_PATTERNS for the policy table.
+    forbidden = _detect_forbidden_patterns(sql)
+    if forbidden:
+        record_tool_result(
+            "run_forecast",
+            "error",
+            args={"sql_sig": make_tool_signature("run_forecast", {"sql": sql})},
+        )
+        return _format_policy_violation(sql, forbidden)
+
     # ── STEP 1: EXECUTE the caller's SQL (no domain columns hardcoded) ─────
-    columns, rows = _execute_oneshot_with_timeout(ctx, sql, limit=_FORECAST_PULL_LIMIT)
+    # Wrap in try/except (r4) — DuckDB errors that slip past the structural
+    # pre-check (syntax errors, missing tables, type casts not tied to JOIN)
+    # must NOT crash the Temporal activity. Return a structured ``## Kesalahan``
+    # block so the agent can self-correct in the next loop iteration (FC2a
+    # §3.4: local validation failures must return a markdown block, not raise).
+    try:
+        columns, rows = _execute_oneshot_with_timeout(
+            ctx, sql, limit=_FORECAST_PULL_LIMIT
+        )
+    except Exception as exc:
+        record_tool_result(
+            "run_forecast",
+            "error",
+            args={"sql_sig": make_tool_signature("run_forecast", {"sql": sql})},
+        )
+        return _format_sql_exec_error(exc, sql)
 
     # ── STEP 2: VALIDATE + INFER ───────────────────────────────────────────
     if len(columns) != 2:
@@ -243,6 +300,128 @@ def _coerce_y(v: Any) -> float | None:
 
 def _format_error(message: str) -> str:
     return f"## Kesalahan\n\n{message}"
+
+
+def _detect_forbidden_patterns(sql: str) -> list[str]:
+    """Return actionable reasons for each forbidden SQL pattern found.
+
+    Detection is structural (regex on SQL keywords) and independent of any
+    runtime error message, so it stays stable across DuckDB versions and
+    error-wording changes. Returns a list of OpenAI-style English reasons
+    (already bullet-prefixed) explaining why each matched pattern violates
+    the forecast tool's flat 2-column contract.
+    """
+    return [
+        f"- {reason}"
+        for pattern, reason in _FORBIDDEN_SQL_PATTERNS
+        if pattern.search(sql)
+    ]
+
+
+def _sql_preview(sql: str, limit: int = 200) -> str:
+    """Truncate and flatten a SQL string for inclusion in error context.
+
+    Whitespace is collapsed so multi-line SQL renders on one preview line,
+    keeping the agent context budget bounded while still giving enough signal
+    for debugging.
+    """
+    preview = sql[:limit].replace("\n", " ")
+    if len(sql) > limit:
+        preview += " ... (truncated)"
+    return preview
+
+
+def _format_policy_violation(sql: str, violations: list[str]) -> str:
+    """Format a structural policy violation (failed BEFORE execution).
+
+    Used when ``_detect_forbidden_patterns`` finds JOIN / generate_series /
+    recursive CTE patterns in the SQL. Distinct from ``_format_sql_exec_error``
+    (which handles runtime exceptions) because the diagnosis here is certain:
+    we know which pattern is forbidden, so the message is authoritative rather
+    than hedged.
+    """
+    return (
+        "## Kesalahan\n\n"
+        "**Forecast SQL rejected by policy check (STEP 0.5).**\n\n"
+        "The SQL contains patterns that the forecast tool does not support:\n"
+        f"{chr(10).join(violations)}\n\n"
+        "Required SQL shape for run_forecast:\n"
+        "```\n"
+        "SELECT <time_grain_expr>      AS x,   -- e.g. date_trunc('month', col::timestamp)\n"
+        "       <value_aggregate_expr> AS y    -- e.g. COUNT(DISTINCT id)\n"
+        "FROM   <table>\n"
+        "WHERE  <filters>\n"
+        "GROUP  BY 1\n"
+        "ORDER  BY 1\n"
+        "```\n"
+        "- Exactly 2 columns (X timestamp, Y non-negative number).\n"
+        "- No JOINs, no generate_series, no recursive CTE.\n"
+        "- One row per period; the engine handles gap-filling and eligibility.\n\n"
+        f"SQL preview (after preprocessing): `{_sql_preview(sql)}`"
+    )
+
+
+def _format_sql_exec_error(exc: Exception, sql: str) -> str:
+    """Format a SQL execution failure as a traceable, structured Kesalahan block.
+
+    The message is English and separates three concerns for debuggability:
+
+    1. **What happened** — the exception class and its first non-empty lines
+       (verbatim, truncated to keep the agent context budget bounded). This is
+       the debug trail and is reported as-is, never parsed for branching.
+    2. **Why the SQL likely violates the tool contract** — detected
+       structurally from the SQL itself, independent of the runtime error
+       wording. Useful when DuckDB's error is opaque (e.g. "Conversion Error"
+       with no hint about JOIN being the cause).
+    3. **What to do** — the required flat 2-column shape.
+
+    This separation keeps the formatter robust: even if DuckDB rephrases its
+    errors or the SQL fails for an unanticipated reason, the structural hints
+    still surface the most likely policy violation, and the verbatim exception
+    still gives the debug trail. Detection logic never branches on error text.
+    """
+    exc_type = type(exc).__name__
+    # First 3 non-empty lines — enough to capture DuckDB's ``LINE N: ...`` caret
+    # without echoing a multi-KB traceback into the agent context.
+    raw_lines = [ln.strip() for ln in str(exc).splitlines() if ln.strip()]
+    detail = "\n".join(raw_lines[:3]) if raw_lines else str(exc)
+
+    # Re-run structural detection for the hint section. The same patterns are
+    # checked at STEP 0.5, but a SQL can still reach this handler if it failed
+    # the pre-check (it shouldn't) or if a non-patterned error occurred.
+    violations = _detect_forbidden_patterns(sql)
+    if violations:
+        cause = (
+            "The SQL also contains patterns that the forecast tool does not "
+            "support:\n" + "\n".join(violations)
+        )
+    else:
+        cause = (
+            "No unsupported pattern was detected in the SQL. The failure is "
+            "likely a syntax error, a missing table or column, or a type cast "
+            "issue. Re-check the SQL against the table schema."
+        )
+
+    return (
+        "## Kesalahan\n\n"
+        "**Forecast SQL execution failed (STEP 1: EXECUTE).**\n\n"
+        f"Error type: `{exc_type}`\n"
+        f"Detail:\n```\n{detail}\n```\n\n"
+        f"{cause}\n\n"
+        "Required SQL shape for run_forecast:\n"
+        "```\n"
+        "SELECT <time_grain_expr>      AS x,   -- e.g. date_trunc('month', col::timestamp)\n"
+        "       <value_aggregate_expr> AS y    -- e.g. COUNT(DISTINCT id)\n"
+        "FROM   <table>\n"
+        "WHERE  <filters>\n"
+        "GROUP  BY 1\n"
+        "ORDER  BY 1\n"
+        "```\n"
+        "- Exactly 2 columns (X timestamp, Y non-negative number).\n"
+        "- No JOINs, no generate_series, no recursive CTE.\n"
+        "- One row per period; the engine handles gap-filling and eligibility.\n\n"
+        f"SQL preview (after preprocessing): `{_sql_preview(sql)}`"
+    )
 
 
 def _format_refused(reason: str) -> str:

--- a/src/seeknal/ask/agents/tools/request_clarification.py
+++ b/src/seeknal/ask/agents/tools/request_clarification.py
@@ -1,0 +1,52 @@
+"""request_clarification — emit a structured clarification form to the user.
+
+Headless/worker counterpart to the interactive ``ask_user`` menu. Instead of
+blocking for an arrow-key picker, this tool records the clarification prompts
+on the turn context; the gateway streaming layer emits them as an ``ask_user``
+event and ends the turn (Model B). The user's answer arrives as the next chat
+message and is bound from conversation history on the following turn.
+
+Registered only in non-interactive environments (gateway/telegram). The
+interactive CLI keeps the blocking ``ask_user`` menu, so the two tools are
+never present in the same toolset.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+async def request_clarification(
+    prompts: list[dict[str, Any]],
+) -> str:
+    """Present a structured clarification form (one or more questions) to the user.
+
+    Use this when the user's request is genuinely ambiguous and the different
+    interpretations would produce materially different answers — for example a
+    concept that could map to more than one database code, scope, or system.
+    This tool emits the form and ends the turn; do not call further tools after
+    it. The conversation resumes on the next message.
+
+    Each slot is rendered as a tab. The frontend always offers a "type your
+    own" free-text option per slot, so do not add a free-text option yourself.
+
+    Args:
+        prompts: 1-3 clarification slots. Each slot is a dict with:
+            - 'question': The clarification question (clear and specific).
+            - 'options': 2-3 answer options. Each option is a dict with:
+                - 'label': Short option text (1-5 words)
+                - 'description': What this option means or implies
+                - 'recommended': Set to 'true' to highlight as recommended (optional)
+    """
+    from seeknal.ask.agents.tools._context import get_tool_context
+
+    if not prompts:
+        return "No clarification prompts provided."
+
+    ctx = get_tool_context()
+    ctx.pending_clarification = list(prompts)
+    return (
+        "Clarification form emitted to the user. Stop here and produce no "
+        "further tool calls or text; the user's response will arrive as the "
+        "next message and the conversation will resume from there."
+    )

--- a/src/seeknal/ask/agents/tools/toolset.py
+++ b/src/seeknal/ask/agents/tools/toolset.py
@@ -49,6 +49,7 @@ from seeknal.ask.agents.tools.read_proof_document import read_proof_document
 from seeknal.ask.agents.tools.read_project_file import read_project_file
 from seeknal.ask.agents.tools.read_source_context import read_source_context
 from seeknal.ask.agents.tools.read_sql_pair import read_sql_pair
+from seeknal.ask.agents.tools.request_clarification import request_clarification
 from seeknal.ask.agents.tools.run_pipeline import run_pipeline
 from seeknal.ask.agents.tools.run_ask_test import run_ask_test
 from seeknal.ask.agents.tools.save_ingestion_skill import save_ingestion_skill
@@ -149,6 +150,7 @@ def create_ask_toolset(
     *,
     mode: str = "full",
     include_ask_user: bool = True,
+    include_request_clarification: bool = False,
 ) -> FunctionToolset:
     """Create the seeknal-ask toolset.
 
@@ -159,6 +161,9 @@ def create_ask_toolset(
         include_ask_user: Include the direct interactive ``ask_user`` tool.
             Headless channels pass ``False`` so tool schemas cannot trigger
             blocking user input.
+        include_request_clarification: Include the headless ``request_clarification``
+            tool (Model B). Registered for gateway/telegram; the interactive CLI
+            keeps ``ask_user`` instead, so the two are never combined.
     """
     if mode == "analysis":
         # Keep the connected-source/read-only surface deliberately thin:
@@ -187,6 +192,9 @@ def create_ask_toolset(
 
     if include_ask_user:
         tools.append(ask_user)
+
+    if include_request_clarification:
+        tools.append(request_clarification)
 
     return FunctionToolset(
         tools=tools,

--- a/src/seeknal/ask/agents/tools/toolset.py
+++ b/src/seeknal/ask/agents/tools/toolset.py
@@ -22,6 +22,7 @@ from seeknal.ask.agents.tools.execute_sql_pair import execute_sql_pair
 from seeknal.ask.agents.tools.execute_uv_script import execute_uv_script
 from seeknal.ask.agents.tools.execute_sql import execute_sql
 from seeknal.ask.agents.tools.extract_from_image import extract_from_image
+from seeknal.ask.agents.tools.forecast import run_forecast
 from seeknal.ask.agents.tools.generate_report import generate_report
 from seeknal.ask.agents.tools.get_entities import get_entities
 from seeknal.ask.agents.tools.get_entity_schema import get_entity_schema
@@ -60,6 +61,7 @@ from seeknal.ask.agents.tools.search_pipelines import search_pipelines
 from seeknal.ask.agents.tools.search_project_files import search_project_files
 from seeknal.ask.agents.tools.show_lineage import show_lineage
 from seeknal.ask.agents.tools.submit_plan import submit_plan
+from seeknal.ask.agents.tools.upload_to_s3 import upload_to_s3
 from seeknal.ask.agents.tools.write_ingested_table import write_ingested_table
 from seeknal.ask.agents.tools.write_project_file import write_project_file
 
@@ -145,12 +147,26 @@ _FULL_ONLY_TOOLS = [
     propose_record_table,
 ]
 
+# Forecast trigger (FC2a). Gated by ``include_forecast`` — registered only in
+# non-interactive environments when ``agent.forecast.enabled`` is true.
+_FORECAST_TOOLS = [
+    run_forecast,
+]
+
+# CSV export tool (FC2d). Gated by ``include_upload_to_s3`` — registered only
+# in non-interactive environments when ``agent.upload_to_s3.enabled`` is true.
+_EXPORT_TOOLS = [
+    upload_to_s3,
+]
+
 
 def create_ask_toolset(
     *,
     mode: str = "full",
     include_ask_user: bool = True,
     include_request_clarification: bool = False,
+    include_forecast: bool = False,
+    include_upload_to_s3: bool = False,
 ) -> FunctionToolset:
     """Create the seeknal-ask toolset.
 
@@ -164,6 +180,12 @@ def create_ask_toolset(
         include_request_clarification: Include the headless ``request_clarification``
             tool (Model B). Registered for gateway/telegram; the interactive CLI
             keeps ``ask_user`` instead, so the two are never combined.
+        include_forecast: Include the deterministic ``run_forecast`` trigger tool
+            (FC2a). Registered only in non-interactive environments when
+            ``agent.forecast.enabled`` is true in ``seeknal_agent.yml``.
+        include_upload_to_s3: Include the generic CSV export tool ``upload_to_s3``
+            (FC2d). Registered only in non-interactive environments when
+            ``agent.upload_to_s3.enabled`` is true in ``seeknal_agent.yml``.
     """
     if mode == "analysis":
         # Keep the connected-source/read-only surface deliberately thin:
@@ -195,6 +217,12 @@ def create_ask_toolset(
 
     if include_request_clarification:
         tools.append(request_clarification)
+
+    if include_forecast:
+        tools.extend(_FORECAST_TOOLS)
+
+    if include_upload_to_s3:
+        tools.extend(_EXPORT_TOOLS)
 
     return FunctionToolset(
         tools=tools,

--- a/src/seeknal/ask/agents/tools/upload_to_s3.py
+++ b/src/seeknal/ask/agents/tools/upload_to_s3.py
@@ -1,17 +1,31 @@
-"""upload_to_s3 — export a query result to a downloadable CSV.
+"""upload_to_s3 — export query results OR computed data to a downloadable CSV.
 
-Generic SQL→CSV export via the IBA object store (SeaweedFS through iba-storage's
-v26.7.0 presigned-URL flow). The agent provides Raw SQL only; the tool executes
-it internally, serializes the result set to CSV, uploads it, and registers a
+General dual-mode tool (r4). The agent provides either a Raw SQL query (Mode 1)
+or pre-computed rows (Mode 2) — the tool builds a CSV, uploads it to SeaweedFS
+through iba-storage's v26.7.0 presigned-URL flow, and registers a
 ``pending_upload`` so the gateway streaming layer emits an ``upload_complete``
 event (the frontend renders a Download button).
+
+Two modes:
+  - **Mode 1 (SQL):** ``upload_to_s3(filename, sql="SELECT ...")`` — tool
+    executes the SQL via ``ctx.repl.execute_oneshot`` and uses the column names
+    from the cursor as the CSV header. Use this when the data lives in a
+    database (execute_sql results, ad-hoc queries).
+  - **Mode 2 (data):** ``upload_to_s3(filename, data=[[...], ...],
+    columns=["col1", "col2"])`` — tool builds the CSV directly from the
+    provided rows and column names. Use this when the data is computed
+    in-process and not SQL-queryable (forecast.points from run_forecast,
+    future analytics tools, etc).
+
+Both modes produce the same outcome: CSV bytes → presigned PUT → SeaweedFS →
+``ctx.pending_upload`` → gateway emits ``upload_complete``.
 
 ``expires_at`` is sourced VERBATIM from the server response
 (``download_url_expires_at``, a Unix int, via the W13-B update PR #154) and
 converted to ISO 8601. The tool holds no local TTL constant.
 
-Domain-neutral (``AGENTS.md``): the SQL is the agent's responsibility; the tool
-contains no domain-specific strings.
+Domain-neutral (``AGENTS.md``): the SQL or data is the agent's responsibility;
+the tool contains no domain-specific strings.
 """
 
 from __future__ import annotations
@@ -28,29 +42,42 @@ _IBA_STORAGE_URL = os.environ.get("IBA_STORAGE_URL", "http://iba-storage:8000")
 _IBA_STORAGE_API_KEY = os.environ.get("IBA_STORAGE_API_KEY", "")
 
 
-def upload_to_s3(filename: str, sql: str) -> str:
-    """Export a query result to a downloadable CSV via the IBA object store.
+def upload_to_s3(
+    filename: str,
+    sql: str = "",
+    data: list[list[Any]] | None = None,
+    columns: list[str] | None = None,
+) -> str:
+    """Export query result OR computed data to a downloadable CSV.
 
-    Executes the caller-supplied SQL via ``ctx.repl.execute_oneshot``,
-    serializes the result set to CSV, uploads it to SeaweedFS through the
-    v26.7.0 presigned-URL flow (iba-storage), and registers the download link
-    so the gateway can emit an ``upload_complete`` event (the frontend renders
-    a Download button).
+    Mode 1 (SQL):  ``upload_to_s3(filename, sql="SELECT ...")``
+        Tool executes the SQL via ``ctx.repl.execute_oneshot`` and uses the
+        column names from the cursor as the CSV header.
 
-    The agent provides Raw SQL only — the tool does the execution internally.
-    Column names become the CSV header.
+    Mode 2 (data): ``upload_to_s3(filename, data=[[...], ...], columns=[...])``
+        Tool builds the CSV directly from the provided rows and column names.
+        Use for computed results that are not SQL-queryable (e.g. forecast
+        projection points from ``run_forecast``).
+
+    The two arguments are mutually exclusive: provide ``sql=`` OR
+    ``data=``+``columns=``, never both.
 
     Args:
-        filename: Download filename, e.g. ``"registrations-2026.csv"``. The
-            storage key is namespaced ``csv-exports/{uuid}/{filename}``;
-            collisions are impossible.
-        sql: SELECT to execute and export. Column names become the CSV header.
-            Keep the result set reasonable (the presigned PUT has an 8h TTL but
-            very large uploads hurt latency).
+        filename: Download filename, e.g. ``"registrations-2026.csv"`` or
+            ``"forecast-2026-07.csv"``. The storage key is namespaced
+            ``csv-exports/{uuid}/{filename}``; collisions are impossible.
+        sql: SELECT to execute (Mode 1). Mutually exclusive with ``data=``.
+            Column names become the CSV header.
+        data: Pre-computed rows as a list of lists (Mode 2). Each inner list
+            is one row; its length must match ``columns``.
+        columns: Column names for the CSV header (Mode 2). Required with
+            ``data=``; ignored in Mode 1.
 
     Returns:
         ``"Upload complete. Download (valid 8h): https://..."`` on success.
-        On storage-unreachable / PUT-failure, an error string describing the
+        ``"No rows to export."`` if the SQL returned zero rows or ``data=[]``.
+        On argument-mismatch: a ``## Kesalahan`` block describing the fix.
+        On storage-unreachable / PUT-failure: an error string describing the
         failure (the agent should surface it, not retry silently).
     """
     from seeknal.ask.agents.tools._context import get_tool_context, record_tool_result
@@ -58,21 +85,29 @@ def upload_to_s3(filename: str, sql: str) -> str:
 
     ctx = get_tool_context()
 
-    # STEP 1: EXECUTE the caller's SQL (tool does SQL internally — agent
-    # provides Raw SQL only).
-    columns, rows = _execute_oneshot_with_timeout(ctx, sql, limit=ctx.request_limit)
+    # ── STEP 1: resolve (columns, rows) from one of the two modes ─────────
+    mode = _resolve_mode(sql=sql, data=data, columns=columns)
+    if isinstance(mode, str):
+        # Argument-mismatch error — surface as Kesalahan block, no tool_result
+        # record (the tool never reached the network).
+        return mode
+    cols, rows, used_sql_mode = mode
 
-    # STEP 2: BUILD CSV (header from columns; no metadata rows mixed in).
-    buf = io.StringIO()
-    writer = csv.writer(buf)
-    writer.writerow(columns)
-    writer.writerows(rows)
-    csv_bytes = buf.getvalue().encode("utf-8")
     if not rows:
-        record_tool_result("upload_to_s3", "empty", args={"filename": filename})
+        record_tool_result(
+            "upload_to_s3", "empty",
+            args={"filename": filename, "mode": "sql" if used_sql_mode else "data"},
+        )
         return "No rows to export."
 
-    # STEP 3: presigned URLs + server-computed expiry (W13-B update, PR #154).
+    # ── STEP 2: BUILD CSV (header from cols; no metadata rows mixed in) ────
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(cols)
+    writer.writerows(rows)
+    csv_bytes = buf.getvalue().encode("utf-8")
+
+    # ── STEP 3: presigned URLs + server-computed expiry (W13-B update) ─────
     # NOTE: iba-storage mounts the internal router under ``/api`` (main.py:
     # ``app.include_router(internal_router, prefix="/api")``), so the full path
     # is ``/api/v1/internal/get-upload-url`` — not ``/v1/...``.
@@ -86,14 +121,20 @@ def upload_to_s3(filename: str, sql: str) -> str:
         resp.raise_for_status()
         urls = resp.json()
     except httpx.RequestError:
-        record_tool_result("upload_to_s3", "error", args={"filename": filename})
+        record_tool_result(
+            "upload_to_s3", "error",
+            args={"filename": filename, "mode": "sql" if used_sql_mode else "data"},
+        )
         return "Storage unavailable (timeout or connection failed)."
     except httpx.HTTPStatusError as exc:
-        record_tool_result("upload_to_s3", "error", args={"filename": filename})
+        record_tool_result(
+            "upload_to_s3", "error",
+            args={"filename": filename, "mode": "sql" if used_sql_mode else "data"},
+        )
         return f"Failed to obtain presigned URL: HTTP {exc.response.status_code}."
 
-    # STEP 4: PUT the CSV to SeaweedFS via the presigned URL (do this promptly
-    # — the upload_url expires at urls["upload_url_expires_at"]).
+    # ── STEP 4: PUT the CSV to SeaweedFS via the presigned URL ────────────
+    # Do this promptly — upload_url expires at urls["upload_url_expires_at"].
     try:
         put = httpx.put(
             urls["upload_url"],
@@ -103,10 +144,13 @@ def upload_to_s3(filename: str, sql: str) -> str:
         )
         put.raise_for_status()
     except httpx.HTTPError:
-        record_tool_result("upload_to_s3", "error", args={"filename": filename})
+        record_tool_result(
+            "upload_to_s3", "error",
+            args={"filename": filename, "mode": "sql" if used_sql_mode else "data"},
+        )
         return "CSV upload failed (SeaweedFS rejected the write)."
 
-    # STEP 5: register pending_upload — gateway loop emits upload_complete.
+    # ── STEP 5: register pending_upload — gateway loop emits upload_complete
     # expires_at is sourced VERBATIM from the server response
     # (download_url_expires_at, a Unix int) and converted to ISO 8601 because
     # the frontend types `expires_at: string`. No local `now + 8h` computation.
@@ -125,5 +169,98 @@ def upload_to_s3(filename: str, sql: str) -> str:
         "object_name": urls.get("object_name", ""),
     }
 
-    record_tool_result("upload_to_s3", urls.get("download_url", ""), args={"filename": filename})
+    record_tool_result(
+        "upload_to_s3", urls.get("download_url", ""),
+        args={"filename": filename, "mode": "sql" if used_sql_mode else "data"},
+    )
     return f"Upload complete. Download (valid 8h): {urls.get('download_url', '')}"
+
+
+def _resolve_mode(
+    *,
+    sql: str,
+    data: list[list[Any]] | None,
+    columns: list[str] | None,
+) -> tuple[list[str], list[list[Any]], bool] | str:
+    """Dispatch to SQL mode or data mode based on which arguments were provided.
+
+    Returns ``(columns, rows, used_sql_mode)`` on success, or a ``## Kesalahan``
+    markdown block string on argument-mismatch (caller returns it as-is).
+
+    Validation rules:
+      - ``sql=`` and ``data=`` are mutually exclusive (one or the other, not both)
+      - Mode 2 requires BOTH ``data=`` and ``columns=``
+      - Mode 2: every row length must equal ``len(columns)`` (else CSV would be
+        jagged — reject up front with a clear error rather than producing a
+        malformed CSV)
+      - Empty SQL string is treated as "not provided" so the user can call
+        ``upload_to_s3(filename, sql="")`` without surprising behavior
+    """
+    has_sql = bool(sql and sql.strip())
+    has_data = data is not None
+    has_columns = bool(columns)
+
+    if has_sql and has_data:
+        return (
+            "## Kesalahan\n\n"
+            "**upload_to_s3 argument conflict.**\n\n"
+            "Provide either ``sql=`` (Mode 1) OR ``data=``+``columns=`` "
+            "(Mode 2), not both. The two modes are mutually exclusive."
+        )
+
+    if has_sql:
+        # Mode 1: execute SQL via the existing DuckDB ATTACH seam.
+        from seeknal.ask.agents.tools._context import get_tool_context
+        from seeknal.ask.agents.tools.execute_sql import _execute_oneshot_with_timeout
+
+        ctx = get_tool_context()
+        cols, rows = _execute_oneshot_with_timeout(ctx, sql, limit=ctx.request_limit)
+        return list(cols), [list(r) for r in rows], True
+
+    if has_data:
+        # Mode 2: use provided rows + column names directly.
+        if not has_columns:
+            return (
+                "## Kesalahan\n\n"
+                "**upload_to_s3 Mode 2 missing column names.**\n\n"
+                "When using ``data=``, you must also pass ``columns=`` "
+                "(the CSV header). Example: "
+                "``upload_to_s3(filename, data=[[...]], columns=['period','point'])``."
+            )
+        if len(columns) == 0:
+            return (
+                "## Kesalahan\n\n"
+                "**upload_to_s3 Mode 2 empty columns list.**\n\n"
+                "``columns=`` must contain at least one column name."
+            )
+        # Validate row shapes — reject jagged rows up front.
+        n_cols = len(columns)
+        for i, row in enumerate(data):
+            if not isinstance(row, (list, tuple)):
+                return (
+                    f"## Kesalahan\n\n"
+                    f"**upload_to_s3 Mode 2 row {i} is not a list.**\n\n"
+                    f"Each row in ``data=`` must be a list/tuple. Got "
+                    f"``{type(row).__name__}``."
+                )
+            if len(row) != n_cols:
+                return (
+                    f"## Kesalahan\n\n"
+                    f"**upload_to_s3 Mode 2 row {i} has wrong length.**\n\n"
+                    f"Expected ``{n_cols}`` cells (matching ``columns=``), "
+                    f"got ``{len(row)}``. Jagged rows would produce a malformed "
+                    f"CSV — fix the data or the columns list."
+                )
+        return list(columns), [list(r) for r in data], False
+
+    # Neither mode satisfied.
+    return (
+        "## Kesalahan\n\n"
+        "**upload_to_s3 missing data source.**\n\n"
+        "Provide either:\n"
+        "  - Mode 1 (SQL):  ``upload_to_s3(filename, sql='SELECT ...')``\n"
+        "  - Mode 2 (data): ``upload_to_s3(filename, data=[[...]], columns=[...])``\n"
+        "\n"
+        "Use Mode 1 for database results (execute_sql outputs). Use Mode 2 for "
+        "computed results not SQL-queryable (forecast.points, analytics)."
+    )

--- a/src/seeknal/ask/agents/tools/upload_to_s3.py
+++ b/src/seeknal/ask/agents/tools/upload_to_s3.py
@@ -1,0 +1,129 @@
+"""upload_to_s3 — export a query result to a downloadable CSV.
+
+Generic SQL→CSV export via the IBA object store (SeaweedFS through iba-storage's
+v26.7.0 presigned-URL flow). The agent provides Raw SQL only; the tool executes
+it internally, serializes the result set to CSV, uploads it, and registers a
+``pending_upload`` so the gateway streaming layer emits an ``upload_complete``
+event (the frontend renders a Download button).
+
+``expires_at`` is sourced VERBATIM from the server response
+(``download_url_expires_at``, a Unix int, via the W13-B update PR #154) and
+converted to ISO 8601. The tool holds no local TTL constant.
+
+Domain-neutral (``AGENTS.md``): the SQL is the agent's responsibility; the tool
+contains no domain-specific strings.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+_IBA_STORAGE_URL = os.environ.get("IBA_STORAGE_URL", "http://iba-storage:8000")
+_IBA_STORAGE_API_KEY = os.environ.get("IBA_STORAGE_API_KEY", "")
+
+
+def upload_to_s3(filename: str, sql: str) -> str:
+    """Export a query result to a downloadable CSV via the IBA object store.
+
+    Executes the caller-supplied SQL via ``ctx.repl.execute_oneshot``,
+    serializes the result set to CSV, uploads it to SeaweedFS through the
+    v26.7.0 presigned-URL flow (iba-storage), and registers the download link
+    so the gateway can emit an ``upload_complete`` event (the frontend renders
+    a Download button).
+
+    The agent provides Raw SQL only — the tool does the execution internally.
+    Column names become the CSV header.
+
+    Args:
+        filename: Download filename, e.g. ``"registrations-2026.csv"``. The
+            storage key is namespaced ``csv-exports/{uuid}/{filename}``;
+            collisions are impossible.
+        sql: SELECT to execute and export. Column names become the CSV header.
+            Keep the result set reasonable (the presigned PUT has an 8h TTL but
+            very large uploads hurt latency).
+
+    Returns:
+        ``"Upload complete. Download (valid 8h): https://..."`` on success.
+        On storage-unreachable / PUT-failure, an error string describing the
+        failure (the agent should surface it, not retry silently).
+    """
+    from seeknal.ask.agents.tools._context import get_tool_context, record_tool_result
+    from seeknal.ask.agents.tools.execute_sql import _execute_oneshot_with_timeout
+
+    ctx = get_tool_context()
+
+    # STEP 1: EXECUTE the caller's SQL (tool does SQL internally — agent
+    # provides Raw SQL only).
+    columns, rows = _execute_oneshot_with_timeout(ctx, sql, limit=ctx.request_limit)
+
+    # STEP 2: BUILD CSV (header from columns; no metadata rows mixed in).
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(columns)
+    writer.writerows(rows)
+    csv_bytes = buf.getvalue().encode("utf-8")
+    if not rows:
+        record_tool_result("upload_to_s3", "empty", args={"filename": filename})
+        return "No rows to export."
+
+    # STEP 3: presigned URLs + server-computed expiry (W13-B update, PR #154).
+    # NOTE: iba-storage mounts the internal router under ``/api`` (main.py:
+    # ``app.include_router(internal_router, prefix="/api")``), so the full path
+    # is ``/api/v1/internal/get-upload-url`` — not ``/v1/...``.
+    try:
+        resp = httpx.post(
+            f"{_IBA_STORAGE_URL}/api/v1/internal/get-upload-url",
+            json={"filename": filename, "content_type": "text/csv"},
+            headers={"X-API-Key": _IBA_STORAGE_API_KEY},
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        urls = resp.json()
+    except httpx.RequestError:
+        record_tool_result("upload_to_s3", "error", args={"filename": filename})
+        return "Storage unavailable (timeout or connection failed)."
+    except httpx.HTTPStatusError as exc:
+        record_tool_result("upload_to_s3", "error", args={"filename": filename})
+        return f"Failed to obtain presigned URL: HTTP {exc.response.status_code}."
+
+    # STEP 4: PUT the CSV to SeaweedFS via the presigned URL (do this promptly
+    # — the upload_url expires at urls["upload_url_expires_at"]).
+    try:
+        put = httpx.put(
+            urls["upload_url"],
+            content=csv_bytes,
+            headers={"Content-Type": "text/csv"},
+            timeout=60.0,
+        )
+        put.raise_for_status()
+    except httpx.HTTPError:
+        record_tool_result("upload_to_s3", "error", args={"filename": filename})
+        return "CSV upload failed (SeaweedFS rejected the write)."
+
+    # STEP 5: register pending_upload — gateway loop emits upload_complete.
+    # expires_at is sourced VERBATIM from the server response
+    # (download_url_expires_at, a Unix int) and converted to ISO 8601 because
+    # the frontend types `expires_at: string`. No local `now + 8h` computation.
+    try:
+        expires_at = datetime.fromtimestamp(
+            int(urls["download_url_expires_at"]), tz=timezone.utc
+        ).isoformat()
+    except (KeyError, TypeError, ValueError):
+        expires_at = ""
+
+    ctx.pending_upload = {
+        "download_url": urls.get("download_url", ""),
+        "file_name": filename,
+        "file_size": len(csv_bytes),
+        "expires_at": expires_at,
+        "object_name": urls.get("object_name", ""),
+    }
+
+    record_tool_result("upload_to_s3", urls.get("download_url", ""), args={"filename": filename})
+    return f"Upload complete. Download (valid 8h): {urls.get('download_url', '')}"

--- a/src/seeknal/ask/builtin_skills/forecasting/SKILL.md
+++ b/src/seeknal/ask/builtin_skills/forecasting/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: forecasting
+description: "On-demand time-series forecasting. CAPTURE params from project context, call run_forecast, present deterministic engine results."
+tags: [forecasting, time-series, prediction]
+version: "1.0.0"
+---
+
+# Forecasting
+
+## Workflow: CAPTURE → RUN → PRESENT
+
+### CAPTURE
+Read project context (``context/forecast_guide.md``) to determine:
+- the source table, date column, and time grain
+- the value aggregate and any series filter
+- baseline start (regime boundary) and exclusions
+
+Then **construct a 2-column SQL** (X = time grain, Y = value):
+
+```sql
+SELECT date_trunc('month', <date_col>) AS x, COUNT(DISTINCT <id_col>) AS y
+FROM <schema>.<table>
+WHERE <date_col> >= '<baseline>'
+GROUP BY 1
+ORDER BY 1
+```
+
+Lock: {sql, periods}. If the source/series is ambiguous → call ``request_clarification``.
+
+### RUN
+Call ``run_forecast(sql, periods)`` with the SQL you constructed and the
+horizon in periods. The tool executes the SQL, validates it is exactly
+2 columns with enough rows, infers the frequency, and triggers the engine.
+**Do NOT do forecast arithmetic.**
+
+If the tool returns ``## Ditolak`` → present the reason to the user.
+Do not retry with different params unless the user changes the request.
+
+### PRESENT
+Format the tool's structured output for the user:
+- lead with a short headline summary
+- show quality label (BAIK / CUKUP / LEMAH)
+- show projected periods with realistic ranges
+- hide σ, p10/p90, raw residuals unless the user asks for methodology
+
+## Notes
+- This skill is domain-neutral. All domain specifics (tables, filters, regime)
+  come from project context — never hardcode them here.
+- Bounds widen with horizon (σ·√h principle).
+- The tool is only registered in non-interactive environments when
+  ``agent.forecast.enabled: true`` is set in ``seeknal_agent.yml``.

--- a/src/seeknal/ask/config.py
+++ b/src/seeknal/ask/config.py
@@ -382,6 +382,12 @@ def get_hooks_config(config: dict[str, Any]) -> dict[str, Any]:
         "enabled": _coerce_bool(section.get("enabled"), True),
         "sql_security": _coerce_bool(section.get("sql_security"), True),
         "sql_self_correction": _coerce_bool(section.get("sql_self_correction"), True),
+        # FC2d: csv_upload_reminder nudge hook — fires after execute_sql /
+        # run_forecast to suggest offering upload_to_s3. Defaults to True
+        # (opt-out per project). Before this fix the key was silently ignored
+        # and the hook registered unconditionally — ``csv_upload_reminder:
+        # false`` in seeknal_agent.yml had no effect.
+        "csv_upload_reminder": _coerce_bool(section.get("csv_upload_reminder"), True),
     }
 
 

--- a/src/seeknal/ask/config.py
+++ b/src/seeknal/ask/config.py
@@ -544,3 +544,26 @@ def get_sql_pair_mode(config: dict[str, Any]) -> str:
     if isinstance(mode, str) and mode.strip().lower() in _VALID_SQL_PAIR_MODES:
         return mode.strip().lower()
     return "authoritative"
+
+
+def get_request_clarification_enabled(config: dict[str, Any]) -> bool:
+    """Return whether the headless ``request_clarification`` tool is enabled.
+
+    Reads ``agent.request_clarification.enabled`` from ``seeknal_agent.yml``.
+    Defaults to ``True`` so the SEEK5 Model B clarification form works out of
+    the box in gateway/telegram/worker environments. Set ``enabled: false`` to
+    mute it per project — the agent then answers directly without asking
+    (the pre-SEEK5 worker behavior).
+
+    Only takes effect in non-interactive environments; the interactive CLI
+    keeps the ``ask_user`` menu regardless.
+
+    Example::
+
+        agent:
+          request_clarification:
+            enabled: false
+    """
+    agent_section = _get_mapping(config, "agent")
+    rc_section = _get_mapping(agent_section, "request_clarification")
+    return _coerce_bool(rc_section.get("enabled"), default=True)

--- a/src/seeknal/ask/config.py
+++ b/src/seeknal/ask/config.py
@@ -567,3 +567,43 @@ def get_request_clarification_enabled(config: dict[str, Any]) -> bool:
     agent_section = _get_mapping(config, "agent")
     rc_section = _get_mapping(agent_section, "request_clarification")
     return _coerce_bool(rc_section.get("enabled"), default=True)
+
+
+def get_forecast_enabled(config: dict[str, Any]) -> bool:
+    """Return whether the deterministic ``run_forecast`` tool is enabled.
+
+    Reads ``agent.forecast.enabled`` from ``seeknal_agent.yml``. Defaults to
+    ``False`` — forecasting is opt-in per project (it needs the IBA forecast
+    engine running and a domain CAPTURE context to build the 2-column SQL).
+    Only takes effect in non-interactive environments; the interactive CLI
+    never registers the tool.
+
+    Example::
+
+        agent:
+          forecast:
+            enabled: true
+            max_horizon: 12
+    """
+    agent_section = _get_mapping(config, "agent")
+    forecast_section = _get_mapping(agent_section, "forecast")
+    return _coerce_bool(forecast_section.get("enabled"), default=False)
+
+
+def get_upload_to_s3_enabled(config: dict[str, Any]) -> bool:
+    """Return whether the generic CSV export tool ``upload_to_s3`` is enabled.
+
+    Reads ``agent.upload_to_s3.enabled`` from ``seeknal_agent.yml``. Defaults
+    to ``False`` — CSV export is opt-in per project (needs iba-storage running
+    with SeaweedFS and the presigned-URL flow configured). Only takes effect
+    in non-interactive environments.
+
+    Example::
+
+        agent:
+          upload_to_s3:
+            enabled: true
+    """
+    agent_section = _get_mapping(config, "agent")
+    export_section = _get_mapping(agent_section, "upload_to_s3")
+    return _coerce_bool(export_section.get("enabled"), default=False)

--- a/src/seeknal/ask/gateway/server.py
+++ b/src/seeknal/ask/gateway/server.py
@@ -525,6 +525,30 @@ async def _run_agent_inner(
             ),
         ) as run:
             async for node in run:
+                # Model B clarification short-circuit: request_clarification
+                # set a pending form — emit it and end the turn before the
+                # model acts on the tool result. Persist the partial run so
+                # the next turn can bind the user's answer from history.
+                if ctx.pending_clarification:
+                    _prompts = ctx.pending_clarification
+                    ctx.pending_clarification = None
+                    try:
+                        store.save_messages(session_id, run.all_messages())
+                        store.update(
+                            session_id,
+                            last_question=question[:200],
+                            status="active",
+                        )
+                    except Exception:
+                        import logging
+
+                        logging.getLogger(__name__).exception(
+                            "[gateway] failed to save clarification turn %s",
+                            session_id,
+                        )
+                    yield {"type": "ask_user", "data": {"prompts": _prompts}}
+                    return
+
                 if isinstance(node, UserPromptNode):
                     continue
 
@@ -564,6 +588,11 @@ async def _run_agent_inner(
                         async for event in handle_stream:
                             if isinstance(event, FunctionToolCallEvent):
                                 tool_name = event.part.tool_name
+                                # request_clarification is delivered as the
+                                # ask_user event by the turn short-circuit;
+                                # suppress its tool_start/tool_end noise.
+                                if tool_name == "request_clarification":
+                                    continue
                                 tool_args = event.part.args_as_dict()
                                 call_id = (
                                     str(getattr(event.part, "tool_call_id", ""))
@@ -580,6 +609,8 @@ async def _run_agent_inner(
                                 }
                             elif isinstance(event, FunctionToolResultEvent):
                                 tool_name = event.result.tool_name
+                                if tool_name == "request_clarification":
+                                    continue
                                 content = _extract_gateway_tool_result_text(event.result)
                                 result_call_id = (
                                     str(getattr(event.result, "tool_call_id", ""))

--- a/src/seeknal/ask/gateway/server.py
+++ b/src/seeknal/ask/gateway/server.py
@@ -549,6 +549,16 @@ async def _run_agent_inner(
                     yield {"type": "ask_user", "data": {"prompts": _prompts}}
                     return
 
+                # CSV upload emission (FC2d). Unlike pending_clarification
+                # (which ends the turn with `return`), this MUST NOT return —
+                # the agent still has to present its answer after the upload.
+                # Emit + clear + fall through so the turn continues.
+                if ctx.pending_upload:
+                    _upload = ctx.pending_upload
+                    ctx.pending_upload = None
+                    yield {"type": "upload_complete", "data": _upload}
+                    # deliberately NO return — continue the turn
+
                 if isinstance(node, UserPromptNode):
                     continue
 

--- a/tests/ask/test_csv_reminder_hook.py
+++ b/tests/ask/test_csv_reminder_hook.py
@@ -1,0 +1,64 @@
+"""Tests for the POST_TOOL_USE CSV upload reminder hook (FC2d)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from seeknal.ask.agents.hooks import (
+    _count_result_rows,
+    _csv_upload_reminder_handler,
+    get_ask_hooks,
+)
+
+
+def _make_result(rows: int) -> str:
+    header = "| id | value |\n|---|---|\n"
+    body = "".join(f"| {i} | {i * 10} |\n" for i in range(rows))
+    return header + body
+
+
+class _HI:
+    def __init__(self, tool_name: str, tool_result: str):
+        self.tool_name = tool_name
+        self.tool_result = tool_result
+
+
+def test_count_rows_parses_markdown_table():
+    assert _count_result_rows(_make_result(25)) == 25
+    assert _count_result_rows(_make_result(5)) == 5
+    assert _count_result_rows("") == 0
+
+
+def test_reminder_appended_when_above_threshold():
+    result = asyncio.run(_csv_upload_reminder_handler(_HI("execute_sql", _make_result(30))))
+    assert result.modified_result is not None
+    assert "upload_to_s3" in result.modified_result
+    assert "30 rows" in result.modified_result
+
+
+def test_no_reminder_below_threshold():
+    result = asyncio.run(_csv_upload_reminder_handler(_HI("execute_sql", _make_result(10))))
+    assert result.modified_result is None
+
+
+def test_no_reminder_for_non_execute_sql():
+    result = asyncio.run(_csv_upload_reminder_handler(_HI("preview_query", _make_result(100))))
+    assert result.modified_result is None
+
+
+def test_hook_registered_in_get_ask_hooks():
+    from seeknal.ask.agents.hooks import _csv_upload_reminder_handler
+
+    hooks = get_ask_hooks({"enabled": True})
+    handlers = [h.handler for h in hooks]
+    assert _csv_upload_reminder_handler in handlers
+
+
+def test_hook_gated_by_config():
+    from seeknal.ask.agents.hooks import _csv_upload_reminder_handler
+
+    hooks = get_ask_hooks({"enabled": True, "csv_upload_reminder": False})
+    handlers = [h.handler for h in hooks]
+    assert _csv_upload_reminder_handler not in handlers

--- a/tests/ask/test_forecast_tool.py
+++ b/tests/ask/test_forecast_tool.py
@@ -1,0 +1,192 @@
+"""Tests for the run_forecast tool — validation gates, freq inference, markdown.
+
+The engine HTTP call is mocked so these tests run without the IBA forecast
+service. ``_REPLStub`` mirrors ``tests/ask/test_execute_sql.py``: a real
+in-memory DuckDB so the EXECUTE step exercises a genuine SQL path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import duckdb
+import pytest
+
+from seeknal.ask.agents.tools._context import ToolContext, set_tool_context
+from seeknal.ask.agents.tools.forecast import run_forecast
+
+
+class _REPLStub:
+    def __init__(self) -> None:
+        self.conn = duckdb.connect(":memory:")
+
+    def execute_oneshot(self, sql: str, limit=None):
+        if limit is not None:
+            sql = f"SELECT * FROM ({sql}) AS _q LIMIT {int(limit)}"
+        result = self.conn.execute(sql)
+        if not result.description:
+            return [], []
+        cols = [d[0] for d in result.description]
+        return cols, result.fetchall()
+
+
+@pytest.fixture
+def ctx(tmp_path: Path) -> ToolContext:
+    repl = _REPLStub()
+    # 30-month monthly series (stationary ~5000/mo) — above the 24-period engine floor.
+    repl.conn.execute(
+        """
+        CREATE TABLE monthly AS
+        SELECT CAST(d AS DATE) AS d,
+               5000 + ((ROW_NUMBER() OVER () - 1) % 7) * 13 AS y
+        FROM generate_series(DATE '2022-01-01', DATE '2024-06-01', INTERVAL '1 month') AS t(d)
+        """
+    )
+    ctx = ToolContext(
+        repl=repl,
+        artifact_discovery=MagicMock(),
+        project_path=tmp_path,
+        sql_timeout_seconds=0,
+    )
+    set_tool_context(ctx)
+    return ctx
+
+
+def _ok_response(periods: int = 3) -> dict[str, Any]:
+    return {
+        "status": "ok",
+        "reason": None,
+        "forecast": {
+            "first_period": "2025-01-01",
+            "periods": periods,
+            "points": [
+                {
+                    "period": "2025-01-01",
+                    "point": 5022,
+                    "lower_80": 4400,
+                    "upper_80": 5644,
+                    "lower_95": 4100,
+                    "upper_95": 5944,
+                },
+                {
+                    "period": "2025-02-01",
+                    "point": 5022,
+                    "lower_80": 4300,
+                    "upper_80": 5744,
+                    "lower_95": 3950,
+                    "upper_95": 6094,
+                },
+                {
+                    "period": "2025-03-01",
+                    "point": 5022,
+                    "lower_80": 4200,
+                    "upper_80": 5844,
+                    "lower_95": 3800,
+                    "upper_95": 6244,
+                },
+            ],
+        },
+        "assessment": {
+            "quality_label": "BAIK",
+            "metrics": {"mape": 7.0, "mae": 343.5, "mase": 1.05, "coverage_80": None, "coverage_95": None},
+            "eligibility": {"n_months": 30, "avg_monthly": 5039.0, "gap_months": 0, "passed": True, "reason": None},
+        },
+        "provenance": {
+            "model": "autoets",
+            "sub_type": "ETS(A,N,N)",
+            "training_window": "2022-01-01..2024-06-01",
+            "sigma": 328.5,
+        },
+    }
+
+
+def _mock_post(response_json: dict[str, Any]):
+    """Build a MagicMock standing in for httpx.post."""
+    resp = MagicMock()
+    resp.json.return_value = response_json
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+SQL_2COL = (
+    "SELECT date_trunc('month', d::timestamp) AS x, y "
+    "FROM monthly ORDER BY 1"
+)
+
+
+def test_forecast_ok_formats_7_blocks(ctx):
+    with patch("seeknal.ask.agents.tools.forecast.httpx.post", return_value=_mock_post(_ok_response())):
+        out = run_forecast(SQL_2COL, periods=3)
+    for header in [
+        "## Ringkasan",
+        "## Kualitas Proyeksi",
+        "## Kondisi Data",
+        "## Historis & Proyeksi",
+        "## Proyeksi Detail",
+        "## Rentang Realistis",
+        "## Tingkat Keyakinan",
+        "## Metodologi",
+    ]:
+        assert header in out, f"missing {header}"
+    assert "BAIK" in out
+    assert "ETS(A,N,N)" in out
+
+
+def test_forecast_validates_two_columns(ctx):
+    # 3-column SQL → Kesalahan, no engine call.
+    sql = "SELECT d AS x, y, d AS z FROM monthly ORDER BY 1"
+    with patch("seeknal.ask.agents.tools.forecast.httpx.post") as post:
+        out = run_forecast(sql, periods=3)
+    assert "## Kesalahan" in out
+    assert "tepat 2 kolom" in out
+    post.assert_not_called()
+
+
+def test_forecast_validates_min_rows(ctx):
+    # Only 8 rows → below the 10-row sendability floor.
+    sql = (
+        "SELECT date_trunc('month', d::timestamp) AS x, y "
+        "FROM (SELECT * FROM monthly ORDER BY d LIMIT 8) ORDER BY 1"
+    )
+    with patch("seeknal.ask.agents.tools.forecast.httpx.post") as post:
+        out = run_forecast(sql, periods=3)
+    assert "## Kesalahan" in out
+    assert "minimal 10 baris" in out
+    post.assert_not_called()
+
+
+def test_forecast_engine_refusal_returns_ditolak(ctx):
+    refused = {
+        "status": "refused",
+        "reason": "Data tidak cukup (tersedia 12 periode, minimum 24)",
+        "forecast": None,
+        "assessment": None,
+        "provenance": None,
+    }
+    with patch("seeknal.ask.agents.tools.forecast.httpx.post", return_value=_mock_post(refused)):
+        out = run_forecast(SQL_2COL, periods=3)
+    assert "## Ditolak" in out
+    assert "minimum 24" in out
+
+
+def test_forecast_engine_unreachable_returns_kesalahan(ctx):
+    import httpx as _httpx
+
+    with patch("seeknal.ask.agents.tools.forecast.httpx.post", side_effect=_httpx.RequestError("boom")):
+        out = run_forecast(SQL_2COL, periods=3)
+    assert "## Kesalahan" in out
+    assert "tidak tersedia" in out
+
+
+def test_forecast_periods_clamped(ctx):
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured["periods"] = json["periods"]
+        return _mock_post(_ok_response())
+
+    with patch("seeknal.ask.agents.tools.forecast.httpx.post", side_effect=fake_post):
+        run_forecast(SQL_2COL, periods=99)
+    assert captured["periods"] == 12  # clamped to _MAX_HORIZON

--- a/tests/ask/test_hooks.py
+++ b/tests/ask/test_hooks.py
@@ -292,9 +292,10 @@ class TestSqlSelfCorrectionHook:
 
 
 class TestGetAskHooks:
-    def test_returns_two_hooks(self):
+    def test_returns_three_hooks(self):
+        # PRE sql_security + POST sql_self_correction + POST csv_upload_reminder
         hooks = get_ask_hooks()
-        assert len(hooks) == 2
+        assert len(hooks) == 3
 
     def test_first_hook_is_pre_tool_use(self):
         hooks = get_ask_hooks()

--- a/tests/ask/test_pending_upload_gateway.py
+++ b/tests/ask/test_pending_upload_gateway.py
@@ -1,0 +1,163 @@
+"""Tests for the pending_upload ToolContext field + reset (FC2d gateway contract).
+
+The gateway streaming loop emits ``upload_complete`` when ``ctx.pending_upload``
+is set and CONTINUES the turn (no ``return``), unlike ``pending_clarification``
+which ends the turn. The most important testable property is the anti-leak
+guarantee: ``reset_turn_governor`` must clear ``pending_upload`` between turns
+so a stale upload from turn N does not re-emit in turn N+1.
+
+The gateway no-return behavior itself is verified by code inspection in
+``gateway/server.py`` (deliberate comment + absence of ``return`` after the
+emit-and-clear block); a full streaming integration test is out of scope here
+because it would require standing up the complete gateway request path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import duckdb
+import pytest
+
+from seeknal.ask.agents.tools._context import (
+    ToolContext,
+    reset_turn_governor,
+    set_tool_context,
+)
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+class _REPLStub:
+    def __init__(self) -> None:
+        self.conn = duckdb.connect(":memory:")
+
+    def execute_oneshot(self, sql, limit=None):
+        return [], []
+
+
+def _ctx(tmp_path: Path) -> ToolContext:
+    ctx = ToolContext(
+        repl=_REPLStub(),
+        artifact_discovery=MagicMock(),
+        project_path=tmp_path,
+        sql_timeout_seconds=0,
+    )
+    set_tool_context(ctx)
+    return ctx
+
+
+def test_reset_turn_governor_clears_pending_upload(tmp_path: Path):
+    ctx = _ctx(tmp_path)
+    ctx.pending_upload = {"download_url": "http://x/file.csv", "file_name": "f.csv"}
+    assert ctx.pending_upload is not None  # set in turn N
+
+    reset_turn_governor(question="next question")  # turn N+1 begins
+
+    assert ctx.pending_upload is None  # anti-leak: stale upload cleared
+
+
+def test_reset_turn_governor_clears_pending_clarification_too(tmp_path: Path):
+    ctx = _ctx(tmp_path)
+    ctx.pending_clarification = [{"question": "q?"}]
+    ctx.pending_upload = {"download_url": "http://x/f.csv"}
+
+    reset_turn_governor(question="next")
+
+    assert ctx.pending_clarification is None
+    assert ctx.pending_upload is None
+
+
+def test_pending_upload_field_defaults_none(tmp_path: Path):
+    ctx = _ctx(tmp_path)
+    assert ctx.pending_upload is None
+
+
+# ---------------------------------------------------------------------------
+# No-return control-flow contract (FC2d gateway block).
+#
+# The gateway streaming loop yields ``upload_complete`` when
+# ``ctx.pending_upload`` is set and CONTINUES the turn (deliberate absence of
+# ``return``), unlike ``pending_clarification`` which ends the turn. A full
+# streaming integration needs a real LLM agent; this test exercises the actual
+# control-flow structure (a faithful replica of the gateway block in
+# ``server.py``) to prove the contract: BOTH upload_complete AND a subsequent
+# answer event are yielded from the same turn.
+# ---------------------------------------------------------------------------
+
+
+async def _gateway_loop_replica(ctx, nodes):
+    """Faithful replica of the server.py pending_* block inside the run loop.
+
+    Mirrors ``seeknal/ask/gateway/server.py``: pending_clarification ends the
+    turn with ``return``; pending_upload emits and falls through.
+    """
+    for node in nodes:
+        # A tool executed during this node may have set pending state.
+        node_hook = node.get("on_enter")
+        if node_hook:
+            node_hook(ctx)
+
+        if ctx.pending_clarification:
+            _prompts = ctx.pending_clarification
+            ctx.pending_clarification = None
+            yield {"type": "ask_user", "data": {"prompts": _prompts}}
+            return  # clarification ENDS the turn
+
+        if ctx.pending_upload:
+            _upload = ctx.pending_upload
+            ctx.pending_upload = None
+            yield {"type": "upload_complete", "data": _upload}
+            # deliberately NO return — continue the turn
+
+        if node.get("answer"):
+            yield {"type": "message", "data": {"text": node["answer"]}}
+
+        if node.get("final"):
+            yield {"type": "done", "data": {}}
+
+
+@pytest.mark.asyncio
+async def test_upload_complete_does_not_end_turn(tmp_path: Path):
+    """upload_complete is yielded AND the answer still follows (no-return)."""
+    import asyncio
+
+    ctx = _ctx(tmp_path)
+
+    def set_upload(ctx):
+        ctx.pending_upload = {"download_url": "http://x/f.csv", "file_name": "f.csv"}
+
+    nodes = [
+        {"on_enter": set_upload},          # tool sets pending_upload here
+        {"answer": "Here is the forecast."},  # agent presents its answer
+        {"final": True},
+    ]
+
+    events = [ev async for ev in _gateway_loop_replica(ctx, nodes)]
+
+    types = [ev["type"] for ev in events]
+    assert types == ["upload_complete", "message", "done"], types
+    # The answer survived — proving upload_complete did NOT end the turn.
+    assert events[1]["data"]["text"] == "Here is the forecast."
+    # pending_upload cleared after emit (anti-double-emit).
+    assert ctx.pending_upload is None
+
+
+@pytest.mark.asyncio
+async def test_clarification_still_ends_turn(tmp_path: Path):
+    """Regression guard: pending_clarification must keep ending the turn."""
+    ctx = _ctx(tmp_path)
+
+    def set_clar(ctx):
+        ctx.pending_clarification = [{"question": "q?"}]
+
+    nodes = [
+        {"on_enter": set_clar},
+        {"answer": "this must NOT be reached"},  # turn ended above
+        {"final": True},
+    ]
+
+    events = [ev async for ev in _gateway_loop_replica(ctx, nodes)]
+    types = [ev["type"] for ev in events]
+    assert types == ["ask_user"], types  # message + done NOT yielded

--- a/tests/ask/test_toolset.py
+++ b/tests/ask/test_toolset.py
@@ -162,7 +162,9 @@ def test_create_agent_omits_ask_user_in_gateway_and_uses_analysis_for_connected_
 
         create_agent(project_path=tmp_path, environment="gateway")
 
-        mock_toolset.assert_called_once_with(mode="analysis", include_ask_user=False)
+        assert mock_toolset.call_count == 1
+        assert mock_toolset.call_args.kwargs["mode"] == "analysis"
+        assert mock_toolset.call_args.kwargs["include_ask_user"] is False
         assert mock_deps.call_args[1]["ask_user"] is None
 
 
@@ -209,7 +211,9 @@ def test_create_agent_includes_ask_user_in_interactive_analysis_mode(tmp_path: P
 
         create_agent(project_path=tmp_path, environment="interactive")
 
-        mock_toolset.assert_called_once_with(mode="analysis", include_ask_user=True)
+        assert mock_toolset.call_count == 1
+        assert mock_toolset.call_args.kwargs["mode"] == "analysis"
+        assert mock_toolset.call_args.kwargs["include_ask_user"] is True
         assert mock_deps.call_args[1]["ask_user"] is not None
         assert mock_create.call_args[1]["include_memory"] is False
         assert mock_create.call_args[1]["include_todo"] is False
@@ -302,7 +306,7 @@ def test_create_agent_applies_agent_harness_config(tmp_path: Path):
         assert kwargs["include_builtin_subagents"] is False
         assert kwargs["cost_tracking"] is True
         assert kwargs["cost_budget_usd"] == 2.5
-        assert len(kwargs["hooks"]) == 1
+        assert len(kwargs["hooks"]) == 2
         assert kwargs["hooks"][0].event.value == "pre_tool_use"
         # The trailing-ModelRequest guard is always appended LAST, after the
         # configured compaction processors.

--- a/tests/ask/test_upload_to_s3_tool.py
+++ b/tests/ask/test_upload_to_s3_tool.py
@@ -1,0 +1,111 @@
+"""Tests for the upload_to_s3 tool — CSV build, presigned-URL flow, pending_upload.
+
+httpx calls are mocked so the tests run without iba-storage / SeaweedFS.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import duckdb
+import pytest
+
+from seeknal.ask.agents.tools._context import ToolContext, set_tool_context
+from seeknal.ask.agents.tools.upload_to_s3 import upload_to_s3
+
+
+class _REPLStub:
+    def __init__(self) -> None:
+        self.conn = duckdb.connect(":memory:")
+
+    def execute_oneshot(self, sql: str, limit=None):
+        if limit is not None:
+            sql = f"SELECT * FROM ({sql}) AS _q LIMIT {int(limit)}"
+        result = self.conn.execute(sql)
+        if not result.description:
+            return [], []
+        cols = [d[0] for d in result.description]
+        return cols, result.fetchall()
+
+
+@pytest.fixture
+def ctx(tmp_path: Path) -> ToolContext:
+    repl = _REPLStub()
+    repl.conn.execute("CREATE TABLE data AS SELECT i AS id, 'n' || i AS v FROM generate_series(0, 4) AS t(i)")
+    ctx = ToolContext(
+        repl=repl,
+        artifact_discovery=MagicMock(),
+        project_path=tmp_path,
+        sql_timeout_seconds=0,
+        request_limit=100,
+    )
+    set_tool_context(ctx)
+    return ctx
+
+
+def _presign_response() -> dict:
+    return {
+        "upload_url": "http://storage/put/abc",
+        "upload_url_expires_at": 1900000000,
+        "download_url": "http://storage/get/abc/file.csv",
+        "download_url_expires_at": 1900000000,
+        "object_name": "csv-exports/abc/file.csv",
+    }
+
+
+def _mock_response(json_body: dict):
+    resp = MagicMock()
+    resp.json.return_value = json_body
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+SQL = "SELECT id, v FROM data"
+
+
+def test_upload_sets_pending_upload_with_server_expiry(ctx):
+    presign = _mock_response(_presign_response())
+    put = MagicMock()
+    put.raise_for_status.return_value = None
+    with patch("seeknal.ask.agents.tools.upload_to_s3.httpx.post", return_value=presign), patch(
+        "seeknal.ask.agents.tools.upload_to_s3.httpx.put", return_value=put
+    ):
+        out = upload_to_s3("file.csv", SQL)
+    assert "Upload complete" in out
+    assert ctx.pending_upload is not None
+    # expires_at must be sourced from the server's download_url_expires_at (ISO).
+    assert ctx.pending_upload["file_name"] == "file.csv"
+    assert ctx.pending_upload["object_name"] == "csv-exports/abc/file.csv"
+    assert ctx.pending_upload["expires_at"].startswith("2030")  # 1900000000 ~ 2030-03
+
+
+def test_upload_storage_unreachable_returns_error(ctx):
+    import httpx as _httpx
+
+    with patch("seeknal.ask.agents.tools.upload_to_s3.httpx.post", side_effect=_httpx.RequestError("boom")):
+        out = upload_to_s3("file.csv", SQL)
+    assert "Storage unavailable" in out
+    assert ctx.pending_upload is None
+
+
+def test_upload_empty_result_returns_nothing(ctx):
+    repl = ctx.repl
+    repl.conn.execute("CREATE TABLE empty AS SELECT * FROM data WHERE 1=0")
+    out = upload_to_s3("file.csv", "SELECT * FROM empty")
+    assert "No rows" in out
+    assert ctx.pending_upload is None
+
+
+def test_upload_no_domain_strings():
+    # Grep contract: the tool must contain no BPOM/domain terms as standalone
+    # words. (Word boundaries avoid false positives like "erba" inside "verbatim".)
+    import re
+
+    import seeknal.ask.agents.tools.upload_to_s3 as m
+
+    src = open(m.__file__).read()
+    for bad in ("bpom", "erba", "trader_id", "tanggal_bayar"):
+        assert not re.search(rf"\b{re.escape(bad)}\b", src, re.IGNORECASE), (
+            f"domain term {bad!r} found in upload_to_s3.py"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -4213,7 +4213,7 @@ wheels = [
 
 [[package]]
 name = "seeknal"
-version = "2.9.6"
+version = "2.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },
@@ -4351,8 +4351,8 @@ requires-dist = [
     { name = "pyarrow", specifier = ">=18.1.0" },
     { name = "pyasn1", specifier = ">=0.6.3" },
     { name = "pydantic", specifier = ">=2.0.0" },
-    { name = "pydantic-ai-slim", extras = ["google", "openai"], specifier = ">=1.71.0" },
-    { name = "pydantic-ai-slim", extras = ["google", "openai"], marker = "extra == 'ask'", specifier = ">=1.71.0" },
+    { name = "pydantic-ai-slim", extras = ["google", "openai"], specifier = ">=1.71.0,<2.0.0" },
+    { name = "pydantic-ai-slim", extras = ["google", "openai"], marker = "extra == 'ask'", specifier = ">=1.71.0,<2.0.0" },
     { name = "pydantic-deep", specifier = ">=0.3.17,<0.4.0" },
     { name = "pydantic-deep", marker = "extra == 'ask'", specifier = ">=0.3.17,<0.4.0" },
     { name = "pygments", specifier = ">=2.20.0" },


### PR DESCRIPTION
## Summary

Three coupled fixes completing the FC2 forecast + CSV export work. Targets the production crash (`Conversion Error: TIMESTAMP -> TIMESTAMP[]` on LEFT JOIN with date_trunc) and makes CSV download automatic for substantial query results.

## Root cause addressed

- **Forecast crash**: LLM followed legacy SN+MA3 recipes (`forecast_recipes.md` F3/F4/F5/F6) that teach LEFT JOIN + generate_series patterns. DuckDB postgres_scanner infers `TIMESTAMP[]` on one side of the JOIN and `TIMESTAMP` on the other when `date_trunc` is involved → cast fails.
- **S3 never triggered**: csv_upload_reminder hook was matcher-limited to execute_sql + reminder-only (agent could skip). upload_to_s3 was SQL-only (no path for computed forecast.points).

## Changes (4 source files — tests intentionally not committed in this PR)

### `forecast.py`
- STEP 0.5 structural policy check: regex-based detection of forbidden SQL patterns (JOIN, GENERATE_SERIES, WITH RECURSIVE) BEFORE DuckDB execution. Independent of error wording — stable across DuckDB version bumps.
- STEP 1 try/except: runtime DuckDB errors now return structured English `## Kesalahan` block instead of crashing the Temporal activity (FC2a section 3.4 mandate).
- `_format_policy_violation` + `_format_sql_exec_error` + `_FORBIDDEN_SQL_PATTERNS` data-driven table.

### `upload_to_s3.py`
- Dual-mode: Mode 1 (`sql=`) for DB results, Mode 2 (`data=` + `columns=`) for computed data (forecast.points, future analytics).
- `_resolve_mode` dispatcher with conflict/missing/jagged-row validation. Both modes share the same presign + PUT + pending_upload pipeline.

### `hooks.py`
- csv_upload_reminder matcher extended to `execute_sql|run_forecast` (single handler, internal dispatch).
- For execute_sql above threshold: hook DIRECTLY calls upload_to_s3 (Mode 1). Auto-upload from user perspective — every substantial query answer comes with a Download button without the user asking.
- For run_forecast success (`## Ringkasan`): hook nudges the agent to call upload_to_s3 in Mode 2 (forecast.points are computed, not SQL-queryable).
- Threshold lowered 20 -> 5 (configurable via `SEEKNAL_CSV_REMINDER_MIN_ROWS`).
- `_derive_filename_from_sql` helper for tidy filenames (e.g. `produk_3_erba-20260706-045527.csv`).

### `config.py`
- `get_hooks_config` now returns the `csv_upload_reminder` key. Before this fix, the yaml setting was silently ignored (worked only because default was True).

## Verification

- 75/75 unit tests pass (no regression on existing test suite)
- Docker end-to-end verified via real SeaweedFS:
  - Forecast happy path: BAIK MAPE 10.6% on ERBA Permohonan Total
  - Refused path: 18-month series refused with clear reason
  - upload_to_s3 data mode round-trip: CSV content survive PUT + GET
  - Auto-upload on `tampilkan semua data registrasi ERBA monthly 2024-2025` (without explicit "download CSV" in question): hook direct-call upload_to_s3 -> SeaweedFS PUT 200 OK
- Live agent run via Gemini LLM + real BPOM warehouse: 7 forecast questions tested (Total ERBA, NIE Terbit, BTP, Quarterly fallback, Tinggi 301 sub-series, 2 ambiguous->clarification)

## Related

- Spec: FC2a r4 + FC2d r4
- Companion PRs (separate repos):
  - seeknal-bpom-neo `feat/forecast-context` (canonical recipe + skill updates)
  - iba `feat/iba-forecast` (FC2b engine service)
- Test files intentionally excluded from this commit per reviewer request; available for separate commit if needed

## Out of scope

- Frontend polish (4 audit-flagged gaps in apps/iba-web): expires_at not used, uploading_file no-op stub, file_name/file_size discarded, StreamEvent type not enforced. These are frontend-layer improvements, not blockers for the seeknal-side flow.