### PR TITLE
feat(forecast): anomaly tool + ETS seasonal engine integration

### DIFF
--- a/src/seeknal/ask/access/registry.py
+++ b/src/seeknal/ask/access/registry.py
@@ -44,10 +44,8 @@ _VIEWER_TOOLS = {
     "extract_from_image",
     "extract_finance_document",
     "ask_user",
-    # FC2: forecast + CSV export tools. Both execute read-only SQL (or accept
-    # pre-computed data) and produce user-facing output (markdown / CSV in
-    # SeaweedFS). No DB writes — same privilege class as execute_sql.
     "run_forecast",
+    "detect_anomaly",
     "upload_to_s3",
 }
 

--- a/src/seeknal/ask/agents/agent.py
+++ b/src/seeknal/ask/agents/agent.py
@@ -225,6 +225,7 @@ def create_agent(
         get_ask_toolset_mode,
         get_request_clarification_enabled,
         get_forecast_enabled,
+        get_anomaly_enabled,
         get_upload_to_s3_enabled,
         get_auto_summarization_config,
         get_cost_tracking_config,
@@ -266,7 +267,7 @@ def create_agent(
 
     # Set request limit and background threshold on the per-session ToolContext
     # (NOT on module-level globals — avoids race conditions across concurrent sessions)
-    from seeknal.ask.agents.tools._context import get_tool_context
+    from seeknal.ask.agents.tools._context import _resolve_engine_url, get_tool_context
 
     tool_ctx = get_tool_context()
     tool_ctx.request_limit = get_request_limit(agent_config)
@@ -278,6 +279,15 @@ def create_agent(
     tool_ctx.sql_pair_mode = get_sql_pair_mode(agent_config)
     if analysis_toolset:
         tool_ctx.tool_call_limit = 24
+
+    # IBA forecast-engine connection: resolved once here (session init),
+    # never inside run_forecast/detect_anomaly themselves. See
+    # ToolContext.iba_forecast_url docstring in _context.py.
+    import os as _os
+
+    tool_ctx.iba_forecast_url = _resolve_engine_url("forecast")
+    tool_ctx.iba_anomaly_url = _resolve_engine_url("anomaly")
+    tool_ctx.iba_forecast_api_key = _os.environ.get("IBA_FORECAST_API_KEY", "")
 
     # Build final system prompt via section registry (4-layer architecture)
     from seeknal.ask.prompt_builder import create_default_builder
@@ -416,6 +426,10 @@ in the final response.
             include_forecast=(
                 environment in ("gateway", "telegram")
                 and get_forecast_enabled(agent_config)
+            ),
+            include_anomaly=(
+                environment in ("gateway", "telegram")
+                and get_anomaly_enabled(agent_config)
             ),
             include_upload_to_s3=(
                 environment in ("gateway", "telegram")

--- a/src/seeknal/ask/agents/tools/_context.py
+++ b/src/seeknal/ask/agents/tools/_context.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import contextvars
 import hashlib
 import json
+import os
 import threading
 import uuid
 from dataclasses import dataclass, field
@@ -96,6 +97,45 @@ class ToolContext:
     # ``upload_complete`` event and CONTINUES the turn — unlike
     # pending_clarification which ends it. ``None`` means no upload is pending.
     pending_upload: dict[str, Any] | None = None
+    # IBA forecast-engine connection, resolved ONCE at agent init (see
+    # agent.py::create_agent) via _resolve_engine_url() below and injected
+    # here -- same pattern as ``repl``/``project_path``. run_forecast and
+    # detect_anomaly read these off ctx; neither tool touches os.environ
+    # itself, so the tool files stay pure functions triggered by
+    # docstring/skill/context, with connectivity supplied externally.
+    iba_forecast_url: str | None = None
+    iba_anomaly_url: str | None = None
+    iba_forecast_api_key: str = ""
+
+
+def _resolve_engine_url(endpoint: str) -> str | None:
+    """Resolve the IBA forecast-engine URL for one endpoint ("forecast" or "anomaly").
+
+    Priority: IBA_FORECAST_URL (direct engine URL) > SEEKNAL_GATEWAY_URL
+    (proxied through the gateway). Returns None when neither is configured --
+    the engine connection is deployment-specific infrastructure, not
+    something a tool should guess a docker-internal hostname for. Called
+    once at session init (agent.py) and stored on ToolContext; tool modules
+    never read os.environ directly.
+    """
+    direct = os.environ.get("IBA_FORECAST_URL", "").strip()
+    if direct:
+        base = direct.rstrip("/")
+        for suffix in ("/forecast", "/anomaly"):
+            if base.endswith(suffix):
+                base = base[: -len(suffix)]
+        return f"{base}/{endpoint}"
+    gateway = os.environ.get("SEEKNAL_GATEWAY_URL", "").strip()
+    if gateway:
+        return gateway.rstrip("/").removesuffix("/v6") + f"/v6/internal/{endpoint}"
+    return None
+
+
+ENGINE_NOT_CONFIGURED = (
+    "## Kesalahan\n\nForecast engine belum dikonfigurasi -- set environment "
+    "variable IBA_FORECAST_URL (URL langsung ke engine) atau "
+    "SEEKNAL_GATEWAY_URL (proxy gateway)."
+)
 
 
 def _make_registry():

--- a/src/seeknal/ask/agents/tools/anomaly.py
+++ b/src/seeknal/ask/agents/tools/anomaly.py
@@ -1,0 +1,163 @@
+"""detect_anomaly — anomaly awareness tool.
+
+Sibling to run_forecast: same 2-column SQL contract, same execution
+pipeline, same engine. Explains which periods in a series look unusual and
+why -- it never removes data and never returns forecast numbers.
+
+Two ways an anomaly explanation reaches the user: the agent calls this tool
+directly for an anomaly-intent question, or run_forecast's own response
+already carries an automatic explanation when its backtest MAPE is poor
+(the engine attaches it server-side). This tool is for the standalone,
+on-demand case.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+# No engine URL/API key here: connectivity is resolved once at session init
+# (agent.py) and injected via ToolContext.iba_anomaly_url/iba_forecast_api_key
+# -- this module never reads os.environ. See _context.py's ToolContext.
+
+_MIN_ROWS = 3  # matches the engine's own floor for anomaly detection
+_ANOMALY_PULL_LIMIT = 500
+
+
+def detect_anomaly(sql: str) -> str:
+    """Explain which periods in a time series look unusual, and why.
+
+    Executes the caller-supplied SQL (which MUST return exactly two columns:
+    X = a time-grain timestamp, Y = a numeric value), and sends the series
+    to the IBA forecast engine's anomaly-detection endpoint. This tool NEVER
+    removes data and NEVER computes a forecast -- for a forecast, use
+    run_forecast instead. Use this when the user asks specifically about
+    anomalies/outliers/pencilan in a series, or wants to understand why a
+    forecast's accuracy is poor.
+
+    Construct the SQL the same way as for run_forecast (see
+    context/forecast_guide.md): the first column is the time grain, the
+    second is the aggregate.
+
+    Args:
+        sql: A SELECT that returns exactly two columns: ``[x, y]`` where
+            ``x`` is a timestamp/DATE and ``y`` is a non-negative number.
+            Must be ordered by ``x`` ascending and aggregated to one row
+            per period.
+
+    Returns:
+        A markdown block listing flagged periods (date, value, and a
+        plain-language reason hint), or a note that no anomalies were
+        found. On local validation failure (wrong column count, too few
+        rows) returns a ``## Kesalahan`` block describing the problem.
+    """
+    from seeknal.ask.agents.tools._context import (
+        ENGINE_NOT_CONFIGURED,
+        get_tool_context,
+        make_tool_signature,
+        record_tool_result,
+    )
+    from seeknal.ask.agents.tools.execute_sql import (
+        _execute_oneshot_with_timeout,
+        _repair_common_sql_before_execution,
+    )
+    from seeknal.ask.agents.tools.forecast import (
+        _coerce_x,
+        _coerce_y,
+        _detect_forbidden_patterns,
+        _format_policy_violation,
+        _format_sql_exec_error,
+    )
+
+    ctx = get_tool_context()
+    if ctx.iba_anomaly_url is None:
+        return ENGINE_NOT_CONFIGURED
+
+    sql = str(sql).strip().rstrip(";").strip()
+    sql, _notices = _repair_common_sql_before_execution(sql)
+
+    forbidden = _detect_forbidden_patterns(sql)
+    if forbidden:
+        record_tool_result(
+            "detect_anomaly", "error",
+            args={"sql_sig": make_tool_signature("detect_anomaly", {"sql": sql})},
+        )
+        return _format_policy_violation(sql, forbidden)
+
+    try:
+        columns, rows = _execute_oneshot_with_timeout(
+            ctx, sql, limit=_ANOMALY_PULL_LIMIT
+        )
+    except Exception as exc:
+        record_tool_result(
+            "detect_anomaly", "error",
+            args={"sql_sig": make_tool_signature("detect_anomaly", {"sql": sql})},
+        )
+        return _format_sql_exec_error(exc, sql)
+
+    if len(columns) != 2:
+        record_tool_result(
+            "detect_anomaly", "error",
+            args={"sql_sig": make_tool_signature("detect_anomaly", {"sql": sql})},
+        )
+        return (
+            f"## Kesalahan\n\nSQL harus mengembalikan tepat 2 kolom "
+            f"(X waktu, Y nilai); dapat {len(columns)}."
+        )
+    if len(rows) < _MIN_ROWS:
+        record_tool_result(
+            "detect_anomaly", "error",
+            args={"sql_sig": make_tool_signature("detect_anomaly", {"sql": sql})},
+        )
+        return f"## Kesalahan\n\nData minimal {_MIN_ROWS} baris untuk deteksi anomali; dapat {len(rows)}."
+
+    data = [[_coerce_x(r[0]), _coerce_y(r[1])] for r in rows]
+    data = [[x, y] for x, y in data if x is not None and y is not None]
+    if len(data) < _MIN_ROWS:
+        return (
+            f"## Kesalahan\n\nData minimal {_MIN_ROWS} baris valid untuk deteksi "
+            f"anomali; dapat {len(data)} setelah filter NULL."
+        )
+
+    try:
+        resp = httpx.post(
+            ctx.iba_anomaly_url,
+            json={"data": data},
+            headers={"X-API-Key": ctx.iba_forecast_api_key},
+            timeout=60.0,
+        )
+        resp.raise_for_status()
+        result: dict[str, Any] = resp.json()
+    except httpx.HTTPStatusError as exc:
+        record_tool_result(
+            "detect_anomaly", "error",
+            args={"sql_sig": make_tool_signature("detect_anomaly", {"sql": sql})},
+        )
+        return f"## Kesalahan\n\nEngine error: HTTP {exc.response.status_code}."
+    except (httpx.RequestError, httpx.HTTPError):
+        record_tool_result(
+            "detect_anomaly", "error",
+            args={"sql_sig": make_tool_signature("detect_anomaly", {"sql": sql})},
+        )
+        return "## Kesalahan\n\nEngine tidak tersedia (timeout atau koneksi gagal)."
+
+    record_tool_result(
+        "detect_anomaly", "ok",
+        args={"sql_sig": make_tool_signature("detect_anomaly", {"sql": sql})},
+    )
+    return _format_anomaly_markdown(result.get("anomalies") or [])
+
+
+def _format_anomaly_markdown(anomalies: list[dict[str, Any]]) -> str:
+    if not anomalies:
+        return (
+            "## Anomali\n\n"
+            "Tidak ada periode yang menonjol sebagai anomali pada data ini."
+        )
+    lines = ["## Anomali", "", "Periode yang menonjol dibanding pola umum data:"]
+    for a in anomalies:
+        lines.append(f"- **{a.get('date')}**: {a.get('value')} -- {a.get('reason_hint')}")
+    lines.append("")
+    lines.append(f"Terdeteksi {len(anomalies)} periode anomali.")
+    return "\n".join(lines)

--- a/src/seeknal/ask/agents/tools/forecast.py
+++ b/src/seeknal/ask/agents/tools/forecast.py
@@ -3,8 +3,8 @@
 Thin trigger that mirrors ``request_clarification`` (SEEK5): the agent
 constructs a 2-column SQL from project context, and this tool owns the
 deterministic EXECUTE → VALIDATE → INFER → POST → FORMAT pipeline. The IBA
-forecast engine (FC2b) owns the AutoETS compute. The LLM does no forecast
-arithmetic.
+forecast engine (FC2b) owns the seasonal-ETS compute (Holt-Winters, single
+deterministic fit per request). The LLM does no forecast arithmetic.
 
 The tool is domain-neutral (``AGENTS.md``: *"Never hardcode customer/domain
 SQL in the agent harness"*). All domain specifics live in project context and
@@ -14,8 +14,8 @@ arrive as a single ``sql`` argument the agent assembles.
 from __future__ import annotations
 
 import logging
-import os
 import re
+from collections import Counter
 from datetime import datetime, timezone
 from typing import Any
 
@@ -23,23 +23,12 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
-# r6: forecast URL construction.
-# Priority: IBA_FORECAST_URL (direct) > SEEKNAL_GATEWAY_URL (proxy) > fallback.
-# The URL stored here is the FULL POST URL (including path).
-_FORECAST_DIRECT_URL = os.environ.get("IBA_FORECAST_URL", "")
-_GATEWAY_URL = os.environ.get("SEEKNAL_GATEWAY_URL", "")
-if _FORECAST_DIRECT_URL:
-    _IBA_FORECAST_URL = _FORECAST_DIRECT_URL.rstrip("/")
-    if not _IBA_FORECAST_URL.endswith("/forecast"):
-        _IBA_FORECAST_URL = f"{_IBA_FORECAST_URL}/forecast"
-elif _GATEWAY_URL:
-    _IBA_FORECAST_URL = _GATEWAY_URL.rstrip("/").removesuffix("/v6") + "/v6/internal/forecast"
-else:
-    _IBA_FORECAST_URL = "http://iba-forecast:6705/forecast"
-_IBA_FORECAST_API_KEY = os.environ.get("IBA_FORECAST_API_KEY", "")
+# No engine URL/API key here: connectivity is resolved once at session init
+# (agent.py) and injected via ToolContext.iba_forecast_url/iba_forecast_api_key
+# -- this module never reads os.environ. See _context.py's ToolContext.
 
-_MIN_ROWS = 10          # tool sendability floor (engine eligibility ≥24 is separate)
-_MAX_HORIZON = 12       # hard cap; engine also enforces periods ≤ 12
+_MIN_ROWS = 10          # tool sendability floor, matches the engine's own eligibility floor
+_MAX_HORIZON = 36       # grain-aware cap (e.g. "3 tahun" on monthly data = 36 steps); engine mirrors this
 _FORECAST_PULL_LIMIT = 500  # well under execute_sql's row/byte budget
 
 # ── SQL shape policy (structural, not error-text-based) ────────────────
@@ -74,14 +63,18 @@ def run_forecast(sql: str, periods: int = 3) -> str:
     Executes the caller-supplied SQL (which MUST return exactly two columns:
     X = a time-grain timestamp, Y = a numeric value), validates the shape,
     infers the frequency from the X-column spacing, sends the series to the
-    IBA forecast engine for AutoETS computation, and returns the result as a
-    7-blok structured markdown answer.
+    IBA forecast engine for a seasonal-ETS computation, and returns the
+    result as a 7-blok structured markdown answer.
 
     Construct the SQL from project context (``context/forecast_guide.md``):
     the first column is the time grain (e.g. ``date_trunc('month', ...)``),
     the second is the aggregate (e.g. ``COUNT(DISTINCT ...)``). Do NOT do
     forecast arithmetic yourself, and do NOT pass domain column names as
     separate tool arguments — they belong inside the SQL.
+
+    ``periods`` is a step count on whatever grain the SQL produces, not a
+    fixed unit. To honor a request in months/years, convert it to steps on
+    the data's grain yourself (e.g. "3 tahun" on a monthly series = 36).
 
     Args:
         sql: A SELECT that returns exactly two columns: ``[x, y]`` where
@@ -96,8 +89,8 @@ def run_forecast(sql: str, periods: int = 3) -> str:
                 GROUP BY 1
                 ORDER BY 1
 
-        periods: Steps ahead to forecast (default 3). Clamped to a max of 12
-            (matching the engine's hard cap).
+        periods: Steps ahead to forecast (default 3), on the grain the SQL
+            produces. Clamped to a max of 36.
 
     Returns:
         A 7-blok markdown string: Ringkasan, Kualitas Proyeksi, Kondisi Data,
@@ -111,6 +104,7 @@ def run_forecast(sql: str, periods: int = 3) -> str:
     """
     # Late imports keep the module light and match request_clarification.
     from seeknal.ask.agents.tools._context import (
+        ENGINE_NOT_CONFIGURED,
         get_tool_context,
         make_tool_signature,
         record_tool_result,
@@ -121,6 +115,9 @@ def run_forecast(sql: str, periods: int = 3) -> str:
     )
 
     ctx = get_tool_context()
+    if ctx.iba_forecast_url is None:
+        return ENGINE_NOT_CONFIGURED
+
     periods = max(1, min(int(periods), _MAX_HORIZON))
 
     # ── STEP 0: PREPARE SQL — same pipeline as execute_sql (r3) ────────────
@@ -132,7 +129,7 @@ def run_forecast(sql: str, periods: int = 3) -> str:
     # locally — different cast/NULL semantics → wrong results.
     sql, _notices = _repair_common_sql_before_execution(sql)
 
-    # ── STEP 0.5: STRUCTURAL POLICY CHECK (r4) ────────────────────────────
+    # ── STEP 0.5: STRUCTURAL POLICY CHECK ──────────────────────────────────
     # Fail fast on forbidden SQL patterns BEFORE calling DuckDB. This is
     # structural detection (regex on SQL keywords) — independent of DuckDB's
     # error wording, so it stays stable across upstream version bumps. The
@@ -149,11 +146,11 @@ def run_forecast(sql: str, periods: int = 3) -> str:
         return _format_policy_violation(sql, forbidden)
 
     # ── STEP 1: EXECUTE the caller's SQL (no domain columns hardcoded) ─────
-    # Wrap in try/except (r4) — DuckDB errors that slip past the structural
+    # Wrap in try/except — DuckDB errors that slip past the structural
     # pre-check (syntax errors, missing tables, type casts not tied to JOIN)
     # must NOT crash the Temporal activity. Return a structured ``## Kesalahan``
-    # block so the agent can self-correct in the next loop iteration (FC2a
-    # §3.4: local validation failures must return a markdown block, not raise).
+    # block so the agent can self-correct in the next loop iteration
+    # (local validation failures must return a markdown block, not raise).
     try:
         columns, rows = _execute_oneshot_with_timeout(
             ctx, sql, limit=_FORECAST_PULL_LIMIT
@@ -212,9 +209,9 @@ def run_forecast(sql: str, periods: int = 3) -> str:
     # ── STEP 3: POST → engine (generic payload) ────────────────────────────
     try:
         resp = httpx.post(
-            _IBA_FORECAST_URL,
+            ctx.iba_forecast_url,
             json={"data": data, "periods": periods, "freq": freq},
-            headers={"X-API-Key": _IBA_FORECAST_API_KEY},
+            headers={"X-API-Key": ctx.iba_forecast_api_key},
             timeout=120.0,
         )
         resp.raise_for_status()
@@ -244,24 +241,16 @@ def run_forecast(sql: str, periods: int = 3) -> str:
     if status != "ok":
         return _format_refused(result.get("reason", "Ditolak engine."))
 
-    # ── STEP 4: FORMAT 7-blok markdown ─────────────────────────────────────
-    markdown = _format_forecast_markdown(result, data)
+    # ── STEP 4: FORMAT structured markdown ────────────────────────────────
+    markdown = _format_forecast_markdown(result, data, lang="id")
 
-    # ── STEP 5: self-upload projection points (audit fix D7, 2026-07-09) ───
-    # Forecast points are computed here and are not SQL-queryable, so they
-    # cannot use execute_sql's auto-upload hook. The prior design relied on a
-    # POST_TOOL_USE nudge telling the agent to call upload_to_s3 itself
-    # (hooks.py `_nudge_forecast_data_export`) -- live testing showed this
-    # never fired, because its success marker checked the rendered markdown
-    # for "## Ringkasan", a header this formatter stopped emitting after the
-    # r5 rewrite to "## Proyeksi". Even setting that bug aside, a text nudge
-    # was not reliably followed by the agent across repeated live runs.
-    # Calling upload_to_s3 here instead reads the projection points straight
-    # from `result` (the engine's JSON response, see STEP 3) rather than the
-    # markdown -- so the Download button no longer depends on any markdown
-    # header, wording, or language, and no longer depends on agent behavior.
-    # This also matches FC2d's original ownership split: export of
-    # forecast.points is owned by the producing tool, not a hook.
+    # ── STEP 5: self-upload projection points ───────────────────────────────
+    # Forecast points are computed here, not SQL-queryable, so they can't
+    # ride execute_sql's export path. This tool exports them itself,
+    # deterministically, reading straight from `result` (the engine's JSON
+    # response, see STEP 3) rather than depending on the agent remembering
+    # to call upload_to_s3 -- every successful forecast gets a Download
+    # button, with no dependence on agent behavior.
     _upload_forecast_points(sql, result)
 
     return markdown
@@ -271,11 +260,15 @@ def run_forecast(sql: str, periods: int = 3) -> str:
 
 
 def _infer_freq(x_values: list[str]) -> str | None:
-    """Infer MS/QS/YS from X spacing. Return None on irregular gaps.
+    """Infer MS/QS/YS from the dominant X spacing. Tolerates gaps.
 
-    Compares consecutive diffs in months. MS → all diffs ≈ 1 month;
-    QS → ≈ 3 months; YS → ≈ 12 months. Anything outside the three bands
-    (or mixed) → None (caller refuses locally; do not send garbage).
+    Computes the month-delta between each consecutive pair, takes the most
+    common delta as the base grain, and accepts the series as long as every
+    delta is a positive integer multiple of that base (a gap -- e.g. one
+    missing month in an otherwise-monthly series -- is just a multiple of
+    the base grain, not a different grain). Only returns None when the base
+    isn't month/quarter/year-aligned, or a delta genuinely doesn't fit that
+    base at all (mixed granularity within one series).
     """
     if len(x_values) < 2:
         return None
@@ -291,14 +284,13 @@ def _infer_freq(x_values: list[str]) -> str | None:
             return None  # unsorted or duplicate period
         month_deltas.append(delta)
 
-    unique = set(month_deltas)
-    if unique == {1}:
-        return "MS"
-    if unique == {3}:
-        return "QS"
-    if unique == {12}:
-        return "YS"
-    return None
+    base = Counter(month_deltas).most_common(1)[0][0]
+    if base not in (1, 3, 12):
+        return None
+    if any(d % base != 0 for d in month_deltas):
+        return None
+
+    return {1: "MS", 3: "QS", 12: "YS"}[base]
 
 
 def _coerce_x(v: Any) -> str | None:
@@ -333,20 +325,20 @@ def _coerce_y(v: Any) -> float | None:
 
 
 def _upload_forecast_points(sql: str, result: dict[str, Any]) -> None:
-    """Best-effort export of the forecast projection points to CSV (D7 fix).
+    """Best-effort export of the forecast projection points to CSV.
 
     Mirrors ``upload_to_s3`` Mode 2 (data=/columns=). Failures are swallowed
     -- an export hiccup must never break the forecast answer that already
-    computed successfully. Lazy import avoids a hooks.py-style import cycle
-    (upload_to_s3 pulls in execute_sql internals at call time).
+    computed successfully. Lazy import avoids an import cycle (upload_to_s3
+    pulls in execute_sql internals at call time).
     """
     points = (result.get("forecast") or {}).get("points") or []
     if not points:
         return
-    columns = ["period", "point", "lower_80", "upper_80", "lower_95", "upper_95"]
+    columns = ["period", "point", "lower_80", "upper_80", "lower_95", "upper_95", "p10", "p90"]
     rows = [
         [p.get("period"), p.get("point"), p.get("lower_80"), p.get("upper_80"),
-         p.get("lower_95"), p.get("upper_95")]
+         p.get("lower_95"), p.get("upper_95"), p.get("p10"), p.get("p90")]
         for p in points
     ]
     filename = _derive_forecast_filename(sql)
@@ -514,97 +506,373 @@ def _format_refused(reason: str) -> str:
     )
 
 
-def _format_forecast_markdown(result: dict[str, Any], history: list[list[Any]]) -> str:
-    """r5: Simplified single continuous timeline table.
+def _lang_key(lang: str) -> str:
+    """Normalise any language code to the two supported keys: 'id' or 'en'."""
+    return "en" if lang.startswith("en") else "id"
 
-    One table with historical (no bounds) + forecast (with bounds) rows.
-    No YoY side-by-side, no 8-section layout.
 
-    This is a technical intermediate block, not the final user-facing answer:
-    the block header (``## Proyeksi``) and quality labels (BAIK/CUKUP/LEMAH/
-    TOLAK, matching ``evaluate.py::assess_quality``) are fixed Indonesian
-    technical markers, not translated per conversation language. The agent
-    reads this raw tool_result and writes its own final prose answer around
-    it — that final answer is what actually follows the conversation's
-    language; this markdown is not re-localized.
+def _translator(lang: str):
+    """Return a ``_t(id_text, en_text)`` closure for one-off inline phrases."""
+    is_en = lang.startswith("en")
+
+    def _t(id_text: str, en_text: str) -> str:
+        return en_text if is_en else id_text
+
+    return _t
+
+
+def _fmt_number(v: Any) -> str:
+    """Format a number with thousands separator. Returns '0' for None/missing."""
+    try:
+        return f"{int(round(float(v))):,}"
+    except (TypeError, ValueError):
+        return "0"
+
+
+def _avg_y(rows: list[list[Any]]) -> float:
+    vals = [float(r[1]) for r in rows if r and r[1] is not None]
+    return sum(vals) / len(vals) if vals else 0.0
+
+
+# Small lookup tables replace the five parallel id/en branch-per-function
+# helpers this module used to have -- one table per concept, one shared
+# lookup pattern, instead of five copies of the same if/else shape.
+
+_QUALITY_SENTENCES = {
+    "id": {
+        "BAIK": "Proyeksi ini terbukti akurat pada data historis -- dapat diandalkan untuk perencanaan.",
+        "CUKUP": "Proyeksi ini cukup dapat diandalkan, gunakan dengan sedikit ruang toleransi.",
+        "LEMAH": "Proyeksi ini adalah perkiraan kasar -- gunakan dengan hati-hati.",
+        "TOLAK": "Akurasi proyeksi ini rendah pada data historis -- gunakan dengan sangat hati-hati.",
+        "UNKNOWN": "Akurasi historis proyeksi ini belum dapat diukur.",
+        "_default": "Gunakan proyeksi ini dengan hati-hati.",
+    },
+    "en": {
+        "BAIK": "This projection has proven accurate on historical data -- reliable for planning.",
+        "CUKUP": "This projection is reasonably reliable, use with some tolerance.",
+        "LEMAH": "This projection is a rough estimate -- use with caution.",
+        "TOLAK": "This projection has low historical accuracy -- use with great caution.",
+        "UNKNOWN": "Historical accuracy of this projection has not yet been measured.",
+        "_default": "Use this projection with caution.",
+    },
+}
+
+_CONFIDENCE_LABELS = {
+    "id": {"BAIK": "Tinggi", "CUKUP": "Sedang", "LEMAH": "Rendah", "TOLAK": "Rendah", "UNKNOWN": "Sedang", "_default": "Sedang"},
+    "en": {"BAIK": "High", "CUKUP": "Medium", "LEMAH": "Low", "TOLAK": "Low", "UNKNOWN": "Medium", "_default": "Medium"},
+}
+
+_CONFIDENCE_SENTENCES = {
+    "id": {
+        "Tinggi": "Tingkat keyakinan tinggi -- proyeksi didukung akurasi historis yang baik.",
+        "Sedang": "Tingkat keyakinan sedang -- proyeksi cukup dapat digunakan dengan catatan.",
+        "Rendah": "Tingkat keyakinan rendah -- sebaiknya gunakan proyeksi ini secara hati-hati.",
+        "_default": "Gunakan proyeksi ini dengan hati-hati.",
+    },
+    "en": {
+        "High": "High confidence -- projection is supported by good historical accuracy.",
+        "Medium": "Medium confidence -- projection is usable with caveats.",
+        "Low": "Low confidence -- use this projection with caution.",
+        "_default": "Use this projection with caution.",
+    },
+}
+
+# Ordered (max_cv, id_label, en_label) thresholds -- first match wins.
+_STABILITY_THRESHOLDS: tuple[tuple[float, str, str], ...] = (
+    (0.3, "stabil", "stable"),
+    (0.5, "cukup stabil", "moderately stable"),
+    (0.8, "fluktuatif", "volatile"),
+)
+_STABILITY_FALLBACK = ("sangat fluktuatif", "highly volatile")
+
+_DIRECTION_WORDS = {"id": {"up": "meningkat", "down": "menurun", "flat": "stabil"},
+                     "en": {"up": "increasing", "down": "decreasing", "flat": "stable"}}
+
+
+def _quality_sentence(label: str, lang: str = "id") -> str:
+    """Plain-language quality assessment in the requested language."""
+    table = _QUALITY_SENTENCES[_lang_key(lang)]
+    return table.get(label, table["_default"])
+
+
+def _confidence_label(quality_label: str, lang: str = "id") -> str:
+    """Map MAPE-based quality label to a plain-language confidence level.
+
+    Every horizon step draws from the same trailing window (with trend
+    projection), so there is no meaningfully different confidence per step.
+    """
+    table = _CONFIDENCE_LABELS[_lang_key(lang)]
+    return table.get(quality_label, table["_default"])
+
+
+def _confidence_sentence(confidence: str, lang: str = "id") -> str:
+    table = _CONFIDENCE_SENTENCES[_lang_key(lang)]
+    return table.get(confidence, table["_default"])
+
+
+def _stability_label(cv: float, lang: str = "id") -> str:
+    """Plain-language data stability -- never prints the raw coefficient of variation."""
+    key = _lang_key(lang)
+    idx = 0 if key == "id" else 1
+    for max_cv, *labels in _STABILITY_THRESHOLDS:
+        if cv <= max_cv:
+            return labels[idx]
+    return _STABILITY_FALLBACK[idx]
+
+
+def _direction_word(hist_avg: float, proj_avg: float, lang: str = "id") -> tuple[str, float]:
+    """Direction + percentage change of the projection vs. recent history."""
+    words = _DIRECTION_WORDS[_lang_key(lang)]
+    if hist_avg == 0:
+        return words["flat"], 0.0
+    pct = (proj_avg - hist_avg) / hist_avg * 100
+    if pct > 5:
+        return words["up"], pct
+    if pct < -5:
+        return words["down"], pct
+    return words["flat"], pct
+
+
+# ── _format_forecast_markdown block builders ────────────────────────────
+#
+# Each function builds exactly one ``##`` block. ``_format_forecast_markdown``
+# extracts the shared values once, then calls these in order and joins them
+# -- so the top-level function reads as a plain pipeline instead of one long
+# block of inline string-building.
+
+
+def _build_summary_block(_t, periods: int, hist_avg: float, proj_avg: float,
+                          direction: str, pct: float) -> str:
+    return (
+        f"## {_t('Ringkasan', 'Summary')}\n\n"
+        f"{_t('Rata-rata', 'Average')} {periods} "
+        f"{_t('periode terakhir', 'last periods')}: {_fmt_number(hist_avg)}\n"
+        f"{_t('Rata-rata', 'Average')} {periods} "
+        f"{_t('periode proyeksi', 'projection periods')}: {_fmt_number(proj_avg)}\n"
+        f"{_t('Arah', 'Direction')}: {direction} ({pct:+.1f}%)"
+    )
+
+
+def _build_quality_block(_t, quality_label: str, mape_str: str, lang: str) -> str:
+    return (
+        f"## {_t('Kualitas Proyeksi', 'Projection Quality')}\n\n"
+        f"**{quality_label}** ({_t('akurasi historis', 'historical accuracy')}: MAPE {mape_str})\n"
+        f"{_quality_sentence(quality_label, lang)}"
+    )
+
+
+def _build_data_condition_block(_t, n_months: int, gap_months: int, gap_caveat: str | None,
+                                 cv: float, anomalies: list[Any] | None, lang: str) -> str:
+    gap_icon = "⚠" if gap_caveat else "✓"
+    stability_icon = "✓" if cv <= 0.5 else "⚠"
+    lines = [
+        f"## {_t('Kondisi Data', 'Data Condition')}",
+        "",
+        f"- ✓ {_t('Riwayat data', 'Data history')}: {n_months} {_t('bulan', 'months')}",
+        f"- {gap_icon} {_t('Kelengkapan data', 'Data completeness')}: "
+        f"{n_months - gap_months}/{n_months} {_t('periode tersedia', 'periods available')}",
+        f"- {stability_icon} {_t('Stabilitas data', 'Data stability')}: {_stability_label(cv, lang)}",
+    ]
+    if anomalies:
+        lines.append(
+            f"- ⚠ {_t('Terdapat', 'Found')} {len(anomalies)} "
+            f"{_t('periode tidak biasa dalam riwayat', 'unusual periods in history')}"
+        )
+    return "\n".join(lines)
+
+
+def _build_history_block(_t, history: list[list[Any]], points: list[dict]) -> str:
+    hist_display = history[-6:] if len(history) > 6 else history
+    timeline_rows = [f"| {str(x)[:7]} | {_fmt_number(y)} |" for x, y in hist_display]
+    timeline_rows.append(f"| {_t('── sekarang ──', '── now ──')} | |")
+    for p in points:
+        period = str(p.get("period", ""))[:7]
+        timeline_rows.append(
+            f"| {period} ({_t('proyeksi', 'forecast')}) | {_fmt_number(p.get('point'))} |"
+        )
+    timeline_table = "\n".join(timeline_rows) if timeline_rows else "| 0 | 0 |"
+
+    hist_vals = [float(y) for _x, y in hist_display if y is not None]
+    hist_stats = (
+        f"{_t('Rata-rata', 'Average')}: {_fmt_number(_avg_y(hist_display))}, "
+        f"{_t('Tertinggi', 'Highest')}: {_fmt_number(max(hist_vals))}, "
+        f"{_t('Terendah', 'Lowest')}: {_fmt_number(min(hist_vals))}"
+        if hist_vals else ""
+    )
+    return (
+        f"## {_t('Historis & Proyeksi', 'History & Projection')}\n\n"
+        f"| {_t('Periode', 'Period')} | {_t('Nilai', 'Value')} |\n"
+        f"|---|---|\n"
+        f"{timeline_table}\n\n"
+        f"{hist_stats}"
+    )
+
+
+def _build_detail_block(_t, points: list[dict], sub_type: str, sigma: float) -> str:
+    # capped bounds: sigma_h = sigma * sqrt(min(h,2))
+    # 80% interval: z = 1.2816
+    detail_rows = [
+        f"| {str(p.get('period', ''))[:7]} | {_fmt_number(p.get('point'))} | "
+        f"{_fmt_number(p.get('lower_80'))} | {_fmt_number(p.get('upper_80'))} |"
+        for p in points
+    ]
+    return (
+        f"## {_t('Proyeksi Detail', 'Projection Detail')}\n\n"
+        f"{_t('Metode', 'Method')}: "
+        f"{_t('ETS musiman', 'seasonal ETS')} "
+        f"({sub_type}), "
+        f"{_t('bounds', 'bounds')}: sigma*sqrt(min(h,2)) (sigma={sigma:.0f})\n\n"
+        f"| {_t('Periode', 'Period')} | {_t('Prediksi', 'Forecast')} | "
+        f"{_t('Bawah', 'Lower')} 80% | {_t('Atas', 'Upper')} 80% |\n"
+        f"|---|---|---|---|\n"
+        f"{chr(10).join(detail_rows) if detail_rows else '| 0 | 0 | 0 | 0 |'}"
+    )
+
+
+def _build_range_block(_t, points: list[dict]) -> str:
+    first = points[0] if points else {}
+    last = points[-1] if points else {}
+    return (
+        f"## {_t('Rentang Proyeksi', 'Projection Range')}\n\n"
+        f"{_t('Interval 80% awal', '80% interval start')}: "
+        f"{_fmt_number(first.get('lower_80'))} s/d {_fmt_number(first.get('upper_80'))}\n"
+        f"{_t('Interval 80% akhir', '80% interval end')}: "
+        f"{_fmt_number(last.get('lower_80'))} s/d {_fmt_number(last.get('upper_80'))}\n\n"
+        f"{_t('Interval melebar sesuai horizon', 'Interval widens with horizon')}: "
+        f"sigma * sqrt(h). "
+        f"{_t('Semakin jauh proyeksi, semakin besar ketidakpastian', 'The further the projection, the greater the uncertainty')}."
+    )
+
+
+def _build_confidence_block(_t, quality_label: str, lang: str) -> str:
+    confidence = _confidence_label(quality_label, lang)
+    return (
+        f"## {_t('Tingkat Keyakinan', 'Confidence Level')}\n\n"
+        f"**{confidence}**\n\n"
+        f"{_confidence_sentence(confidence, lang)}"
+    )
+
+
+def _build_meaning_block(_t, direction: str, pct: float, periods: int,
+                          gap_caveat: str | None, anomalies: list[Any] | None) -> str:
+    lines = [
+        f"## {_t('Apa Artinya', 'What It Means')}",
+        "",
+        f"- {_t('Proyeksi', 'Projection')} {direction} "
+        f"{_t('dibanding rata-rata', 'compared to average')} "
+        f"{periods} {_t('bulan terakhir', 'last months')} ({pct:+.1f}%)",
+        f"- {_t('Gunakan interval 80% untuk perencanaan', 'Use the 80% interval for planning')}",
+    ]
+    if gap_caveat:
+        lines.append(f"- {gap_caveat}")
+    if anomalies:
+        lines.append(
+            f"- {_t('Riwayat data memiliki periode tidak biasa', 'History contains unusual periods')}"
+        )
+    return "\n".join(lines)
+
+
+def _build_methodology_block(_t, sub_type: str, sigma: float, window_used: Any,
+                              window_selection: dict[str, Any], mape_str: str,
+                              training_window: str) -> str:
+    lines = [
+        f"## {_t('Metodologi', 'Methodology')}",
+        "",
+        f"{_t('Metode', 'Method')}: {_t('ETS musiman (Holt-Winters)', 'seasonal ETS (Holt-Winters)')}",
+        f"{_t('Konfigurasi', 'Configuration')}: {sub_type}",
+        f"{_t('Jendela', 'Window')}: {window_used} {_t('periode (dipilih otomatis', 'periods (auto-selected')}: {window_selection.get('state', 'unknown')})",
+        f"Sigma: {sigma:.0f} ({_t('residual std fit', 'fit residual std')})",
+        f"Bounds: sigma * sqrt(min(h,2)), z=1.2816 (80%)",
+        f"{_t('Akurasi backtest', 'Backtest accuracy')}: MAPE {mape_str}",
+        f"{_t('Cakupan data', 'Data range')}: {training_window}",
+    ]
+    if window_selection.get("state") in ("partial", "fail"):
+        lines.append(f"{_t('Catatan', 'Note')}: {window_selection.get('reason', '')}")
+    return "\n".join(lines)
+
+
+def _build_anomaly_block(_t, anomalies: list[dict[str, Any]]) -> str:
+    lines = [
+        f"## {_t('Anomali', 'Anomalies')}",
+        "",
+        _t(
+            "Periode berikut menonjol dibanding pola umum data:",
+            "The following periods stand out from the general data pattern:",
+        ),
+    ]
+    for a in anomalies:
+        lines.append(f"- **{a.get('date')}**: {_fmt_number(a.get('value'))} -- {a.get('reason_hint')}")
+    return "\n".join(lines)
+
+
+def _format_forecast_markdown(result: dict[str, Any], history: list[list[Any]], lang: str = "id") -> str:
+    """Structured forecast markdown — adaptive language (id/en).
+
+    Blocks: Summary, Projection Quality, Data Condition,
+    History & Projection, Projection Detail, Projection Range,
+    Confidence Level, What It Means, Methodology (+ Anomaly if attached).
+
+    This is a technical intermediate block. The agent reads this raw
+    tool_result and composes its own final prose around it.
+
+    Bounds widen with horizon but the growth is capped:
+        sigma_h = sigma * sqrt(min(h, 2))
+        lower = point - z * sigma_h   (z = 1.2816 for 80%)
+        upper = point + z * sigma_h
+    All values clamped to >= 0.
+
+    Args:
+        result: Engine response dict.
+        history: Historical data [[x, y], ...].
+        lang: Language code — "id" (Indonesian) or "en" (English).
     """
     forecast = result.get("forecast") or {}
     assessment = result.get("assessment") or {}
     provenance = result.get("provenance") or {}
+    eligibility = assessment.get("eligibility") or {}
 
     points = forecast.get("points") or []
+    periods = forecast.get("periods") or len(points) or 1
     metrics = assessment.get("metrics") or {}
 
-    quality_label = assessment.get("quality_label", "-")
+    quality_label = assessment.get("quality_label", "UNKNOWN")
     mape = metrics.get("mape")
-    reason = result.get("reason")
+    anomalies = assessment.get("anomalies")
+    cv = eligibility.get("cv", 0.0)
+    n_months = eligibility.get("n_months", len(history))
+    gap_months = eligibility.get("gap_months", 0)
+    gap_caveat = provenance.get("gap_caveat")
+    sub_type = provenance.get("sub_type", "ETS(A,N,N)")
+    sigma = provenance.get("sigma", 0.0)
+    window_selection = provenance.get("window_selection") or {}
+    window_used = window_selection.get("chosen")
 
-    def _fmt(v: Any) -> str:
-        try:
-            return f"{int(v):,}"
-        except (TypeError, ValueError):
-            return "-"
+    _t = _translator(lang)
+    mape_str = f"{mape:.1f}%" if mape is not None else _t("tidak diketahui", "unknown")
 
-    # Build continuous timeline: last N historical + all forecast points.
-    rows: list[str] = []
+    hist_window = history[-periods:] if len(history) >= periods else history
+    hist_avg = _avg_y(hist_window)
+    proj_avg = sum(float(p.get("point", 0)) for p in points) / len(points) if points else 0.0
+    direction, pct = _direction_word(hist_avg, proj_avg, lang)
 
-    # Historical rows (last 6 from the pulled data, no bounds).
-    hist_display = history[-6:] if len(history) > 6 else history
-    for x, y in hist_display:
-        period = str(x)[:7]
-        rows.append(f"| {period} | {_fmt(y)} | - | - |")
+    blocks = [
+        _build_summary_block(_t, periods, hist_avg, proj_avg, direction, pct),
+        _build_quality_block(_t, quality_label, mape_str, lang),
+        _build_data_condition_block(_t, n_months, gap_months, gap_caveat, cv, anomalies, lang),
+        _build_history_block(_t, history, points),
+        _build_detail_block(_t, points, sub_type, sigma),
+        _build_range_block(_t, points),
+        _build_confidence_block(_t, quality_label, lang),
+        _build_meaning_block(_t, direction, pct, periods, gap_caveat, anomalies),
+        _build_methodology_block(
+            _t, sub_type, sigma, window_used, window_selection, mape_str,
+            provenance.get("training_window", "N/A"),
+        ),
+    ]
 
-    # Forecast rows (with 80% bounds).
-    for p in points:
-        period = str(p.get("period", ""))[:7]
-        rows.append(
-            f"| {period} | {_fmt(p.get('point'))} | "
-            f"{_fmt(p.get('lower_80'))} | {_fmt(p.get('upper_80'))} |"
-        )
+    # Anomali only appears when the engine auto-attached one for a
+    # poor-quality forecast.
+    if anomalies:
+        blocks.append(_build_anomaly_block(_t, anomalies))
 
-    table = "\n".join(rows) if rows else "| - | - | - | - |"
-
-    # Quality line.
-    mape_str = f"{mape:.1f}%" if mape is not None else "N/A"
-    quality_line = f"**Quality: {quality_label}** (MAPE {mape_str})"
-
-    # Warning if TOLAK.
-    warning = ""
-    if reason:
-        warning = f"\n\n> ⚠ {reason}"
-
-    return (
-        f"## Proyeksi\n\n"
-        f"| Period | Value | Lower 80% | Upper 80% |\n"
-        f"|--------|-------|-----------|----------|\n"
-        f"{table}\n\n"
-        f"{quality_line}"
-        f"{warning}"
-    )
-
-
-def _quality_explain(label: str) -> str:
-    """Kept for backward compat — r5 output no longer uses this in the main table."""
-    return {
-        "BAIK": "trustworthy for planning",
-        "CUKUP": "usable with caveats",
-        "LEMAH": "rough estimate, hedge it",
-        "TOLAK": "low accuracy — use with caveat",
-    }.get(label, "-")
-
-
-def _confidence_explain(label: str) -> str:
-    """Kept for backward compat."""
-    return {
-        "BAIK": "MAPE <= 15%",
-        "CUKUP": "MAPE 15-25%",
-        "LEMAH": "MAPE 25-35%",
-        "TOLAK": "MAPE > 35%",
-    }.get(label, "-")
-
-
-def _subtype_explain(sub_type: str) -> str:
-    """Kept for backward compat."""
-    if "ETS(A,N,N)" in str(sub_type):
-        return "Simple Exponential Smoothing"
-    return "AutoETS-selected"
+    return "\n\n".join(blocks)

--- a/src/seeknal/ask/agents/tools/toolset.py
+++ b/src/seeknal/ask/agents/tools/toolset.py
@@ -8,6 +8,7 @@ tools instead of relying on prompt-only steering.
 
 from pydantic_ai.toolsets import FunctionToolset
 
+from seeknal.ask.agents.tools.anomaly import detect_anomaly
 from seeknal.ask.agents.tools.apply_draft import apply_draft
 from seeknal.ask.agents.tools.ask_user_tool import ask_user
 from seeknal.ask.agents.tools.bootstrap_semantic_model import bootstrap_semantic_model
@@ -147,14 +148,21 @@ _FULL_ONLY_TOOLS = [
     propose_record_table,
 ]
 
-# Forecast trigger (FC2a). Gated by ``include_forecast`` — registered only in
-# non-interactive environments when ``agent.forecast.enabled`` is true.
+# Deterministic forecast trigger tool. Gated by ``include_forecast`` --
+# registered only in non-interactive environments when
+# ``agent.forecast.enabled`` is true.
 _FORECAST_TOOLS = [
     run_forecast,
 ]
 
-# CSV export tool (FC2d). Gated by ``include_upload_to_s3`` — registered only
-# in non-interactive environments when ``agent.upload_to_s3.enabled`` is true.
+# Anomaly-awareness tool. Sibling of run_forecast: same gating pattern, same
+# engine. Gated by ``include_anomaly``.
+_ANOMALY_TOOLS = [
+    detect_anomaly,
+]
+
+# CSV export tool. Gated by ``include_upload_to_s3`` -- registered only in
+# non-interactive environments when ``agent.upload_to_s3.enabled`` is true.
 _EXPORT_TOOLS = [
     upload_to_s3,
 ]
@@ -166,6 +174,7 @@ def create_ask_toolset(
     include_ask_user: bool = True,
     include_request_clarification: bool = False,
     include_forecast: bool = False,
+    include_anomaly: bool = False,
     include_upload_to_s3: bool = False,
 ) -> FunctionToolset:
     """Create the seeknal-ask toolset.
@@ -180,11 +189,14 @@ def create_ask_toolset(
         include_request_clarification: Include the headless ``request_clarification``
             tool (Model B). Registered for gateway/telegram; the interactive CLI
             keeps ``ask_user`` instead, so the two are never combined.
-        include_forecast: Include the deterministic ``run_forecast`` trigger tool
-            (FC2a). Registered only in non-interactive environments when
+        include_forecast: Include the deterministic ``run_forecast`` trigger
+            tool. Registered only in non-interactive environments when
             ``agent.forecast.enabled`` is true in ``seeknal_agent.yml``.
-        include_upload_to_s3: Include the generic CSV export tool ``upload_to_s3``
-            (FC2d). Registered only in non-interactive environments when
+        include_anomaly: Include the ``detect_anomaly`` tool. Registered
+            only in non-interactive environments when ``agent.anomaly.enabled``
+            is true in ``seeknal_agent.yml``.
+        include_upload_to_s3: Include the generic CSV export tool ``upload_to_s3``.
+            Registered only in non-interactive environments when
             ``agent.upload_to_s3.enabled`` is true in ``seeknal_agent.yml``.
     """
     if mode == "analysis":
@@ -220,6 +232,9 @@ def create_ask_toolset(
 
     if include_forecast:
         tools.extend(_FORECAST_TOOLS)
+
+    if include_anomaly:
+        tools.extend(_ANOMALY_TOOLS)
 
     if include_upload_to_s3:
         tools.extend(_EXPORT_TOOLS)

--- a/src/seeknal/ask/config.py
+++ b/src/seeknal/ask/config.py
@@ -590,6 +590,26 @@ def get_forecast_enabled(config: dict[str, Any]) -> bool:
     return _coerce_bool(forecast_section.get("enabled"), default=False)
 
 
+def get_anomaly_enabled(config: dict[str, Any]) -> bool:
+    """Return whether the ``detect_anomaly`` tool is enabled.
+
+    Reads ``agent.anomaly.enabled`` from ``seeknal_agent.yml``. Defaults to
+    ``False`` -- anomaly detection is opt-in per project, same gating
+    pattern as ``forecast`` (it needs the IBA forecast engine running).
+    Only takes effect in non-interactive environments; the interactive CLI
+    never registers the tool.
+
+    Example::
+
+        agent:
+          anomaly:
+            enabled: true
+    """
+    agent_section = _get_mapping(config, "agent")
+    anomaly_section = _get_mapping(agent_section, "anomaly")
+    return _coerce_bool(anomaly_section.get("enabled"), default=False)
+
+
 def get_upload_to_s3_enabled(config: dict[str, Any]) -> bool:
     """Return whether the generic CSV export tool ``upload_to_s3`` is enabled.
 

--- a/tests/ask/test_anomaly_tool.py
+++ b/tests/ask/test_anomaly_tool.py
@@ -1,0 +1,149 @@
+"""Tests for the detect_anomaly tool — URL resolution, validation gates, markdown.
+
+The engine HTTP call is mocked so these tests run without the IBA forecast
+service. Mirrors tests/ask/test_forecast_tool.py: same ``_REPLStub`` pattern,
+same engine (detect_anomaly is a sibling of run_forecast, same 2-column
+SQL contract and execution pipeline).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import duckdb
+import pytest
+
+from seeknal.ask.agents.tools._context import ToolContext, set_tool_context
+from seeknal.ask.agents.tools.anomaly import detect_anomaly
+
+
+class _REPLStub:
+    def __init__(self) -> None:
+        self.conn = duckdb.connect(":memory:")
+
+    def execute_oneshot(self, sql: str, limit=None):
+        if limit is not None:
+            sql = f"SELECT * FROM ({sql}) AS _q LIMIT {int(limit)}"
+        result = self.conn.execute(sql)
+        if not result.description:
+            return [], []
+        cols = [d[0] for d in result.description]
+        return cols, result.fetchall()
+
+
+@pytest.fixture
+def ctx(tmp_path: Path) -> ToolContext:
+    repl = _REPLStub()
+    repl.conn.execute(
+        """
+        CREATE TABLE monthly AS
+        SELECT CAST(d AS DATE) AS d,
+               5000 + ((ROW_NUMBER() OVER () - 1) % 7) * 13 AS y
+        FROM generate_series(DATE '2022-01-01', DATE '2024-06-01', INTERVAL '1 month') AS t(d)
+        """
+    )
+    ctx = ToolContext(
+        repl=repl,
+        artifact_discovery=MagicMock(),
+        project_path=tmp_path,
+        sql_timeout_seconds=0,
+        # Engine connectivity: injected here exactly like a real session
+        # (agent.py resolves these once at init and sets them on ToolContext);
+        # detect_anomaly never reads os.environ itself. See
+        # test_anomaly_engine_not_configured for the unset-config path.
+        iba_anomaly_url="http://test-engine/anomaly",
+        iba_forecast_api_key="test-key",
+    )
+    set_tool_context(ctx)
+    return ctx
+
+
+def _mock_post(response_json: dict[str, Any]):
+    resp = MagicMock()
+    resp.json.return_value = response_json
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+SQL_2COL = (
+    "SELECT date_trunc('month', d::timestamp) AS x, y "
+    "FROM monthly ORDER BY 1"
+)
+
+
+def test_anomaly_found_formats_markdown(ctx):
+    response = {
+        "status": "ok",
+        "anomalies": [
+            {"index": 5, "date": "2022-06-01", "value": 9000, "modified_z": 4.1,
+             "reason_hint": "isolated spike"},
+        ],
+    }
+    with patch("seeknal.ask.agents.tools.anomaly.httpx.post", return_value=_mock_post(response)):
+        out = detect_anomaly(SQL_2COL)
+    assert "## Anomali" in out
+    assert "2022-06-01" in out
+    assert "isolated spike" in out
+    assert "Terdeteksi 1 periode anomali." in out
+
+
+def test_anomaly_none_found(ctx):
+    response = {"status": "ok", "anomalies": []}
+    with patch("seeknal.ask.agents.tools.anomaly.httpx.post", return_value=_mock_post(response)):
+        out = detect_anomaly(SQL_2COL)
+    assert "## Anomali" in out
+    assert "Tidak ada periode yang menonjol" in out
+
+
+def test_anomaly_engine_not_configured(ctx):
+    """No IBA_FORECAST_URL / SEEKNAL_GATEWAY_URL resolved at session init ->
+    clear config error, never a guess at a docker-internal hostname, and no
+    SQL/network attempt.
+    """
+    ctx.iba_anomaly_url = None
+    with patch("seeknal.ask.agents.tools.anomaly.httpx.post") as post:
+        out = detect_anomaly(SQL_2COL)
+    assert "## Kesalahan" in out
+    assert "belum dikonfigurasi" in out
+    post.assert_not_called()
+
+
+def test_anomaly_validates_two_columns(ctx):
+    sql = "SELECT d AS x, y, d AS z FROM monthly ORDER BY 1"
+    with patch("seeknal.ask.agents.tools.anomaly.httpx.post") as post:
+        out = detect_anomaly(sql)
+    assert "## Kesalahan" in out
+    assert "tepat 2 kolom" in out
+    post.assert_not_called()
+
+
+def test_anomaly_validates_min_rows(ctx):
+    sql = (
+        "SELECT date_trunc('month', d::timestamp) AS x, y "
+        "FROM (SELECT * FROM monthly ORDER BY d LIMIT 2) ORDER BY 1"
+    )
+    with patch("seeknal.ask.agents.tools.anomaly.httpx.post") as post:
+        out = detect_anomaly(sql)
+    assert "## Kesalahan" in out
+    assert "minimal 3 baris" in out
+    post.assert_not_called()
+
+
+def test_anomaly_engine_unreachable_returns_kesalahan(ctx):
+    import httpx as _httpx
+
+    with patch("seeknal.ask.agents.tools.anomaly.httpx.post", side_effect=_httpx.RequestError("boom")):
+        out = detect_anomaly(SQL_2COL)
+    assert "## Kesalahan" in out
+    assert "tidak tersedia" in out
+
+
+def test_anomaly_policy_check_rejects_join(ctx):
+    sql = "SELECT m.x, a.y FROM monthly m LEFT JOIN monthly a ON m.x = a.x"
+    with patch("seeknal.ask.agents.tools.anomaly.httpx.post") as post:
+        out = detect_anomaly(sql)
+    assert "## Kesalahan" in out
+    assert "JOIN" in out
+    post.assert_not_called()

--- a/tests/ask/test_forecast_tool.py
+++ b/tests/ask/test_forecast_tool.py
@@ -49,6 +49,12 @@ def ctx(tmp_path: Path) -> ToolContext:
         artifact_discovery=MagicMock(),
         project_path=tmp_path,
         sql_timeout_seconds=0,
+        # Engine connectivity: injected here exactly like a real session
+        # (agent.py resolves these once at init and sets them on ToolContext);
+        # run_forecast never reads os.environ itself. See
+        # test_forecast_engine_not_configured for the unset-config path.
+        iba_forecast_url="http://test-engine/forecast",
+        iba_forecast_api_key="test-key",
     )
     set_tool_context(ctx)
     return ctx
@@ -127,6 +133,19 @@ def test_forecast_ok_formats_7_blocks(ctx):
         assert header in out, f"missing {header}"
     assert "BAIK" in out
     assert "Quality:" in out
+
+
+def test_forecast_engine_not_configured(ctx):
+    """No IBA_FORECAST_URL / SEEKNAL_GATEWAY_URL resolved at session init ->
+    clear config error, never a guess at a docker-internal hostname, and no
+    SQL/network attempt.
+    """
+    ctx.iba_forecast_url = None
+    with patch("seeknal.ask.agents.tools.forecast.httpx.post") as post:
+        out = run_forecast(SQL_2COL, periods=3)
+    assert "## Kesalahan" in out
+    assert "belum dikonfigurasi" in out
+    post.assert_not_called()
 
 
 def test_forecast_validates_two_columns(ctx):


### PR DESCRIPTION
## Summary

- Add `detect_anomaly` tool (modified z-score via iba-forecast engine)
- Update `run_forecast` to work with ETS seasonal engine (non-flat output)
- Add forecast/anomaly URL resolution in agent init
- Enable forecast + anomaly tools in toolset and access registry

## Changes

- **New tool**: `detect_anomaly(sql)` — same 2-column SQL contract as `run_forecast`
- **Forecast tool**: Updated for ETS seasonal engine (expects per-month varying points)
- **Agent init**: Resolves `iba_forecast_url` and `iba_anomaly_url` at session start
- **Access registry**: Enables forecast + anomaly tools
- **Tests**: Added `test_anomaly_tool.py`, updated `test_forecast_tool.py`

## Test plan

- [ ] Run `pytest tests/ask/test_forecast_tool.py`
- [ ] Run `pytest tests/ask/test_anomaly_tool.py`
- [ ] Verify forecast tool produces non-flat markdown output
- [ ] Verify anomaly tool returns flagged periods with reason hints