### PR TITLE
[feat, seeknal] M9: visualize_chart tool + gateway emit + config

### DIFF
--- a/draft_second_order_aggregation_test.yml
+++ b/draft_second_order_aggregation_test.yml
@@ -1,0 +1,24 @@
+kind: second_order_aggregation
+name: test
+description: "second order aggregation node"
+owner: "ml-team@example.com"
+id_col: region_id
+feature_date_col: date
+application_date_col: application_date
+source: aggregation.upstream_aggregation
+features:
+  total_entities:
+    basic: [count]
+  avg_feature_value:
+    basic: [mean, stddev]
+    source_feature: feature_value
+  weekly_total:
+    window: [7, 7]
+    basic: [sum]
+    source_feature: daily_amount
+  recent_vs_historical:
+    ratio:
+      numerator: [1, 7]
+      denominator: [8, 30]
+      aggs: [sum]
+    source_feature: transaction_amount

--- a/scripts/build-gcp.sh
+++ b/scripts/build-gcp.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Build a seeknal Docker image and push it to the team's GCP Artifact Registry.
+#
+# Mirrors iba-deploy-runbook/configs/build-seeknal-worker.sh so the same
+# registry and tag conventions are used. Use this to ship a seeknal build
+# (e.g. the forecast tool on a feature branch) to the Dev VM BEFORE the
+# upstream seeknal release image is published to GHCR.
+#
+# Usage (from anywhere inside the seeknal repo):
+#   ./scripts/build-gcp.sh                              # worker image, tag :dev
+#   ./scripts/build-gcp.sh -i gateway                   # gateway image
+#   ./scripts/build-gcp.sh -i worker -t seek5-2026-07-03  # custom tag
+#   ./scripts/build-gcp.sh -i worker --tag-version      # tag = version from pyproject.toml
+#
+# Images: worker (default) | gateway | prefect | report-server
+#
+# Env:
+#   SEEKNAL_REGISTRY   override the registry base
+#                      (default: asia-southeast2-docker.pkg.dev/arched-jetty-392811/mta-docker)
+#
+# Prereqs:
+#   - docker running
+#   - one-time auth against the registry:
+#       gcloud auth login
+#       gcloud config set project arched-jetty-392811
+#       gcloud auth configure-docker asia-southeast2-docker.pkg.dev
+set -euo pipefail
+
+DEFAULT_REGISTRY="asia-southeast2-docker.pkg.dev/arched-jetty-392811/mta-docker"
+REGISTRY="${SEEKNAL_REGISTRY:-$DEFAULT_REGISTRY}"
+
+IMAGE="worker"
+TAG="dev"
+TAG_VERSION=0
+
+usage() {
+  sed -n '2,21p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -i|--image)    IMAGE="$2"; shift 2;;
+    -t|--tag)      TAG="$2"; shift 2;;
+    --tag-version) TAG_VERSION=1; shift;;
+    -h|--help)     usage 0;;
+    *) echo "unknown arg: $1" >&2; usage 2;;
+  esac
+done
+
+case "$IMAGE" in
+  worker)        DOCKERFILE="docker/Dockerfile.worker";    ARTIFACT="seeknal-worker";;
+  gateway)       DOCKERFILE="docker/Dockerfile.gateway";   ARTIFACT="seeknal-gateway";;
+  prefect)       DOCKERFILE="docker/Dockerfile.prefect";   ARTIFACT="seeknal-prefect";;
+  report-server) DOCKERFILE="docker/report-server/Dockerfile"; ARTIFACT="seeknal-report-server";;
+  *) echo "unknown image: $IMAGE (worker|gateway|prefect|report-server)" >&2; exit 2;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ ! -f "$REPO_ROOT/$DOCKERFILE" ]; then
+  echo "$DOCKERFILE not found under $REPO_ROOT" >&2
+  echo "Run this script from a seeknal repo checkout." >&2
+  exit 1
+fi
+
+VERSION="$(python3 -c '
+import re
+with open("'"$REPO_ROOT"'/pyproject.toml", encoding="utf-8") as f:
+    match = re.search(r"^version\s*=\s*\"([^\"]+)\"", f.read(), re.MULTILINE)
+    print(match.group(1) if match else "0.0.0")
+')"
+if [ "$TAG_VERSION" = "1" ]; then
+  TAG="$VERSION"
+fi
+
+IMAGE_REF="${REGISTRY}/${ARTIFACT}:${TAG}"
+
+echo "==> Building ${IMAGE_REF}"
+echo "    context : ${REPO_ROOT}"
+echo "    docker  : ${DOCKERFILE}"
+echo "    version : ${VERSION} (seeknal)"
+docker build --platform=linux/amd64 -f "$REPO_ROOT/$DOCKERFILE" -t "$IMAGE_REF" "$REPO_ROOT"
+
+echo "==> Pushing ${IMAGE_REF}"
+docker push "$IMAGE_REF"
+
+cat <<EOF
+
+Done. ${IMAGE_REF}
+
+EOF
+
+if [ "$IMAGE" = "worker" ]; then
+  cat <<EOF
+To run it on the Dev VM, set in iba-deploy-runbook/configs/.env.seeknal-vm:
+  SEEKNAL_WORKER_IMAGE=${REGISTRY}/${ARTIFACT}
+  SEEKNAL_WORKER_VERSION=${TAG}
+Then on the VM:
+  docker compose -f docker-compose.seeknal-vm.yml --env-file .env.seeknal-vm up -d
+EOF
+fi

--- a/src/seeknal/ask/_pg_oracle.py
+++ b/src/seeknal/ask/_pg_oracle.py
@@ -50,23 +50,6 @@ from seeknal.connections.postgresql import (
 from seeknal.sources.config import SourceConfig, SourceRegistry
 
 
-# Regexes for namespace detection (used in detect_pg_only_namespace).
-# Quoted variants like "ns"."schema"."table" are also recognized.
-_IDENT = r'(?:"[^"]+"|[A-Za-z_][A-Za-z0-9_]*)'
-_RE_3PART = re.compile(rf'\b({_IDENT})\.({_IDENT})\.({_IDENT})\b')
-_RE_2PART = re.compile(rf'\b({_IDENT})\.({_IDENT})\b')
-_RE_UNQUALIFIED = re.compile(
-    rf'\b(?:FROM|JOIN)\s+({_IDENT})\b(?!\s*\.)',
-    flags=re.IGNORECASE,
-)
-
-
-def _strip_ident_quotes(token: str) -> str:
-    if token.startswith('"') and token.endswith('"'):
-        return token[1:-1]
-    return token
-
-
 def detect_pg_only_namespace(
     sql: str,
     registry: SourceRegistry,
@@ -80,7 +63,14 @@ def detect_pg_only_namespace(
     A connected-PG source is one where ``source_kind == "connected"``,
     ``source_type == "database"``, ``connector in {"postgresql", "postgres"}``,
     and the source is read-only.
+
+    The structural decision is delegated to :mod:`seeknal.ask.sql_routing`,
+    which parses the statement instead of matching text — a name can be a
+    remote table, a local view, or a CTE the statement defines, and only a
+    parser can tell those apart.
     """
+    from seeknal.ask.sql_routing import analyze
+
     pg_ns_set: set[str] = set()
     for source in registry.sources.values():
         if (
@@ -91,39 +81,7 @@ def detect_pg_only_namespace(
         ):
             pg_ns_set.add(source.namespace)
 
-    if not pg_ns_set:
-        return None
-
-    # Collect leading-identifier set from qualified refs.
-    # 3-part scan FIRST; replace those spans with whitespace so a follow-up
-    # 2-part scan does not double-count the inner ``schema.table`` portion.
-    leading: set[str] = set()
-    masked = list(sql)
-    for m in _RE_3PART.finditer(sql):
-        leading.add(_strip_ident_quotes(m.group(1)))
-        for idx in range(m.start(), m.end()):
-            masked[idx] = " "
-    masked_sql = "".join(masked)
-    for m in _RE_2PART.finditer(masked_sql):
-        leading.add(_strip_ident_quotes(m.group(1)))
-
-    if not leading:
-        return None
-
-    # Any unqualified table ref forces a DuckDB fallback. This prevents
-    # false-positive routing on SQL that mixes a qualified PG table and a
-    # bare parquet view. Scan the masked SQL so the leading identifier of
-    # a 3-part ref is not counted as an unqualified ``FROM`` ident.
-    if _RE_UNQUALIFIED.search(masked_sql):
-        return None
-
-    # Every leading identifier must be the same single connected-PG namespace.
-    if not leading.issubset(pg_ns_set):
-        return None
-    if len(leading) != 1:
-        return None
-    (ns,) = leading
-    return ns
+    return analyze(sql, pg_ns_set, target_dialect="postgres").namespace
 
 
 def resolve_pg_dsn(

--- a/src/seeknal/ask/access/registry.py
+++ b/src/seeknal/ask/access/registry.py
@@ -47,6 +47,7 @@ _VIEWER_TOOLS = {
     "run_forecast",
     "detect_anomaly",
     "upload_to_s3",
+    "visualize_chart",
 }
 
 # Analysts can additionally save personal preferences, draft pipelines, and

--- a/src/seeknal/ask/agents/agent.py
+++ b/src/seeknal/ask/agents/agent.py
@@ -273,6 +273,9 @@ def create_agent(
     tool_ctx = get_tool_context()
     tool_ctx.request_limit = get_request_limit(agent_config)
     tool_ctx.sql_timeout_seconds = get_sql_timeout_seconds(agent_config)
+    from seeknal.ask.config import get_pg_passthrough_enabled
+
+    tool_ctx.pg_passthrough = get_pg_passthrough_enabled(agent_config)
     tool_ctx.discovery_cache_ttl_seconds = get_discovery_cache_ttl_seconds(agent_config)
     tool_ctx.background_threshold = get_background_threshold(agent_config)
     from seeknal.ask.config import get_sql_pair_mode

--- a/src/seeknal/ask/agents/agent.py
+++ b/src/seeknal/ask/agents/agent.py
@@ -273,9 +273,10 @@ def create_agent(
     tool_ctx = get_tool_context()
     tool_ctx.request_limit = get_request_limit(agent_config)
     tool_ctx.sql_timeout_seconds = get_sql_timeout_seconds(agent_config)
-    from seeknal.ask.config import get_pg_passthrough_enabled
+    from seeknal.ask.config import get_pg_passthrough_enabled, get_read_max_lines
 
     tool_ctx.pg_passthrough = get_pg_passthrough_enabled(agent_config)
+    tool_ctx.read_max_lines = get_read_max_lines(agent_config)
     tool_ctx.discovery_cache_ttl_seconds = get_discovery_cache_ttl_seconds(agent_config)
     tool_ctx.background_threshold = get_background_threshold(agent_config)
     from seeknal.ask.config import get_sql_pair_mode

--- a/src/seeknal/ask/agents/agent.py
+++ b/src/seeknal/ask/agents/agent.py
@@ -227,6 +227,7 @@ def create_agent(
         get_forecast_enabled,
         get_anomaly_enabled,
         get_upload_to_s3_enabled,
+        get_visualize_chart_enabled,
         get_auto_summarization_config,
         get_cost_tracking_config,
         get_hooks_config,
@@ -439,6 +440,10 @@ in the final response.
             include_upload_to_s3=(
                 environment in ("gateway", "telegram")
                 and get_upload_to_s3_enabled(agent_config)
+            ),
+            include_visualize_chart=(
+                environment in ("gateway", "telegram")
+                and get_visualize_chart_enabled(agent_config)
             ),
         ),
         context_toolset,

--- a/src/seeknal/ask/agents/hooks.py
+++ b/src/seeknal/ask/agents/hooks.py
@@ -214,6 +214,10 @@ def get_ask_hooks(config: dict | None = None) -> list[Hook]:
       does on failure, so this hook's existing generic hint-enrichment
       applies to both without new logic).
 
+    `visualize_chart` is covered by both for the same reason `upload_to_s3` is:
+    its Mode 1 runs agent-supplied SQL through the same DuckDB seam, and it
+    names the argument `sql`, so the existing handlers apply unchanged.
+
     No CSV-upload hook lives here anymore: `execute_sql` no longer
     auto-uploads per call (see the module comment above this function for
     why); `run_forecast` self-uploads its own projection points from inside
@@ -230,7 +234,7 @@ def get_ask_hooks(config: dict | None = None) -> list[Hook]:
             Hook(
                 event=HookEvent.PRE_TOOL_USE,
                 handler=_sql_security_handler,
-                matcher="execute_sql|upload_to_s3|run_forecast|detect_anomaly",
+                matcher="execute_sql|upload_to_s3|run_forecast|detect_anomaly|visualize_chart",
             )
         )
     if cfg.get("sql_self_correction", True):
@@ -238,7 +242,7 @@ def get_ask_hooks(config: dict | None = None) -> list[Hook]:
             Hook(
                 event=HookEvent.POST_TOOL_USE,
                 handler=_sql_self_correction_handler,
-                matcher="execute_sql|upload_to_s3|run_forecast|detect_anomaly",
+                matcher="execute_sql|upload_to_s3|run_forecast|detect_anomaly|visualize_chart",
             )
         )
     return hooks

--- a/src/seeknal/ask/agents/tools/_chart_payload.py
+++ b/src/seeknal/ask/agents/tools/_chart_payload.py
@@ -1,0 +1,526 @@
+"""Chart payload construction shared by ``visualize_chart`` and ``run_forecast``.
+
+Single source of truth for the M9 chat-chart wire shape. Both the generic
+SQL-driven tool and ``run_forecast``'s self-chart path build their payload here,
+so the two can never drift apart -- one payload shape, two correctly scoped
+sources of data.
+
+The emitted shape is the array iba-web's chat renderer already parses::
+
+    [{
+        "chart_json": {
+            "widgetId": str, "widgetType": str, "widgetTitle": str,
+            "widgetData": [{col: value, ...}, ...], "widgetSize": int,
+        },
+        "chart_type": str,
+    }]
+
+Deliberately absent: ``vegaSpec``. iba-web builds its own Vega-Lite spec
+client-side from ``widgetData``, so nothing on the wire carries a spec. Column
+order IS the axis contract for every widget type: the first column is X, the
+second is Y, and a third (when present) is the series/colour dimension.
+
+Domain-neutral (``AGENTS.md``): callers supply the data and the widget type;
+this module contains no domain-specific strings.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any, TypeVar
+
+# _downsample works on both raw rows and rendered widgetData dicts.
+_Item = TypeVar("_Item")
+
+# Widget types iba-web can render. The first twelve map to the chat renderer's
+# client-side Vega-Lite spec generator; ``big_number`` is routed to a separate
+# scalar component. Anything outside this list renders as nothing, so the tool
+# validates against it before emitting.
+SUPPORTED_WIDGET_TYPES: tuple[str, ...] = (
+    "big_number",
+    "bar_chart",
+    "line_chart",
+    "pie_chart",
+    "horizontal_bar_chart",
+    "grouped_bar_chart",
+    "grouped_line_chart",
+    "grouped_pie_chart",
+    "area_chart",
+    "scatter_plot",
+    "heatmap",
+    "box_plot",
+    "treemap",
+)
+
+# Payload caps. Concrete values so two implementers cannot diverge; every
+# reduction below is deterministic and reported back to the agent as a notice,
+# never applied silently.
+CHART_MAX_ROWS = 500        # hard ceiling on widgetData length
+CHART_MAX_POINTS = 200      # max points on a single time-series line/area
+CHART_TOP_N = 12            # categorical charts keep the top N, bucket the rest
+CHART_MAX_SERIES = 8        # max distinct values in the third (series) column
+CHART_MAX_PAYLOAD_BYTES = 100_000  # serialized ceiling; the payload is persisted
+
+# Label for the bucket that absorbs categories beyond CHART_TOP_N. Explicit so
+# the chart never silently hides part of the total.
+OTHERS_LABEL = "Others"
+
+_CATEGORICAL_TYPES = frozenset(
+    {"bar_chart", "horizontal_bar_chart", "pie_chart", "grouped_pie_chart", "treemap"}
+)
+_TIME_SERIES_TYPES = frozenset({"line_chart", "area_chart", "grouped_line_chart"})
+
+# ---------------------------------------------------------------------------
+# Per-widget shape contracts
+# ---------------------------------------------------------------------------
+# The renderer reads AT MOST three columns -- ``keys[0]`` as X, ``keys[1]`` as Y
+# and ``keys[2]`` as the colour/series dimension -- and silently ignores every
+# column after the third. It also fixes the X encoding per widget type, so a
+# label the encoding cannot parse yields an empty axis rather than an error.
+#
+# Encoding a wrong shape is therefore invisible at run time: the chart still
+# renders, just wrong. These contracts move that failure forward to the tool
+# call, where the agent can still fix it.
+#
+# ``x_kind`` mirrors the renderer's X encoding:
+#   temporal      -- parsed as a date; non-ISO labels collapse the axis
+#   categorical   -- nominal; any label works
+#   quantitative  -- parsed as a number; non-numeric collapses the axis
+# ``series`` is whether the renderer actually reads the third column.
+
+
+class WidgetSpec:
+    """The data shape one widget type can faithfully render."""
+
+    __slots__ = ("x_kind", "series", "shows")
+
+    def __init__(self, x_kind: str, series: bool, shows: str) -> None:
+        self.x_kind = x_kind
+        self.series = series
+        self.shows = shows
+
+
+WIDGET_SPECS: dict[str, WidgetSpec] = {
+    "line_chart": WidgetSpec("temporal", True, "a metric over time"),
+    "grouped_line_chart": WidgetSpec("temporal", True, "several metrics over time"),
+    "area_chart": WidgetSpec("temporal", True, "a cumulative metric over time"),
+    "bar_chart": WidgetSpec("categorical", False, "one metric across categories"),
+    "grouped_bar_chart": WidgetSpec(
+        "categorical", True, "several metrics across categories"
+    ),
+    "horizontal_bar_chart": WidgetSpec(
+        "categorical", False, "one metric across categories with long labels"
+    ),
+    "pie_chart": WidgetSpec("categorical", False, "one metric's share of a total"),
+    "grouped_pie_chart": WidgetSpec(
+        "categorical", False, "one metric's share of a total"
+    ),
+    "treemap": WidgetSpec("categorical", False, "nested share of a total"),
+    "box_plot": WidgetSpec("categorical", False, "a metric's spread per category"),
+    "scatter_plot": WidgetSpec("quantitative", True, "two metrics correlated"),
+    "heatmap": WidgetSpec("categorical", True, "a metric across two dimensions"),
+    "big_number": WidgetSpec("categorical", False, "a single headline value"),
+}
+
+# Suggested replacement when the chosen type cannot carry a series column but
+# the data has one. Types absent here have no series-capable equivalent.
+_SERIES_ALTERNATIVE: dict[str, str] = {
+    "bar_chart": "grouped_bar_chart",
+    "horizontal_bar_chart": "grouped_bar_chart",
+    "line_chart": "grouped_line_chart",
+    "pie_chart": "grouped_bar_chart",
+    "grouped_pie_chart": "grouped_bar_chart",
+    "treemap": "grouped_bar_chart",
+    "box_plot": "grouped_bar_chart",
+}
+
+# Widget types whose X axis tolerates period labels, offered when a temporal
+# chart is asked to plot labels that are not parseable dates.
+_CATEGORICAL_ALTERNATIVE: dict[str, str] = {
+    "line_chart": "bar_chart",
+    "grouped_line_chart": "grouped_bar_chart",
+    "area_chart": "bar_chart",
+}
+
+# Accepted temporal literals: a year, a year-month, a date, or a full ISO
+# timestamp. Deliberately narrower than the renderer's own date parsing, which
+# accepts locale-dependent forms that differ between browsers.
+_ISO_TEMPORAL = re.compile(
+    r"^\d{4}(-\d{2}(-\d{2}([T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?)?)?)?$"
+)
+
+MAX_CHART_COLUMNS = 3
+
+
+def chart_widget_id(session_id: str, sql: str) -> str:
+    """Build a deterministic widget id for one chart.
+
+    Same session and same SQL always produce the same id, so repeated
+    inspection and debugging are stable. The id is not load-bearing for
+    de-duplication -- one chart per turn is enforced by the single-slot
+    ``ctx.pending_visualization``, not by comparing ids.
+
+    Args:
+        session_id: The ask session id from ``ToolContext``.
+        sql: The SQL (or any stable fingerprint) behind this chart.
+
+    Returns:
+        An id of the form ``"{session_id}-{8-hex-digest}"``.
+    """
+    digest = hashlib.sha1(sql.strip().encode("utf-8")).hexdigest()[:8]
+    return f"{session_id}-{digest}"
+
+
+def validate_chart_shape(
+    widget_type: str,
+    columns: list[str],
+    rows: list[list[Any]],
+) -> str | None:
+    """Check the data against the widget's shape contract.
+
+    Returns ``None`` when the shape renders faithfully, otherwise one sentence
+    naming the mismatch plus the concrete fix. Every rule here guards a failure
+    the renderer would otherwise absorb silently -- a dropped column, a
+    collapsed axis -- and produce a chart that disagrees with the answer.
+
+    Args:
+        widget_type: One of :data:`SUPPORTED_WIDGET_TYPES`.
+        columns: Column names in axis order.
+        rows: Row values aligned to ``columns``.
+
+    Returns:
+        ``None`` if valid, else the reason and the remedy.
+    """
+    spec = WIDGET_SPECS.get(widget_type)
+    if spec is None or not rows:
+        return None
+
+    column_count = len(columns)
+
+    # Rule 1 -- wide data. The 4th column onwards is dropped by the renderer,
+    # so a wide table charts only its first metric and silently hides the rest.
+    if column_count > MAX_CHART_COLUMNS:
+        extra = ", ".join(str(name) for name in columns[MAX_CHART_COLUMNS:])
+        return (
+            f"{column_count} columns given; a chart reads at most "
+            f"{MAX_CHART_COLUMNS} ({columns[0]} = X, {columns[1]} = Y, "
+            f"{columns[2]} = series). These would be dropped: {extra}. "
+            "Reshape the query from wide to long so every metric becomes rows "
+            "of one series column -- SELECT period, 'metric name' AS series, "
+            "metric AS value ... UNION ALL ... (or UNPIVOT) -- then chart it "
+            "with grouped_bar_chart or grouped_line_chart to show all metrics "
+            "at once."
+        )
+
+    # Rule 2 -- a series column this widget type cannot draw. The renderer only
+    # reads keys[2] for the types marked series-capable; for the rest the third
+    # column is dropped, so the chart shows one metric while the answer covers
+    # several.
+    if column_count == MAX_CHART_COLUMNS and not spec.series:
+        alternative = _SERIES_ALTERNATIVE.get(widget_type)
+        remedy = (
+            f"Use '{alternative}' to draw all series, or drop the third column."
+            if alternative
+            else "Drop the third column."
+        )
+        return (
+            f"'{widget_type}' draws {spec.shows} and ignores the third column "
+            f"('{columns[2]}'), so that series would not appear. {remedy}"
+        )
+
+    # Rule 3 -- an X axis the encoding cannot parse. A temporal axis fed period
+    # names, or a quantitative axis fed labels, renders an empty or flat chart
+    # rather than failing.
+    offender = _first_unparseable_x(spec.x_kind, rows)
+    if offender is not None:
+        if spec.x_kind == "temporal":
+            alternative = _CATEGORICAL_ALTERNATIVE.get(widget_type, "bar_chart")
+            return (
+                f"'{widget_type}' plots X as a date, but '{columns[0]}' holds "
+                f"{offender!r}, which is not one. Either return ISO periods "
+                "(2024-01-01, or 2024-01 for months) so the axis is ordered by "
+                f"time, or use '{alternative}', whose X axis takes labels."
+            )
+        return (
+            f"'{widget_type}' plots X as a number, but '{columns[0]}' holds "
+            f"{offender!r}. Put the numeric measure first, or use "
+            "'bar_chart' for a labelled X axis."
+        )
+
+    return None
+
+
+def _first_unparseable_x(x_kind: str, rows: list[list[Any]]) -> Any | None:
+    """Return the first X value the given encoding cannot parse, else ``None``."""
+    if x_kind == "categorical":
+        return None
+
+    for row in rows:
+        if not row:
+            continue
+        value = row[0]
+        if value is None:
+            continue
+        if x_kind == "temporal":
+            if isinstance(value, (datetime, date)):
+                continue
+            if isinstance(value, str) and _ISO_TEMPORAL.match(value.strip()):
+                continue
+            return value
+        if x_kind == "quantitative":
+            if isinstance(value, bool):
+                return value
+            if isinstance(value, (int, float, Decimal)):
+                continue
+            try:
+                float(str(value))
+            except (TypeError, ValueError):
+                return value
+    return None
+
+
+def build_chart_payload(
+    *,
+    widget_type: str,
+    widget_title: str,
+    widget_id: str,
+    columns: list[str],
+    rows: list[list[Any]],
+    widget_size: int = 1,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Build the chart payload from tabular data, enforcing the payload caps.
+
+    Args:
+        widget_type: One of :data:`SUPPORTED_WIDGET_TYPES`. Callers validate
+            this first; it is used here only to pick the right cap strategy.
+        widget_title: Human-readable chart title, also the accessible label.
+        widget_id: Deterministic id from :func:`chart_widget_id`.
+        columns: Column names in axis order -- ``[x, y]`` or ``[x, y, series]``.
+        rows: Row values aligned to ``columns``.
+        widget_size: Layout hint consumed by the frontend grid.
+
+    Returns:
+        A ``(payload, notices)`` tuple. ``payload`` is the array described in
+        the module docstring. ``notices`` describes every deterministic
+        reduction applied (top-N bucketing, downsampling, series trimming) so
+        the caller can tell the agent what the chart actually shows.
+    """
+    capped_rows, notices = _apply_caps(widget_type, rows)
+
+    widget_data = [
+        {str(column): _json_safe(cell) for column, cell in zip(columns, row)}
+        for row in capped_rows
+    ]
+    widget_data, byte_notice = _fit_payload_bytes(widget_data)
+    if byte_notice:
+        notices.append(byte_notice)
+
+    payload = [
+        {
+            "chart_json": {
+                "widgetId": widget_id,
+                "widgetType": widget_type,
+                "widgetTitle": widget_title,
+                "widgetData": widget_data,
+                "widgetSize": widget_size,
+            },
+            "chart_type": widget_type,
+        }
+    ]
+    return payload, notices
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _json_safe(value: Any) -> Any:
+    """Coerce one DuckDB cell into a value ``json.dumps`` accepts.
+
+    The payload is serialized onto the SSE stream and persisted into a JSON
+    column, so a stray ``date``/``Decimal`` would break the whole turn rather
+    than just the chart.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
+
+
+def _as_number(value: Any) -> float:
+    """Return ``value`` as a float, treating anything unparseable as zero.
+
+    Used only for ranking and bucketing, where a non-numeric metric should sort
+    last rather than raise.
+    """
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _apply_caps(widget_type: str, rows: list[list[Any]]) -> tuple[list[list[Any]], list[str]]:
+    """Apply the payload caps in a fixed order, returning rows plus notices.
+
+    Order matters and is deliberate: trim series first (it removes whole rows),
+    then bucket categories, then downsample, then enforce the absolute row
+    ceiling. Running it the other way round would downsample rows that
+    bucketing was about to merge anyway.
+    """
+    notices: list[str] = []
+
+    rows, notice = _cap_series(rows)
+    if notice:
+        notices.append(notice)
+
+    if widget_type in _CATEGORICAL_TYPES:
+        rows, notice = _bucket_top_n(rows)
+        if notice:
+            notices.append(notice)
+
+    if widget_type in _TIME_SERIES_TYPES:
+        original = len(rows)
+        rows = _downsample_per_series(rows, CHART_MAX_POINTS)
+        if len(rows) != original:
+            notices.append(
+                f"downsampled {original} points to {len(rows)} "
+                f"(cap {CHART_MAX_POINTS} points per series)"
+            )
+
+    if len(rows) > CHART_MAX_ROWS:
+        original = len(rows)
+        rows = _downsample(rows, CHART_MAX_ROWS)
+        notices.append(
+            f"reduced {original} rows to {len(rows)} (cap {CHART_MAX_ROWS} rows)"
+        )
+
+    return rows, notices
+
+
+def _cap_series(rows: list[list[Any]]) -> tuple[list[list[Any]], str | None]:
+    """Keep only the largest ``CHART_MAX_SERIES`` values of the series column.
+
+    Applies only to three-column data, where the third column is the series
+    dimension. Series are ranked by their summed metric so the dominant ones
+    survive; rows belonging to dropped series are removed entirely rather than
+    merged, because merging unrelated series would misrepresent the data.
+    """
+    if not rows or len(rows[0]) < 3:
+        return rows, None
+
+    totals: dict[Any, float] = {}
+    for row in rows:
+        totals[row[2]] = totals.get(row[2], 0.0) + _as_number(row[1])
+    if len(totals) <= CHART_MAX_SERIES:
+        return rows, None
+
+    ranked = sorted(totals.items(), key=lambda item: item[1], reverse=True)
+    keep = {name for name, _total in ranked[:CHART_MAX_SERIES]}
+    notice = (
+        f"kept the top {CHART_MAX_SERIES} of {len(totals)} series "
+        f"(cap {CHART_MAX_SERIES} series)"
+    )
+    return [row for row in rows if row[2] in keep], notice
+
+
+def _bucket_top_n(rows: list[list[Any]]) -> tuple[list[list[Any]], str | None]:
+    """Keep the top ``CHART_TOP_N`` categories and bucket the rest as "Others".
+
+    Only meaningful for two-column categorical data. The remainder is summed
+    into one explicit row instead of being dropped, so the chart's total still
+    matches the answer's total.
+    """
+    if len(rows) <= CHART_TOP_N or not rows or len(rows[0]) != 2:
+        return rows, None
+
+    ranked = sorted(rows, key=lambda row: _as_number(row[1]), reverse=True)
+    kept = list(ranked[:CHART_TOP_N])
+    remainder = sum(_as_number(row[1]) for row in ranked[CHART_TOP_N:])
+    kept.append([OTHERS_LABEL, remainder])
+    notice = (
+        f"kept the top {CHART_TOP_N} of {len(rows)} categories and bucketed the "
+        f'remainder into "{OTHERS_LABEL}"'
+    )
+    return kept, notice
+
+
+def _downsample_per_series(
+    rows: list[list[Any]], target: int
+) -> list[list[Any]]:
+    """Downsample a time series, keeping each series independently intact.
+
+    Long-format multi-series rows interleave series, so a single global stride
+    would keep different periods for different series and draw lines that jump
+    between points the data never had. Each series is therefore strided on its
+    own and the original row order is restored.
+    """
+    if not rows or len(rows[0]) < 3:
+        return _downsample(rows, target)
+
+    positions_by_series: dict[Any, list[int]] = {}
+    for index, row in enumerate(rows):
+        positions_by_series.setdefault(row[2], []).append(index)
+
+    if all(len(positions) <= target for positions in positions_by_series.values()):
+        return rows
+
+    kept: set[int] = set()
+    for positions in positions_by_series.values():
+        kept.update(_downsample(positions, target))
+    return [row for index, row in enumerate(rows) if index in kept]
+
+
+def _downsample(rows: list[_Item], target: int) -> list[_Item]:
+    """Reduce ``rows`` to at most ``target`` entries with an even stride.
+
+    Deterministic (no sampling) and always keeps the last row, so a time series
+    still ends where the data ends -- a downsampled trend that stops early
+    would read as a drop that never happened.
+    """
+    if len(rows) <= target or target < 1:
+        return rows
+
+    step = len(rows) / float(target)
+    indexes = sorted({min(len(rows) - 1, int(i * step)) for i in range(target)})
+    if indexes[-1] != len(rows) - 1:
+        indexes[-1] = len(rows) - 1
+    return [rows[index] for index in indexes]
+
+
+def _fit_payload_bytes(
+    widget_data: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], str | None]:
+    """Halve the row count until the serialized payload fits the byte ceiling.
+
+    The last line of defence: wide rows can blow the ceiling even at a legal row
+    count, and the payload is persisted into a JSON column and replayed on every
+    history load.
+    """
+    if not widget_data:
+        return widget_data, None
+
+    original = len(widget_data)
+    while len(widget_data) > 1 and _payload_bytes(widget_data) > CHART_MAX_PAYLOAD_BYTES:
+        widget_data = _downsample(widget_data, max(1, len(widget_data) // 2))
+
+    if len(widget_data) == original:
+        return widget_data, None
+    return widget_data, (
+        f"reduced {original} rows to {len(widget_data)} to fit the "
+        f"{CHART_MAX_PAYLOAD_BYTES // 1000} KB chart payload ceiling"
+    )
+
+
+def _payload_bytes(widget_data: list[Any]) -> int:
+    """Return the serialized byte size of ``widget_data``."""
+    return len(json.dumps(widget_data, ensure_ascii=False).encode("utf-8"))

--- a/src/seeknal/ask/agents/tools/_context.py
+++ b/src/seeknal/ask/agents/tools/_context.py
@@ -97,6 +97,27 @@ class ToolContext:
     # ``upload_complete`` event and CONTINUES the turn — unlike
     # pending_clarification which ends it. ``None`` means no upload is pending.
     pending_upload: dict[str, Any] | None = None
+    # M9: pending chat chart. Set by visualize_chart (and run_forecast's
+    # self-chart step). The gateway streaming layer emits a ``visualization``
+    # event and CONTINUES the turn -- same lifecycle as pending_upload.
+    # Single-slot on purpose: one question yields at most one chart, so a
+    # second chart attempt in the same turn is refused rather than silently
+    # overwriting the first. ``None`` means no chart is pending.
+    pending_visualization: list[dict[str, Any]] | None = None
+    # M9: the dataset this turn exported as CSV, as
+    # ``{"name": str, "columns": [...], "rows": [[...], ...]}``.
+    #
+    # Single-slot, last-wins -- mirroring ``pending_upload``, which is also
+    # single-slot, so the registered rows always match the one Download button
+    # the user actually gets. One question yields one CSV.
+    #
+    # Exists so a chart can be drawn from data that is NOT re-queryable. A
+    # forecast's projection is computed in-process, never in SQL, so charting
+    # it from its source query would show history only -- a picture that
+    # contradicts the text beside it. Re-typing those numbers into the tool is
+    # worse still: transcription drift. Reusing the exact rows that went into
+    # the CSV keeps table, download and chart on one source of truth.
+    exported_dataset: dict[str, Any] | None = None
     # IBA engine connection, resolved ONCE at agent init (see
     # agent.py::create_agent) and injected here -- same pattern as
     # ``repl``/``project_path``. run_forecast and detect_anomaly read
@@ -216,6 +237,56 @@ def get_successful_sql_cache(ctx: ToolContext | None = None) -> dict[str, str]:
         setattr(ctx.repl, "_seeknal_successful_sql_cache", cache)
     ctx.successful_sql_cache = cache
     return cache
+
+
+def get_structured_sql_cache(
+    ctx: ToolContext | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Return the session structured SQL-result cache on the durable REPL object.
+
+    Parallel to :func:`get_successful_sql_cache`, which caches the *rendered
+    markdown table*. Chart building needs machine-readable rows, so this cache
+    holds ``{"columns": [...], "rows": [[...], ...]}`` written by ``execute_sql``
+    under the SAME ``_sql_cache_key(sql)`` key.
+
+    Sharing that key is the correctness contract behind M9 charts: the same SQL
+    resolves to the same entry, so the chart and the textual answer are built
+    from one dataset instead of two independent reads. Rows are stored
+    post-governance (Atlas masking already applied), so a chart can never
+    surface a value the answer itself was not allowed to show.
+    """
+    ctx = ctx or get_tool_context()
+    cache = getattr(ctx.repl, "_seeknal_structured_sql_cache", None)
+    if not isinstance(cache, dict):
+        cache = {}
+        setattr(ctx.repl, "_seeknal_structured_sql_cache", cache)
+    return cache
+
+
+def register_exported_dataset(
+    name: str,
+    columns: list[str],
+    rows: list[list[Any]],
+    ctx: ToolContext | None = None,
+) -> None:
+    """Record the rows a tool just exported as CSV, so a chart can reuse them.
+
+    Called by whichever tool produced the downloadable file. Last write wins,
+    matching ``pending_upload``: if a turn exports twice, both the Download
+    button and the chart follow the second export.
+
+    Args:
+        name: The exported file name, for reference in tool results.
+        columns: Column names in export order.
+        rows: Row values aligned to ``columns``.
+        ctx: Tool context; resolved from the contextvar when omitted.
+    """
+    ctx = ctx or get_tool_context()
+    ctx.exported_dataset = {
+        "name": name,
+        "columns": list(columns),
+        "rows": [list(row) for row in rows],
+    }
 
 
 def get_loaded_sql_pairs(ctx: ToolContext | None = None) -> dict[str, str]:
@@ -496,6 +567,8 @@ def reset_turn_governor(question: str | None = None) -> None:
     ctx.timing_events_this_turn.clear()
     ctx.pending_clarification = None
     ctx.pending_upload = None
+    ctx.pending_visualization = None
+    ctx.exported_dataset = None
 
 
 def get_discovery_cache_value(key: str) -> Any | None:
@@ -652,13 +725,22 @@ def synthesize_evidence_fallback(reason: str) -> str:
     return "\n".join(lines).strip()
 
 
-def build_evidence_synthesis_prompt(reason: str) -> str:
-    """Build a no-tool final-answer prompt from the turn governor evidence.
+def build_evidence_synthesis_prompt(reason: str, allow_chart: bool = False) -> str:
+    """Build a final-answer prompt from the turn governor evidence.
 
     This is a safety valve for bounded read-only analysis sessions. If the
     model keeps exploring until the harness budget is reached, we give it the
-    already-collected evidence and explicitly prohibit more tools so the user
+    already-collected evidence and prohibit further exploration so the user
     gets a natural-language answer instead of raw harness diagnostics.
+
+    Args:
+        reason: Why the turn stopped, quoted back to the model.
+        allow_chart: Whether ``visualize_chart`` is available at this stage.
+            The caller decides that by restricting the toolset; the prompt has
+            to agree with it, because a blanket "do not call any tools" is
+            obeyed even when a tool *is* offered -- the model then describes a
+            chart in prose instead of drawing one, which is exactly the
+            "visualisation unavailable" answer this stage used to produce.
     """
     ctx = get_tool_context()
     question = (ctx.current_question or "").strip()
@@ -670,7 +752,15 @@ def build_evidence_synthesis_prompt(reason: str) -> str:
 
     parts = [
         "You are writing the final answer for a read-only data-analysis turn.",
-        "Do not call any tools. Do not ask for more context.",
+        (
+            "Do not gather more data: no SQL, no lookups, no context reads, and "
+            "do not ask for more context. You MAY call visualize_chart once, "
+            "and only that -- it draws rows already gathered and adds no "
+            "exploration. If the evidence below carries a trend, a comparison "
+            "or a breakdown, chart it rather than describing a chart in words."
+            if allow_chart
+            else "Do not call any tools. Do not ask for more context."
+        ),
         "Use only the evidence below; if it is incomplete, say what is missing as a caveat.",
         "Do not infer labels for coded dimensions unless the evidence includes the mapping.",
         "If a label mapping is missing, keep the raw code and state that the label was not found.",

--- a/src/seeknal/ask/agents/tools/_context.py
+++ b/src/seeknal/ask/agents/tools/_context.py
@@ -76,6 +76,10 @@ class ToolContext:
     sql_pairs_checked_this_turn: bool = False
     authoritative_sql_pair_result_this_turn: dict[str, str] | None = None
     sql_timeout_seconds: int = 60
+    # SQLR: route PG-only SQL straight to PostgreSQL instead of running it
+    # through DuckDB's postgres_scanner. Off unless the project opts in; any
+    # failure on that path falls back to DuckDB (see execute_sql._try_pg_route).
+    pg_passthrough: bool = False
     discovery_cache_ttl_seconds: int = 300
     discovery_cache: dict[str, tuple[float, Any]] = field(default_factory=dict)
     timing_events_this_turn: list[dict[str, Any]] = field(default_factory=list)

--- a/src/seeknal/ask/agents/tools/_context.py
+++ b/src/seeknal/ask/agents/tools/_context.py
@@ -76,6 +76,10 @@ class ToolContext:
     sql_pairs_checked_this_turn: bool = False
     authoritative_sql_pair_result_this_turn: dict[str, str] | None = None
     sql_timeout_seconds: int = 60
+    # How many lines read_project_file returns per call. 200 suits source files;
+    # projects whose rule documents run longer can raise it so the tail is not
+    # silently cut (see ask.config.get_read_max_lines).
+    read_max_lines: int = 200
     # SQLR: route PG-only SQL straight to PostgreSQL instead of running it
     # through DuckDB's postgres_scanner. Off unless the project opts in; any
     # failure on that path falls back to DuckDB (see execute_sql._try_pg_route).

--- a/src/seeknal/ask/agents/tools/execute_sql.py
+++ b/src/seeknal/ask/agents/tools/execute_sql.py
@@ -78,6 +78,7 @@ def execute_sql(
         bump_authoritative_drift_attempt,
         get_authoritative_sql_pair_result,
         get_tool_context,
+        get_structured_sql_cache,
         get_successful_sql_cache,
         record_tool_result,
         repeated_failure_message,
@@ -304,6 +305,14 @@ def execute_sql(
     if drift_notice:
         result += "\n\n" + drift_notice
     success_cache[cache_key] = result
+    # M9: chart tools need machine-readable rows, not the rendered table above.
+    # Cache the governed (masked) rows under the SAME key so a later
+    # visualize_chart(sql) call charts exactly the dataset this answer used,
+    # without re-executing the query.
+    get_structured_sql_cache(ctx)[cache_key] = {
+        "columns": list(columns),
+        "rows": [list(row) for row in trimmed_rows],
+    }
     record_tool_result("execute_sql", result, args={"sql": sql})
     return result
 

--- a/src/seeknal/ask/agents/tools/execute_sql.py
+++ b/src/seeknal/ask/agents/tools/execute_sql.py
@@ -822,12 +822,137 @@ def _count_total(ctx, sql: str) -> int | None:
     return None
 
 
+# PostgreSQL truncates identifiers at NAMEDATALEN-1 bytes. A name it cannot
+# hold would come back truncated — a different header, which is exactly what
+# carrying the local names over is meant to prevent — so such a statement is
+# left on the local engine instead.
+_PG_MAX_IDENTIFIER_BYTES = 63
+
+
+def _local_column_names(ctx, sql: str) -> list[str] | None:
+    """Ask the local engine what it would call this statement's result columns.
+
+    Returns None when the question cannot be answered; the caller then leaves
+    the statement on the local engine rather than guessing at a name.
+    """
+    from seeknal.ask.sql_routing import probe_sql
+
+    probe = probe_sql(sql)
+    if probe is None:
+        return None
+    try:
+        with ctx.db_lock:
+            cursor = ctx.repl.conn.execute(probe)
+            return [str(column[0]) for column in cursor.description or []]
+    except Exception:  # noqa: BLE001 — probing is best-effort
+        return None
+
+
+def _try_pg_route(ctx, sql: str, limit: int | None):
+    """Run PG-only SQL directly on PostgreSQL; return ``(columns, rows)`` or None.
+
+    DuckDB's postgres_scanner pushes down predicates but never aggregation, so
+    ``COUNT(DISTINCT ...)`` over an attached table transfers the raw column and
+    computes locally. Sending PG-only SQL to PostgreSQL lets the source do the
+    aggregation and return only the result rows.
+
+    Returning None means "not routed" and the caller continues on the DuckDB
+    path. That is the case for every failure too — unsupported SQL, a dialect
+    error, an unreachable database. Routing may make a query slower by falling
+    back, but it can never change the answer or surface a new error.
+
+    This is the one place the agent path deliberately differs from the oracle
+    path in ``ask/testing.py``, which must NOT fall back (a wrong-engine answer
+    would defeat a ground-truth oracle). Here availability wins.
+    """
+    import time
+
+    from seeknal.ask.agents.tools._context import record_timing_event
+
+    if not getattr(ctx, "pg_passthrough", False):
+        return None
+
+    started = time.monotonic()
+    try:
+        from seeknal.ask._pg_oracle import execute_via_psycopg2, resolve_pg_dsn
+        from seeknal.ask.sql_routing import analyze
+        from seeknal.sources.config import load_source_registry
+        from seeknal.workflow.materialization.profile_loader import ProfileLoader
+
+        registry = load_source_registry(ctx.project_path)
+        remote = {
+            s.namespace
+            for s in registry.sources.values()
+            if s.source_kind == "connected"
+            and s.source_type == "database"
+            and s.connector in ("postgresql", "postgres")
+            and s.is_read_only
+        }
+        plan = analyze(sql, remote, target_dialect="postgres")
+        if not plan.is_routable and plan.reason.startswith("unaliased projection"):
+            # The statement leaves a projection for the engine to name, and the
+            # engines disagree. Ask the local engine what it would call them —
+            # LIMIT 0 plans the statement without reading rows — then carry
+            # those names over so the routed result is labelled identically.
+            plan = analyze(
+                sql,
+                remote,
+                target_dialect="postgres",
+                local_column_names=_local_column_names(ctx, sql),
+                max_identifier_bytes=_PG_MAX_IDENTIFIER_BYTES,
+            )
+        if not plan.is_routable:
+            return None
+        # registry.sources is keyed by .name, not .namespace — match on the
+        # attribute (same lookup as ask/testing.py:266).
+        source = next(
+            (s for s in registry.sources.values() if s.namespace == plan.namespace),
+            None,
+        )
+        if source is None:
+            return None
+
+        profile_path = ctx.project_path / "profiles.yml"
+        loader = ProfileLoader(
+            profile_path=profile_path if profile_path.exists() else None
+        )
+        dsn = resolve_pg_dsn(source, loader._load_profile_data())
+
+        pg_sql = plan.sql
+        if limit is not None:
+            pg_sql = f"SELECT * FROM ({pg_sql}) _seeknal_routed LIMIT {int(limit)}"
+
+        result = execute_via_psycopg2(dsn, pg_sql)
+        if result.error:
+            record_timing_event(
+                "execute_sql_pg_fallback",
+                int((time.monotonic() - started) * 1000),
+                reason=str(result.error)[:200],
+            )
+            return None
+        return [str(col) for col in result.columns], list(result.rows)
+    except Exception as exc:  # noqa: BLE001 — any failure means "use DuckDB"
+        try:
+            record_timing_event(
+                "execute_sql_pg_fallback",
+                int((time.monotonic() - started) * 1000),
+                reason=f"{type(exc).__name__}: {exc}"[:200],
+            )
+        except Exception:  # noqa: BLE001 — observability never blocks
+            pass
+        return None
+
+
 def _execute_oneshot_with_timeout(ctx, sql: str, limit: int | None = None):
     """Execute REPL SQL with the session db lock and optional hard timeout."""
     import concurrent.futures
     import time
 
     from seeknal.ask.agents.tools._context import record_timing_event
+
+    routed = _try_pg_route(ctx, sql, limit)
+    if routed is not None:
+        return routed
 
     timeout = int(getattr(ctx, "sql_timeout_seconds", 0) or 0)
     started = time.monotonic()

--- a/src/seeknal/ask/agents/tools/forecast.py
+++ b/src/seeknal/ask/agents/tools/forecast.py
@@ -414,11 +414,15 @@ def _upload_combined_forecast_csv(
     # History rows: value filled, projection columns blank.
     for x, y in history:
         rows.append([x, "historis", int(round(y)), "", "", "", "", ""])
-    # Projection rows: value blank, projection columns filled from the engine.
+    # Projection rows: `value` carries the point estimate too, so `value` is one
+    # continuous Y across historis+proyeksi and the pair [period, value, kind] is
+    # chartable as [x, y, series]. `point` + bounds stay as the explicit projection
+    # fields. Charting `point` alone would render every historis period as a flat 0.
     for p in points:
+        point_value = p.get("point")
         rows.append([
-            p.get("period"), proj_kind, "",
-            p.get("point"), p.get("lower_80"), p.get("upper_80"),
+            p.get("period"), proj_kind, point_value,
+            point_value, p.get("lower_80"), p.get("upper_80"),
             p.get("lower_95"), p.get("upper_95"),
         ])
     filename = _derive_forecast_filename(sql)

--- a/src/seeknal/ask/agents/tools/read_project_file.py
+++ b/src/seeknal/ask/agents/tools/read_project_file.py
@@ -65,7 +65,7 @@ def _do_read(path: str, project_path, start_line: int = 1, max_lines: int = 200)
 def read_project_file(
     path: str,
     start_line: int = 1,
-    max_lines: int = 200,
+    max_lines: int | None = None,
 ) -> str:
     """Read any file in the project by its relative path.
 
@@ -78,9 +78,12 @@ def read_project_file(
     Args:
         path: File path relative to the project root.
         start_line: Line number to start reading from (default 1).
-        max_lines: Maximum number of lines to return (default 200).
+        max_lines: Maximum number of lines to return. Omit to use the
+            project's configured window.
     """
     from seeknal.ask.agents.tools._context import get_tool_context
 
     ctx = get_tool_context()
+    if max_lines is None:
+        max_lines = getattr(ctx, "read_max_lines", 200)
     return _do_read(path, ctx.project_path, start_line, max_lines)

--- a/src/seeknal/ask/agents/tools/toolset.py
+++ b/src/seeknal/ask/agents/tools/toolset.py
@@ -63,6 +63,7 @@ from seeknal.ask.agents.tools.search_project_files import search_project_files
 from seeknal.ask.agents.tools.show_lineage import show_lineage
 from seeknal.ask.agents.tools.submit_plan import submit_plan
 from seeknal.ask.agents.tools.upload_to_s3 import upload_to_s3
+from seeknal.ask.agents.tools.visualize_chart import visualize_chart
 from seeknal.ask.agents.tools.write_ingested_table import write_ingested_table
 from seeknal.ask.agents.tools.write_project_file import write_project_file
 
@@ -167,6 +168,13 @@ _EXPORT_TOOLS = [
     upload_to_s3,
 ]
 
+# Chat chart tool. The single owner of chart building -- no other tool attaches
+# a chart of its own. Gated by ``include_visualize_chart``, registered only in
+# non-interactive environments when ``agent.visualize_chart.enabled`` is true.
+_VISUALIZATION_TOOLS = [
+    visualize_chart,
+]
+
 
 def create_ask_toolset(
     *,
@@ -176,6 +184,7 @@ def create_ask_toolset(
     include_forecast: bool = False,
     include_anomaly: bool = False,
     include_upload_to_s3: bool = False,
+    include_visualize_chart: bool = False,
 ) -> FunctionToolset:
     """Create the seeknal-ask toolset.
 
@@ -198,6 +207,9 @@ def create_ask_toolset(
         include_upload_to_s3: Include the generic CSV export tool ``upload_to_s3``.
             Registered only in non-interactive environments when
             ``agent.upload_to_s3.enabled`` is true in ``seeknal_agent.yml``.
+        include_visualize_chart: Include the chat chart tool ``visualize_chart``.
+            Registered only in non-interactive environments when
+            ``agent.visualize_chart.enabled`` is true in ``seeknal_agent.yml``.
     """
     if mode == "analysis":
         # Keep the connected-source/read-only surface deliberately thin:
@@ -238,6 +250,9 @@ def create_ask_toolset(
 
     if include_upload_to_s3:
         tools.extend(_EXPORT_TOOLS)
+
+    if include_visualize_chart:
+        tools.extend(_VISUALIZATION_TOOLS)
 
     return FunctionToolset(
         tools=tools,

--- a/src/seeknal/ask/agents/tools/upload_to_s3.py
+++ b/src/seeknal/ask/agents/tools/upload_to_s3.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import csv
 import io
+import logging
 import os
 import re
 import time
@@ -39,6 +40,8 @@ from datetime import datetime, timezone
 from typing import Any
 
 import httpx
+
+logger = logging.getLogger(__name__)
 
 # No storage URL/API key here: connectivity is resolved once at session init
 # (agent.py) and injected via ToolContext.iba_storage_presign_url/iba_storage_api_key
@@ -104,7 +107,11 @@ def upload_to_s3(
         On storage-unreachable / PUT-failure: an error string describing the
         failure (the agent should surface it, not retry silently).
     """
-    from seeknal.ask.agents.tools._context import get_tool_context, record_tool_result
+    from seeknal.ask.agents.tools._context import (
+        get_tool_context,
+        record_tool_result,
+        register_exported_dataset,
+    )
     from seeknal.ask.agents.tools.errors import (
         TERMINAL_DEPENDENCY_UNAVAILABLE,
         format_tool_error,
@@ -235,6 +242,18 @@ def upload_to_s3(
         "expires_at": expires_at,
         "object_name": urls.get("object_name", ""),
     }
+
+    # M9: publish the exported rows so visualize_chart can draw this exact
+    # dataset. Matters most for Mode 2, whose rows a tool computed in-process
+    # and no query can reproduce -- charting those from SQL would silently drop
+    # the computed part. Best-effort: a registry failure must never fail an
+    # upload that already succeeded.
+    try:
+        register_exported_dataset(filename, list(cols), rows, ctx=ctx)
+    except Exception:
+        logger.exception(
+            "[upload_to_s3] dataset registration failed; upload unaffected"
+        )
 
     record_tool_result(
         "upload_to_s3", urls.get("download_url", ""),

--- a/src/seeknal/ask/agents/tools/upload_to_s3.py
+++ b/src/seeknal/ask/agents/tools/upload_to_s3.py
@@ -10,7 +10,10 @@ Two modes:
   - **Mode 1 (SQL):** ``upload_to_s3(filename, sql="SELECT ...")`` — tool
     executes the SQL via ``ctx.repl.execute_oneshot`` and uses the column names
     from the cursor as the CSV header. Use this when the data lives in a
-    database (execute_sql results, ad-hoc queries).
+    database (execute_sql results, ad-hoc queries). Mode 1 exports ALL
+    returned rows — it deliberately passes ``limit=None`` so the exported file
+    carries every row the query produces (an export is an intentional full-data
+    dump, unlike execute_sql's 500-row chat-display cap).
   - **Mode 2 (data):** ``upload_to_s3(filename, data=[[...], ...],
     columns=["col1", "col2"])`` — tool builds the CSV directly from the
     provided rows and column names. Use this when the data is computed
@@ -33,7 +36,6 @@ from __future__ import annotations
 import csv
 import io
 import logging
-import os
 import re
 import time
 from datetime import datetime, timezone
@@ -46,16 +48,6 @@ logger = logging.getLogger(__name__)
 # No storage URL/API key here: connectivity is resolved once at session init
 # (agent.py) and injected via ToolContext.iba_storage_presign_url/iba_storage_api_key
 # -- this module never reads os.environ for storage config. See _context.py's ToolContext.
-
-# CSV exports are files, not chat-context tables — decoupled from both
-# execute_sql's 500-row chat-display cap and ctx.request_limit (the
-# pydantic-ai UsageLimits.request_limit model-request budget, NOT a row
-# count; using it as a row limit silently truncated "full data" exports to
-# ~100 rows). 5000 keeps exports well under typical SeaweedFS/browser CSV
-# handling while covering the export use case (raw dumps larger than the
-# chat table, smaller than a full warehouse scan).
-_CSV_EXPORT_ROW_LIMIT = int(os.environ.get("SEEKNAL_CSV_EXPORT_ROW_LIMIT", "5000"))
-
 
 def upload_to_s3(
     filename: str,
@@ -350,17 +342,20 @@ def _resolve_mode(
     if has_sql:
         # Mode 1: execute SQL via the existing DuckDB ATTACH seam.
         #
-        # Repair + row-limit + governance mirror execute_sql.py exactly so the
-        # CSV always matches what the agent saw on screen (audit fix D1-D3,
-        # 2026-07-09):
+        # Repair + governance mirror execute_sql.py exactly so the CSV always
+        # matches what the agent saw on screen (audit fix D1-D3, 2026-07-09).
+        # The ROW LIMIT is deliberately NOT mirrored: exports are intentional
+        # full-data dumps, so limit=None is passed to
+        # _execute_oneshot_with_timeout (repl.py only wraps "LIMIT N" when a
+        # non-None limit is given) — every returned row reaches the file.
         #   D1 — without _repair_common_sql_before_execution, EXTRACT(YEAR
         #        FROM ...) filters are NOT pushed down to PostgreSQL and are
         #        evaluated locally in DuckDB with different cast/NULL
         #        semantics, silently producing different row counts than the
         #        execute_sql call the agent already ran for the same SQL.
         #   D2 — ctx.request_limit is pydantic-ai's UsageLimits.request_limit
-        #        (a model-request budget, default 100), not a row count. Using
-        #        it here silently truncated "full data" exports.
+        #        (a model-request budget, default 100), NOT a row count; it is
+        #        never used as a row limit here. Exports carry no row cap.
         #   D3 — execute_sql masks sensitive columns via Atlas governance;
         #        skipping that here would let a masked column leave
         #        ungoverned through the exported file.
@@ -376,11 +371,11 @@ def _resolve_mode(
         # D1 follow-up (audit fix, 2026-07-09): execute_sql.py strips a
         # trailing semicolon BEFORE repair/execution; this branch didn't, so
         # agent SQL ending in ";" (LLMs add this routinely) survived into
-        # _execute_oneshot_with_timeout, which wraps the query as
-        # "SELECT * FROM (<sql>) AS _q LIMIT N" to apply the row cap -- the
-        # leftover ";" then lands mid-statement ("...;) AS _q LIMIT 5000"),
-        # a guaranteed DuckDB ParserException on every semicolon-terminated
-        # query. Strip it here too, matching execute_sql.py exactly.
+        # _execute_oneshot_with_timeout and the leftover ";" could land
+        # mid-statement if the query ever got wrapped ("SELECT * FROM
+        # (<sql>;) AS _q ..."), a guaranteed DuckDB ParserException on every
+        # semicolon-terminated query. Strip it here too, matching
+        # execute_sql.py exactly.
         sql = str(sql).strip().rstrip(";").strip()
         repaired_sql, _notices = _repair_common_sql_before_execution(sql)
 
@@ -400,9 +395,7 @@ def _resolve_mode(
         # suggestions, DuckDB syntax tips -- rather than a second,
         # upload_to_s3-specific self-correction path.
         try:
-            cols, rows = _execute_oneshot_with_timeout(
-                ctx, repaired_sql, limit=_CSV_EXPORT_ROW_LIMIT
-            )
+            cols, rows = _execute_oneshot_with_timeout(ctx, repaired_sql, limit=None)
         except Exception as exc:
             # One auto-retry using DuckDB's own "Did you mean" suggestion,
             # same as execute_sql.py -- most missing-table typos self-resolve
@@ -411,7 +404,7 @@ def _resolve_mode(
             if suggested_sql and suggested_sql != repaired_sql:
                 try:
                     cols, rows = _execute_oneshot_with_timeout(
-                        ctx, suggested_sql, limit=_CSV_EXPORT_ROW_LIMIT
+                        ctx, suggested_sql, limit=None
                     )
                     repaired_sql = suggested_sql
                 except Exception as retry_exc:

--- a/src/seeknal/ask/agents/tools/upload_to_s3.py
+++ b/src/seeknal/ask/agents/tools/upload_to_s3.py
@@ -198,16 +198,31 @@ def upload_to_s3(
             timeout=60.0,
         )
         put.raise_for_status()
-    except httpx.HTTPError:
+    # FC2i: split the two failure modes STEP 3 above already distinguishes.
+    # httpx.HTTPError is the base class of BOTH HTTPStatusError (the endpoint
+    # answered with a status) and RequestError (it was never reached), so
+    # catching it lost the one detail that identifies the fault — and named
+    # SeaweedFS, which is three hops away and often never contacted at all.
+    except httpx.RequestError as exc:
         record_tool_result(
             "upload_to_s3",
             format_tool_error(
                 TERMINAL_DEPENDENCY_UNAVAILABLE,
-                "CSV upload failed (SeaweedFS rejected the write).",
+                f"CSV upload failed: storage endpoint unreachable ({type(exc).__name__}).",
             ),
             args={"filename": filename, "mode": "sql" if used_sql_mode else "data"},
         )
-        return "CSV upload failed (SeaweedFS rejected the write)."
+        return f"CSV upload failed: storage endpoint unreachable ({type(exc).__name__})."
+    except httpx.HTTPStatusError as exc:
+        record_tool_result(
+            "upload_to_s3",
+            format_tool_error(
+                TERMINAL_DEPENDENCY_UNAVAILABLE,
+                f"CSV upload failed: storage rejected the write (HTTP {exc.response.status_code}).",
+            ),
+            args={"filename": filename, "mode": "sql" if used_sql_mode else "data"},
+        )
+        return f"CSV upload failed: storage rejected the write (HTTP {exc.response.status_code})."
 
     # ── STEP 5: register pending_upload — gateway loop emits upload_complete
     # expires_at is sourced VERBATIM from the server response

--- a/src/seeknal/ask/agents/tools/visualize_chart.py
+++ b/src/seeknal/ask/agents/tools/visualize_chart.py
@@ -1,0 +1,455 @@
+"""visualize_chart — render one chart for the current answer in the chat.
+
+Deterministic M9 tool, and the ONLY place a chart is ever built. No other tool
+attaches a chart of its own: ``run_forecast``, ``detect_anomaly``, and
+``execute_sql`` produce data, and the agent decides -- guided by the
+``chart-visualize`` skill and project context -- whether that data deserves a
+chart and which type fits it. Seeknal triggers, the frontend renders.
+
+Three sources, chosen by what the data is:
+  - **Mode 1 (SQL), the default:** ``visualize_chart(widget_type, widget_title,
+    sql="SELECT ...")`` -- rows come from the structured SQL cache
+    ``execute_sql`` already wrote under the same cache key, so the chart and the
+    answer text are built from one dataset. Only on a cache miss does the tool
+    run the SQL itself, through the same pipeline ``execute_sql`` uses.
+  - **Exported CSV, for values SQL cannot return:** ``visualize_chart(
+    widget_type, widget_title, columns=[x, y, series])`` with no ``sql=`` or
+    ``data=`` -- charts the rows this turn exported as CSV. Values a tool
+    computed in-process (a forecast projection) become chartable without anyone
+    re-typing them, and the chart matches the Download button exactly.
+  - **Mode 2 (data):** ``visualize_chart(widget_type, widget_title,
+    data=[[...], ...], columns=[...])`` -- last resort, for values neither
+    exported nor queryable. Transcribed numbers can drift from the answer, so
+    prefer either source above.
+
+Charting and exporting are independent: a failed CSV upload leaves the SQL path
+untouched, so it must never be reported as a chart failure.
+
+The renderer reads at most three columns and fixes each widget type's X
+encoding, so a wrong shape renders wrong rather than failing. The shape is
+therefore validated here, against ``_chart_payload.WIDGET_SPECS``, before any
+payload is built -- an invalid shape is refused with the fix named.
+
+Unlike ``run_forecast``/``detect_anomaly`` this tool makes no external call --
+the chart "engine" is the frontend's own Vega-Lite renderer, which builds its
+spec client-side from the emitted column order. Nothing here authors a spec.
+
+One question yields at most one chart. That is enforced structurally --
+``ctx.pending_visualization`` is a single slot, and a second call in the same
+turn is refused rather than silently overwriting the first. This matters
+because a tool like ``run_forecast`` may legitimately run several times in one
+question: the agent chooses which result is worth charting, instead of each run
+racing to attach a chart of its own.
+
+Domain-neutral (``AGENTS.md``): the data, the chart type, and the title are the
+agent's responsibility; the tool contains no domain-specific strings.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Minimum columns for an actual chart: X and Y. ``big_number`` is the one
+# exception -- it renders a single scalar and needs no second axis.
+_MIN_CHART_COLUMNS = 2
+_SCALAR_WIDGET_TYPE = "big_number"
+
+
+def visualize_chart(
+    widget_type: str,
+    widget_title: str,
+    sql: str = "",
+    data: list[list[Any]] | None = None,
+    columns: list[str] | None = None,
+    widget_size: int = 1,
+) -> str:
+    """Render one chart for the answer you are about to give.
+
+    You decide whether a chart helps and which type fits; the tool validates the
+    shape but never substitutes a type for you. The ``chart-visualize`` skill
+    covers which type suits which question and how to reshape data for it.
+
+    **Column order IS the axis contract, for every type: first column = X,
+    second = Y, optional third = the series that splits the chart by colour.**
+    A third column turns one line into several, each with its own colour and a
+    legend entry. Only three columns are ever read; extra ones are refused
+    rather than dropped.
+
+    Three sources; pick by what the data is, not by what ran first:
+
+    Mode 1 (SQL):  ``visualize_chart(widget_type, widget_title, sql="SELECT ...")``
+        The default whenever the numbers are queryable. Prefer SQL you already
+        ran with ``execute_sql`` this turn -- the result is reused from cache,
+        which saves a round-trip and guarantees the chart shows exactly the
+        numbers your answer quotes.
+
+    Exported CSV: ``visualize_chart(widget_type, widget_title, columns=[x, y, series])``
+        No ``sql=``, no ``data=``. Charts the rows this turn exported as CSV,
+        with ``columns=`` naming which of that file's columns to plot, in axis
+        order. Use it for values a query cannot return -- a forecast's
+        projection -- so the chart covers what the text describes.
+
+    Mode 2 (data): ``visualize_chart(widget_type, widget_title, data=[[...]], columns=[...])``
+        Last resort, for values neither exported nor queryable. Copy the
+        numbers from the tool output verbatim; a chart that disagrees with the
+        text is worse than no chart.
+
+    ``sql=`` and ``data=`` are mutually exclusive, and passing neither selects
+    the exported CSV. A failed CSV export never prevents charting from SQL --
+    the download and the chart are independent outcomes.
+
+    Args:
+        widget_type: One of ``big_number``, ``bar_chart``, ``line_chart``,
+            ``pie_chart``, ``horizontal_bar_chart``, ``grouped_bar_chart``,
+            ``grouped_line_chart``, ``grouped_pie_chart``, ``area_chart``,
+            ``scatter_plot``, ``heatmap``, ``box_plot``, ``treemap``.
+        widget_title: Short chart title. Also serves as the accessible label,
+            so make it describe the data, not the request.
+        sql: A SELECT with columns ordered ``[x, y]`` or ``[x, y, series]``
+            (Mode 1). For ``big_number`` a single column is enough.
+        data: Pre-computed rows as a list of lists (Mode 2). Each inner list is
+            one row and its length must match ``columns``.
+        columns: Column names in axis order. With ``data=`` these name the
+            supplied rows; with neither ``sql=`` nor ``data=`` they select
+            columns from the exported CSV. Ignored in Mode 1.
+        widget_size: Layout width hint for the frontend grid. Defaults to 1.
+
+    Returns:
+        A short confirmation naming the chart type, title, and row count, plus
+        any deterministic reduction that was applied (top-N bucketing,
+        downsampling, series trimming). Do NOT repeat the underlying table in
+        your answer -- the chart renders on its own, and duplicating the data
+        as markdown makes the reply noisy.
+        ``"No rows to chart."`` when there is nothing to plot.
+        On an unsupported ``widget_type``, an argument conflict, an unusable
+        shape, or a second chart in the same turn: a short refusal explaining
+        the fix, with no chart registered.
+        On Mode 1 SQL execution failure: the same structured JSON error
+        ``execute_sql`` returns, so the existing self-correction hook can
+        enrich it with retry hints.
+    """
+    from seeknal.ask.agents.tools._chart_payload import (
+        SUPPORTED_WIDGET_TYPES,
+        build_chart_payload,
+        chart_widget_id,
+        validate_chart_shape,
+    )
+    from seeknal.ask.agents.tools._context import (
+        get_tool_context,
+        record_tool_result,
+        repeated_failure_message,
+    )
+    from seeknal.ask.agents.tools.errors import RETRYABLE_SYNTAX, format_tool_error
+
+    ctx = get_tool_context()
+    signature_args = {"sql": sql, "widget_title": widget_title}
+
+    # ── STEP 0: one chart per question (single-slot mutex) ─────────────────
+    # Checked before anything else. A tool such as run_forecast may run several
+    # times in one question, so "the last call wins" would make the rendered
+    # chart depend on call order rather than on the agent's judgement.
+    if ctx.pending_visualization is not None:
+        result = (
+            "A chart is already prepared for this answer. One question renders "
+            "at most one chart, so this call was ignored. Present the existing "
+            "chart, or reconsider which result deserves the chart before "
+            "charting anything else."
+        )
+        record_tool_result("visualize_chart", result, args=signature_args)
+        return result
+
+    # ── STEP 0.5: validate the chart type against what the frontend renders ─
+    # An unknown type would reach the frontend and render nothing at all, so it
+    # is rejected here rather than emitted. The tool never picks a type on the
+    # agent's behalf: choosing one is a reading of the data, which belongs in
+    # the skill and project context, not in a lookup table here.
+    widget_type = str(widget_type).strip()
+    if widget_type not in SUPPORTED_WIDGET_TYPES:
+        result = format_tool_error(
+            RETRYABLE_SYNTAX,
+            f"Unsupported widget_type '{widget_type}'.",
+            hint="Supported types: " + ", ".join(SUPPORTED_WIDGET_TYPES) + ".",
+        )
+        record_tool_result("visualize_chart", result, args=signature_args)
+        return result
+
+    # ── REPEATED FAILURE CHECK — same pattern as execute_sql ───────────────
+    prior_failure = repeated_failure_message("visualize_chart", signature_args)
+    if prior_failure:
+        result = format_tool_error(
+            RETRYABLE_SYNTAX,
+            prior_failure,
+            hint=(
+                "Do not retry the same chart. Fix the query or the data, or "
+                "answer with a table instead of a chart."
+            ),
+        )
+        record_tool_result("visualize_chart", result, args=signature_args)
+        return result
+
+    # ── STEP 1: RESOLVE (columns, rows) from one of the two modes ──────────
+    resolved = _resolve_mode(sql=sql, data=data, columns=columns)
+    if isinstance(resolved, str):
+        record_tool_result("visualize_chart", resolved, args=signature_args)
+        return resolved
+    chart_columns, chart_rows, fingerprint = resolved
+
+    # ── STEP 2: VALIDATE SHAPE ─────────────────────────────────────────────
+    if not chart_rows:
+        result = "No rows to chart."
+        record_tool_result("visualize_chart", result, args=signature_args)
+        return result
+
+    minimum_columns = 1 if widget_type == _SCALAR_WIDGET_TYPE else _MIN_CHART_COLUMNS
+    if len(chart_columns) < minimum_columns:
+        result = format_tool_error(
+            RETRYABLE_SYNTAX,
+            f"'{widget_type}' needs at least {minimum_columns} column(s); "
+            f"got {len(chart_columns)}.",
+            hint=(
+                "Put the X dimension first and the Y metric second, then call "
+                "the tool again -- or pick a type that fits this shape."
+            ),
+        )
+        record_tool_result("visualize_chart", result, args=signature_args)
+        return result
+
+    # The renderer reads three columns and fixes each type's X encoding, so a
+    # wrong shape draws a wrong chart instead of failing. Refuse it here, where
+    # the agent can still act on the reason.
+    shape_problem = validate_chart_shape(widget_type, chart_columns, chart_rows)
+    if shape_problem:
+        result = format_tool_error(
+            RETRYABLE_SYNTAX,
+            shape_problem,
+            hint=(
+                "Fix the shape or the widget_type, then call the tool again. "
+                "Do not chart data the chosen type cannot show."
+            ),
+        )
+        record_tool_result("visualize_chart", result, args=signature_args)
+        return result
+
+    # ── STEP 3: BUILD PAYLOAD + REGISTER ───────────────────────────────────
+    payload, notices = build_chart_payload(
+        widget_type=widget_type,
+        widget_title=str(widget_title).strip(),
+        widget_id=chart_widget_id(ctx.session_id, fingerprint),
+        columns=chart_columns,
+        rows=chart_rows,
+        widget_size=_coerce_widget_size(widget_size),
+    )
+    ctx.pending_visualization = payload
+
+    result = _format_confirmation(payload, notices)
+    record_tool_result("visualize_chart", result, args=signature_args)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_exported_dataset(
+    columns: list[str] | None,
+) -> tuple[list[str], list[list[Any]], str] | str:
+    """Chart this turn's exported CSV, projecting the requested columns.
+
+    ``columns`` selects from the export by name and fixes the axis order, so
+    the caller can chart three of a wider file -- the combined history and
+    projection a forecast exports, for instance, whose eight columns carry the
+    two series the chart needs. Names are matched case-insensitively because
+    the agent reads them back from a tool result.
+
+    Omitting ``columns`` charts the export's own first columns, which is right
+    only when the file is already in axis order.
+
+    Returns ``(columns, rows, fingerprint)`` or a ``## Kesalahan`` string.
+    """
+    from seeknal.ask.agents.tools._chart_payload import MAX_CHART_COLUMNS
+    from seeknal.ask.agents.tools._context import get_tool_context
+
+    dataset = get_tool_context().exported_dataset
+    if not dataset or not dataset.get("rows"):
+        return (
+            "## Kesalahan\n\n"
+            "**visualize_chart has nothing to chart.**\n\n"
+            "No CSV has been exported in this turn, so there is no dataset to "
+            "draw. Export the answer's data first, or pass ``sql=`` (Mode 1) "
+            "or ``data=``+``columns=`` (Mode 2)."
+        )
+
+    source_columns = [str(name) for name in dataset.get("columns", [])]
+    source_rows = dataset.get("rows", [])
+    name = dataset.get("name", "")
+
+    wanted = [str(column).strip() for column in (columns or []) if str(column).strip()]
+    if not wanted:
+        selected = source_columns[:MAX_CHART_COLUMNS]
+        indexes = list(range(len(selected)))
+    else:
+        lookup = {column.lower(): index for index, column in enumerate(source_columns)}
+        indexes = []
+        for column in wanted:
+            index = lookup.get(column.lower())
+            if index is None:
+                return (
+                    "## Kesalahan\n\n"
+                    f"**Column '{column}' is not in the exported CSV.**\n\n"
+                    f"'{name}' has: {', '.join(source_columns)}. Name the "
+                    "columns to chart in axis order (X, Y, then the optional "
+                    "series), or pass ``sql=`` to chart a query instead."
+                )
+            indexes.append(index)
+        selected = [source_columns[index] for index in indexes]
+
+    rows = [[row[index] for index in indexes] for row in source_rows if len(row) > max(indexes, default=0)]
+    return selected, rows, f"export:{name}:{','.join(selected)}"
+
+
+def _resolve_mode(
+    *,
+    sql: str,
+    data: list[list[Any]] | None,
+    columns: list[str] | None,
+) -> tuple[list[str], list[list[Any]], str] | str:
+    """Dispatch to SQL mode or data mode based on which arguments were provided.
+
+    Returns ``(columns, rows, fingerprint)`` on success, where ``fingerprint``
+    is the stable string the deterministic widget id is derived from. Returns a
+    ``## Kesalahan`` markdown block string on argument mismatch or SQL failure,
+    which the caller returns as-is.
+
+    Validation rules mirror ``upload_to_s3._resolve_mode``:
+      - ``sql=`` and ``data=`` are mutually exclusive
+      - Mode 2 requires BOTH ``data=`` and ``columns=``
+      - Mode 2: every row length must equal ``len(columns)``, otherwise the
+        column-order axis contract would silently bind the wrong values
+      - an empty ``sql`` string counts as "not provided"
+      - neither ``sql=`` nor ``data=`` selects this turn's exported CSV
+    """
+    from seeknal.ask.agents.tools._chart_payload import CHART_MAX_ROWS
+    from seeknal.ask.agents.tools._context import (
+        get_structured_sql_cache,
+        get_tool_context,
+    )
+    from seeknal.ask.agents.tools.errors import classify_duckdb_error, format_tool_error
+    from seeknal.ask.agents.tools.execute_sql import (
+        _execute_oneshot_with_timeout,
+        _repair_common_sql_before_execution,
+        _sql_cache_key,
+    )
+
+    has_sql = bool(sql and sql.strip())
+    has_data = data is not None
+    has_columns = bool(columns)
+
+    if has_sql and has_data:
+        return (
+            "## Kesalahan\n\n"
+            "**visualize_chart argument conflict.**\n\n"
+            "Provide either ``sql=`` (Mode 1) OR ``data=``+``columns=`` "
+            "(Mode 2), not both. The two modes are mutually exclusive."
+        )
+
+    if has_data:
+        if not has_columns:
+            return (
+                "## Kesalahan\n\n"
+                "**visualize_chart is missing ``columns=``.**\n\n"
+                "Mode 2 needs column names in axis order alongside ``data=``, "
+                "because column order is what binds values to the X and Y axes."
+            )
+        rows = [list(row) for row in data or []]
+        jagged = [index for index, row in enumerate(rows) if len(row) != len(columns or [])]
+        if jagged:
+            return (
+                "## Kesalahan\n\n"
+                f"**visualize_chart row length mismatch** at row index {jagged[0]}.\n\n"
+                f"Every row must have exactly {len(columns or [])} values to match "
+                "``columns=``; otherwise values bind to the wrong axis."
+            )
+        # Fingerprint from the column names plus the row count: stable across
+        # repeated calls with the same computed series, without hashing the
+        # whole dataset.
+        return list(columns or []), rows, f"{','.join(columns or [])}:{len(rows)}"
+
+    if not has_sql:
+        return _resolve_exported_dataset(columns)
+
+    # Mode 1: normalise the SQL through the same pipeline execute_sql uses, so
+    # the cache key matches the one it stored and an already-answered query
+    # charts without re-running.
+    ctx = get_tool_context()
+    sql = str(sql).strip().rstrip(";").strip()
+    sql, _lint_notices = _repair_common_sql_before_execution(sql)
+
+    cache_key = _sql_cache_key(sql)
+    cached = get_structured_sql_cache(ctx).get(cache_key)
+    if cached is not None:
+        return list(cached.get("columns") or []), list(cached.get("rows") or []), sql
+
+    # Cache miss: the agent is charting a query it has not shown. Pull up to the
+    # chart's own row ceiling -- enough for top-N bucketing to be accurate,
+    # bounded by the same number the payload caps enforce.
+    try:
+        sql_columns, sql_rows = _execute_oneshot_with_timeout(
+            ctx, sql, limit=CHART_MAX_ROWS
+        )
+    except Exception as exc:
+        return format_tool_error(classify_duckdb_error(str(exc)), str(exc))
+
+    return list(sql_columns), [list(row) for row in sql_rows], sql
+
+
+def _coerce_widget_size(widget_size: Any) -> int:
+    """Return a usable layout size, falling back to 1 for unusable input.
+
+    The frontend grid only understands small positive integers, and a bad size
+    is never worth failing an otherwise-valid chart over.
+    """
+    try:
+        return max(1, int(widget_size))
+    except (TypeError, ValueError):
+        return 1
+
+
+def _format_confirmation(payload: list[dict[str, Any]], notices: list[str]) -> str:
+    """Build the tool result the agent reads after a chart is registered."""
+    chart = payload[0]["chart_json"]
+    widget_data = chart["widgetData"]
+    row_count = len(widget_data)
+    lines = [
+        f"Chart ready: {chart['widgetType']} \"{chart['widgetTitle']}\" "
+        f"({row_count} rows). It renders automatically with your answer -- "
+        f"do not repeat the underlying table in your reply."
+    ]
+
+    # Report the series so the agent can describe what the reader will see: a
+    # multi-series chart draws one colour per series and a legend naming them,
+    # and the answer text should match that rather than describe one line.
+    series_names = _series_names(widget_data)
+    if series_names:
+        lines.append(
+            f"Series drawn ({len(series_names)}), each its own colour with a "
+            f"legend: {', '.join(series_names)}."
+        )
+
+    if notices:
+        lines.append("Applied limits: " + "; ".join(notices) + ".")
+    return "\n".join(lines)
+
+
+def _series_names(widget_data: list[dict[str, Any]]) -> list[str]:
+    """Return the distinct values of the series column, in first-seen order."""
+    if not widget_data:
+        return []
+    keys = list(widget_data[0].keys())
+    if len(keys) < 3:
+        return []
+    series_key = keys[2]
+    seen: dict[str, None] = {}
+    for row in widget_data:
+        seen.setdefault(str(row.get(series_key)), None)
+    return list(seen)

--- a/src/seeknal/ask/builtin_skills/chart-visualize/SKILL.md
+++ b/src/seeknal/ask/builtin_skills/chart-visualize/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: chart-visualize
+description: "On-demand chat charts. DECIDE whether a chart helps, pick the type from the data shape, call visualize_chart once, present it alongside the text."
+tags: [visualization, chart, chat]
+version: "1.0.0"
+---
+
+# Chart Visualization
+
+One tool builds every chart: ``visualize_chart``. No other tool attaches a
+chart of its own, so deciding *whether* to chart and *which type* fits is your
+judgement, made once per answer, on the data you actually have in front of you.
+
+## Workflow: DECIDE → BUILD → PRESENT
+
+### DECIDE
+
+Ask two questions, in this order.
+
+**1. Does a chart add anything the text does not?**
+A chart earns its place when it reveals shape — a trend, a ranking, a share, a
+spread, an outlier. It adds nothing when the answer is one or two numbers the
+sentence already states, or when the user asked for a list they will read
+value by value.
+
+Chart when:
+- the user explicitly asks for a chart, grafik, plot, visual, or dashboard —
+  then always chart, unless the data genuinely cannot carry one (see refusals)
+- the answer is about movement over time, a comparison across categories, a
+  composition, a distribution, or a relationship between two metrics — and the
+  project has enabled automatic charts
+
+Do not chart when:
+- the project has not enabled automatic charts and the user did not ask
+- the answer is a single figure with nothing to compare it against
+- the result is a lookup or a record listing rather than an analysis
+
+**2. Which type fits the shape of the data?**
+
+Read the question for the intent, then the data for the shape. Both have to
+agree: "how has X moved" wants time on X even if the data would also fit a bar
+chart; "which category is biggest" wants a ranking even if the data has dates.
+
+| What the answer is about | Type |
+|---|---|
+| one headline figure | ``big_number`` |
+| a trend over time | ``line_chart`` (``area_chart`` when cumulative) |
+| several trends over time | ``grouped_line_chart`` |
+| comparing categories | ``bar_chart``, or ``horizontal_bar_chart`` when labels are long |
+| the same categories split by a second dimension | ``grouped_bar_chart`` |
+| share of a total, few slices | ``pie_chart`` |
+| two metrics correlated | ``scatter_plot`` |
+| a value across two dimensions at once | ``heatmap`` |
+| spread within categories | ``box_plot`` |
+| nested part-of-whole | ``treemap`` |
+
+Pick the type the data supports, not the type that looks impressive. If no
+type fits honestly, answer with a table — that is a valid outcome, not a
+failure.
+
+**Two shape rules the renderer enforces, worth knowing before you choose:**
+
+- **A chart reads exactly three columns**: X, Y, and an optional series. It has
+  no way to show a fourth. Passing more is refused.
+- **Each type fixes its X axis.** ``line_chart``/``area_chart``/
+  ``grouped_line_chart`` plot X as a *date*, so periods must be ISO
+  (``2024-01-01``, or ``2024-01`` for months) — a label like "Januari" or "Q1"
+  belongs on a ``bar_chart``, whose X takes any text. ``scatter_plot`` needs a
+  *number* on X. Everything else takes labels.
+
+**Lock: {type, title, source of rows}.**
+
+**3. Is the answer about more than one thing?**
+
+If it is — several codes, several statuses, several segments — the chart should
+show all of them, not just the total. One metric charted out of five throws
+away most of what the answer says.
+
+The third column is what makes that possible: it splits the chart into one
+series per distinct value, each drawn in its own colour with a legend naming
+it. A ``line_chart`` becomes several lines; a ``grouped_bar_chart`` becomes
+bars side by side per category.
+
+The data has to be in **long** form for that. Answers are usually written wide,
+one column per metric:
+
+| period | metric A | metric B | metric C | total |
+|---|---|---|---|---|
+
+That shape cannot be charted — only three columns are ever read, so everything
+past the third would vanish. Reshape so each metric becomes rows tagged in a
+single series column:
+
+```sql
+SELECT period, 'metric A' AS series, metric_a AS value FROM t
+UNION ALL
+SELECT period, 'metric B' AS series, metric_b AS value FROM t
+UNION ALL
+SELECT period, 'metric C' AS series, metric_c AS value FROM t
+ORDER BY 1, 2
+```
+
+Then chart ``[period, value, series]`` as ``grouped_line_chart`` over time, or
+``grouped_bar_chart`` across categories. Often the long form is the *natural*
+query anyway — a ``GROUP BY period, code`` — and the wide table is just how it
+was written up for reading.
+
+Keep the number of series small enough to tell apart; beyond roughly eight the
+tool keeps the largest and says so. Chart the total *or* the breakdown, not
+both in one chart — a total plotted beside its own parts dwarfs them.
+
+### BUILD
+
+Call ``visualize_chart`` **once**. Column order is the axis contract for every
+type: X first, Y second, an optional series dimension third.
+
+Three ways to supply the rows. Pick by what the data *is*, not by what ran
+first.
+
+**Default — SQL you already ran.** Whenever the chart's numbers can be queried,
+this is the source. Pass the same SQL you gave ``execute_sql`` this turn; the
+rows are reused from cache, so the chart shows exactly the numbers your text
+quotes.
+
+```
+visualize_chart(
+    widget_type="line_chart",
+    widget_title="Registrations per month",
+    sql="SELECT month, total FROM ... ORDER BY 1",
+)
+```
+
+**The exported CSV — for values a query cannot return.** Some numbers are
+computed in-process and no SQL brings them back: a forecast's projection, for
+instance. Charting the source SQL there would draw the history alone while your
+text talks about the projection. If those values were exported to CSV this
+turn, chart the CSV: pass no ``sql=`` and no ``data=``, and name the columns to
+plot in axis order.
+
+```
+visualize_chart(
+    widget_type="grouped_line_chart",
+    widget_title="History and projection",
+    columns=["period", "value", "kind"],
+)
+```
+
+Nothing is retyped, so the chart, the download and the text cannot disagree.
+
+**Mode 2 — values neither exported nor queryable.** Last resort. Copy the
+numbers from the producing tool's output verbatim; never re-derive or round
+them. Transcription is the one path where the chart can quietly drift from the
+text.
+
+> **An export failure never cancels the chart.** Exporting a CSV and drawing a
+> chart are separate outcomes with separate failure modes. If the export fails
+> — storage unreachable, upload rejected — say so about the *download*, then
+> chart from SQL as usual. Reporting "no chart" because a file could not be
+> written is wrong: the reader loses a picture the data fully supported.
+
+Use a third column to distinguish segments whenever a chart mixes measured and
+computed values — a projection drawn as if it were history misleads the reader.
+
+**One chart per answer.** A tool such as ``run_forecast`` may run several times
+in one question; that does not mean several charts. Choose the single result
+worth charting. A second call is refused, so the choice is yours to make
+deliberately rather than by call order.
+
+### PRESENT
+
+- write the answer as you normally would: the finding first, in words
+- do **not** paste the chart's underlying table as markdown — the chart already
+  shows it, and repeating it makes the reply noisy
+- a small table alongside the chart is fine when the exact figures matter; the
+  chart carries the shape, the table carries the precision
+- when the chart draws several series, the tool lists them back to you; describe
+  what the reader will actually see — name the series rather than writing as if
+  there were one line
+- mention any limit the tool reported (top-N bucketing, downsampling) if it
+  changes how the chart should be read
+
+## Refusals
+
+Decide these before calling the tool — the tool validates the type name but
+never swaps your type for a different one.
+
+- zero rows → no chart
+- a single row with nothing to compare → prefer text, or ``big_number``
+- many categories → still chart; the tool keeps the top ones and buckets the
+  rest into an explicit "Others" row rather than hiding them
+- many time points → still chart; the tool downsamples evenly, keeps the final
+  point, and strides each series separately so the lines stay comparable
+- the shape does not match any type honestly → answer with a table and say why
+
+If the tool refuses a shape, it names the mismatch and the fix — more columns
+than a chart reads, a series the chosen type cannot draw, or an X axis the type
+cannot parse. Act on the reason rather than retrying the same call: the refusal
+means the chart would have rendered *wrong*, not that it failed.
+
+## Notes
+
+- This skill is domain-neutral. Which questions deserve a chart in a given
+  project, and what the charts should be titled, come from project context —
+  never hardcode them here.
+- The tool is registered only in non-interactive environments when
+  ``agent.visualize_chart.enabled: true`` is set in ``seeknal_agent.yml``.
+  Automatic charting additionally requires ``agent.visualize_chart.auto_emit``;
+  without it, chart only when the user asks.
+- Charts render in the chat and persist with the conversation. Pinning a chart
+  to a dashboard is not part of this tool.
+- ``execute_python`` plotting stays for report and artifact output. It produces
+  image files that never reach the chat, so it is not an alternative to this
+  tool for answering a user.

--- a/src/seeknal/ask/config.py
+++ b/src/seeknal/ask/config.py
@@ -315,6 +315,9 @@ def get_background_threshold(config: dict[str, Any]) -> int:
 
 _DEFAULT_HARNESS_SECTION = "agent_harness"
 
+# read_project_file window. 200 fits source files; rule documents are read whole.
+_DEFAULT_READ_MAX_LINES = 200
+
 
 def get_agent_harness_settings(config: dict[str, Any]) -> dict[str, Any]:
     """Return optional low-level pydantic-deep harness settings.
@@ -522,6 +525,32 @@ def get_ask_toolset_mode(config: dict[str, Any]) -> str:
     if mode in _READ_ONLY_ANALYST_MODES:
         return "analysis"
     return "full"
+
+
+def get_read_max_lines(config: dict[str, Any]) -> int:
+    """Return how many lines ``read_project_file`` returns per call.
+
+    The default suits source files, where a 200-line window is usually the part
+    worth reading. Project rule documents are different: they are meant to be
+    read whole, and a document longer than the window is silently cut at it. The
+    tool does say how to continue, but a model that does not ask again simply
+    never sees the rest — so a project whose context files run long can raise
+    this instead of depending on that follow-up.
+
+    Example::
+
+        agent_harness:
+          read_max_lines: 500
+    """
+    section = _get_mapping(config, _DEFAULT_HARNESS_SECTION)
+    value = section.get("read_max_lines")
+    if value is None:
+        return _DEFAULT_READ_MAX_LINES
+    try:
+        lines = int(value)
+        return lines if lines > 0 else _DEFAULT_READ_MAX_LINES
+    except (TypeError, ValueError):
+        return _DEFAULT_READ_MAX_LINES
 
 
 def get_pg_passthrough_enabled(config: dict[str, Any]) -> bool:

--- a/src/seeknal/ask/config.py
+++ b/src/seeknal/ask/config.py
@@ -524,6 +524,28 @@ def get_ask_toolset_mode(config: dict[str, Any]) -> str:
     return "full"
 
 
+def get_pg_passthrough_enabled(config: dict[str, Any]) -> bool:
+    """Return whether PG-only SQL may be executed directly on PostgreSQL.
+
+    DuckDB's ``postgres_scanner`` never pushes aggregation past the
+    ``COPY (SELECT ... TO STDOUT)`` boundary, so ``COUNT(DISTINCT ...)`` over an
+    attached table transfers the raw column and computes locally. Routing
+    PG-only SQL straight to PostgreSQL lets the source do the aggregation and
+    returns only the result rows.
+
+    Default is ``False``: no project changes execution engine without an
+    explicit decision. Any failure on the routed path falls back to DuckDB, so
+    enabling this can slow a query down but can never change its answer.
+
+    Example::
+
+        sql_routing:
+          pg_passthrough: true
+    """
+    section = _get_mapping(config, "sql_routing")
+    return _coerce_bool(section.get("pg_passthrough"), False)
+
+
 _VALID_SQL_PAIR_MODES = {"authoritative", "advisory"}
 
 

--- a/src/seeknal/ask/config.py
+++ b/src/seeknal/ask/config.py
@@ -627,3 +627,44 @@ def get_upload_to_s3_enabled(config: dict[str, Any]) -> bool:
     agent_section = _get_mapping(config, "agent")
     export_section = _get_mapping(agent_section, "upload_to_s3")
     return _coerce_bool(export_section.get("enabled"), default=False)
+
+
+def get_visualize_chart_enabled(config: dict[str, Any]) -> bool:
+    """Return whether the chat chart tool ``visualize_chart`` is enabled.
+
+    Reads ``agent.visualize_chart.enabled`` from ``seeknal_agent.yml``. Defaults
+    to ``False`` -- charting is opt-in per project, and must stay off until the
+    consuming service understands the ``visualization`` event, otherwise the
+    chart is silently dropped in transit. Only takes effect in non-interactive
+    environments.
+
+    Example::
+
+        agent:
+          visualize_chart:
+            enabled: true
+    """
+    agent_section = _get_mapping(config, "agent")
+    chart_section = _get_mapping(agent_section, "visualize_chart")
+    return _coerce_bool(chart_section.get("enabled"), default=False)
+
+
+def get_visualize_chart_auto_emit(config: dict[str, Any]) -> bool:
+    """Return whether charts may be emitted without an explicit user request.
+
+    Reads ``agent.visualize_chart.auto_emit`` from ``seeknal_agent.yml``.
+    Defaults to ``False``: with charting enabled the agent still charts only
+    when asked, unless a project opts into the bounded automatic mode. The flag
+    is consumed by skill/context policy, not by the tool -- deciding a chart is
+    useful is a reading of the question, which belongs in the skill.
+
+    Example::
+
+        agent:
+          visualize_chart:
+            enabled: true
+            auto_emit: true
+    """
+    agent_section = _get_mapping(config, "agent")
+    chart_section = _get_mapping(agent_section, "visualize_chart")
+    return _coerce_bool(chart_section.get("auto_emit"), default=False)

--- a/src/seeknal/ask/gateway/server.py
+++ b/src/seeknal/ask/gateway/server.py
@@ -797,7 +797,18 @@ async def _run_agent_inner(
             # gathered (the structured cache or the exported CSV) and makes no
             # external call. One call is allowed, matching the one-chart-per-
             # question rule the pending_visualization slot already enforces.
-            chart_toolset = _chart_only_toolset(agent)
+            #
+            # But only when the main pass has NOT already produced a chart. A
+            # chart already in the slot means this stage must not invite a
+            # second one: on models that narrate tool calls as text, that
+            # invitation comes back as a raw {"action": ...} block leaked into
+            # the answer. The existing chart is still emitted by
+            # _drain_pending_side_channels below, so Case B loses nothing.
+            chart_toolset = (
+                _chart_only_toolset(agent)
+                if ctx.pending_visualization is None
+                else None
+            )
             # The prompt and the toolset must agree. Offering the tool while
             # the prompt still says "do not call any tools" makes the model
             # obey the prompt and describe a chart in prose instead.

--- a/src/seeknal/ask/gateway/server.py
+++ b/src/seeknal/ask/gateway/server.py
@@ -299,6 +299,47 @@ def _safe_auth_context_ws(websocket: WebSocket) -> tuple[AuthContext, str | None
 # ---------------------------------------------------------------------------
 
 
+
+_CHART_TOOL_NAME = "visualize_chart"
+
+
+def _chart_only_toolset(agent):
+    """Return a toolset holding just ``visualize_chart``, or ``None``.
+
+    Used by the evidence-synthesis stage, which otherwise runs with no tools at
+    all. The tool is lifted from the agent's own toolsets rather than imported,
+    so the project flag that decides whether charting exists at all keeps
+    deciding it here -- a project without the tool gets ``None`` and the
+    original no-tools behaviour, unchanged.
+    """
+    from pydantic_ai.toolsets import FunctionToolset
+
+    for toolset in getattr(agent, "toolsets", []) or []:
+        tools = getattr(toolset, "tools", None)
+        if isinstance(tools, dict) and _CHART_TOOL_NAME in tools:
+            return FunctionToolset(tools=[tools[_CHART_TOOL_NAME].function])
+    return None
+
+
+def _drain_pending_side_channels(ctx):
+    """Yield any pending upload/chart events, clearing each slot.
+
+    Called immediately before every ``answer`` yield. The per-node checks in the
+    run loop only fire when another node follows the tool that set them, and the
+    loop can exit through several paths, so a chart or an export produced by the
+    LAST tool call would otherwise be silently dropped. Draining next to the
+    answer covers every path that actually produces one.
+    """
+    if ctx.pending_upload:
+        _upload = ctx.pending_upload
+        ctx.pending_upload = None
+        yield {"type": "upload_complete", "data": _upload}
+    if ctx.pending_visualization:
+        _visualization = ctx.pending_visualization
+        ctx.pending_visualization = None
+        yield {"type": "visualization", "data": _visualization}
+
+
 async def _run_agent_streaming(
     project_path: Path,
     session_id: str,
@@ -559,6 +600,15 @@ async def _run_agent_inner(
                     yield {"type": "upload_complete", "data": _upload}
                     # deliberately NO return — continue the turn
 
+                # Chart emission (M9). Same lifecycle as pending_upload above:
+                # emit + clear + fall through, because the agent still has to
+                # present the answer the chart belongs to.
+                if ctx.pending_visualization:
+                    _visualization = ctx.pending_visualization
+                    ctx.pending_visualization = None
+                    yield {"type": "visualization", "data": _visualization}
+                    # deliberately NO return — continue the turn
+
                 if isinstance(node, UserPromptNode):
                     continue
 
@@ -660,6 +710,21 @@ async def _run_agent_inner(
                 elif isinstance(node, End):
                     break
 
+            # Drain the side channels one last time. The checks above run at
+            # the START of a node, so anything a tool set during the FINAL
+            # node — the common case, since exports and charts are the last
+            # thing an agent does before answering — would otherwise never be
+            # emitted: the loop ends before the next iteration can see it.
+            if ctx.pending_upload:
+                _upload = ctx.pending_upload
+                ctx.pending_upload = None
+                yield {"type": "upload_complete", "data": _upload}
+
+            if ctx.pending_visualization:
+                _visualization = ctx.pending_visualization
+                ctx.pending_visualization = None
+                yield {"type": "visualization", "data": _visualization}
+
             result = run.result
 
         # Final answer
@@ -695,6 +760,8 @@ async def _run_agent_inner(
 
         if answer:
             record_prior_turn_answer(question=question, answer=answer)
+            for _evt in _drain_pending_side_channels(ctx):
+                yield _evt
             yield {"type": "answer", "data": answer}
 
     except UsageLimitExceeded as exc:
@@ -716,23 +783,52 @@ async def _run_agent_inner(
             reason = (
                 "tool-call budget reached before the model produced a final answer"
             )
-        prompt = build_evidence_synthesis_prompt(reason)
         deterministic = synthesize_evidence_fallback(reason)
         try:
             ctx = get_tool_context()
-            result = await agent.run(
-                prompt,
-                deps=deps,
-                message_history=message_history,
-                usage_limits=UsageLimits(
-                    request_limit=ctx.request_limit,
-                    tool_calls_limit=0,
-                ),
+            # The synthesis stage bans tools so the turn cannot keep exploring
+            # after its budget ran out -- but that also banned charting, and
+            # the agent typically charts last. A question that spent its budget
+            # gathering evidence then reported "no chart available" was the
+            # visible symptom.
+            #
+            # visualize_chart is exempt because it cannot extend the
+            # exploration this stage exists to stop: it reads rows already
+            # gathered (the structured cache or the exported CSV) and makes no
+            # external call. One call is allowed, matching the one-chart-per-
+            # question rule the pending_visualization slot already enforces.
+            chart_toolset = _chart_only_toolset(agent)
+            # The prompt and the toolset must agree. Offering the tool while
+            # the prompt still says "do not call any tools" makes the model
+            # obey the prompt and describe a chart in prose instead.
+            prompt = build_evidence_synthesis_prompt(
+                reason, allow_chart=chart_toolset is not None
             )
+            limits = UsageLimits(
+                request_limit=ctx.request_limit,
+                tool_calls_limit=0 if chart_toolset is None else 1,
+            )
+            if chart_toolset is None:
+                result = await agent.run(
+                    prompt,
+                    deps=deps,
+                    message_history=message_history,
+                    usage_limits=limits,
+                )
+            else:
+                with agent.override(toolsets=[chart_toolset]):
+                    result = await agent.run(
+                        prompt,
+                        deps=deps,
+                        message_history=message_history,
+                        usage_limits=limits,
+                    )
             answer = result.output or deterministic
         except UsageLimitExceeded:
             answer = deterministic
         record_prior_turn_answer(question=question, answer=answer)
+        for _evt in _drain_pending_side_channels(get_tool_context()):
+            yield _evt
         yield {"type": "answer", "data": answer}
 
     except Exception as exc:
@@ -769,6 +865,8 @@ async def _run_agent_inner(
             "answering from the evidence gathered so far"
         )
         record_prior_turn_answer(question=question, answer=answer)
+        for _evt in _drain_pending_side_channels(get_tool_context()):
+            yield _evt
         yield {"type": "answer", "data": answer}
 
     finally:

--- a/src/seeknal/ask/sql_routing.py
+++ b/src/seeknal/ask/sql_routing.py
@@ -1,0 +1,223 @@
+"""Decide whether a SQL statement can run on a remote source instead of DuckDB.
+
+Seeknal executes agent SQL through DuckDB, which may hold local views (parquet,
+Iceberg) alongside ``ATTACH``-ed remote databases. DuckDB pushes down predicates
+but not aggregation, so an aggregate over an attached table transfers the raw
+columns and computes locally. When a statement touches exactly one remote source
+and nothing local, sending it to that source is dramatically cheaper.
+
+"Can we send it" is a structural question about the statement, so it is answered
+from a parsed AST rather than by matching text. Two properties matter and text
+matching gets both wrong:
+
+- **What the statement references.** A name may be a remote table, a local view,
+  or a CTE the statement defines for itself. Only the parser knows which.
+- **What the statement means in the target dialect.** Engines differ on details
+  such as NULL ordering — PostgreSQL sorts NULLs first under ``ORDER BY x DESC``
+  while DuckDB sorts them last. Transpiling makes those defaults explicit so the
+  remote engine returns what the local one would have.
+
+Both come from ``sqlglot``, which Seeknal already depends on.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Sequence
+
+import sqlglot
+from sqlglot import exp
+
+# Dialect of the SQL agents write. DuckDB is Seeknal's local execution engine,
+# so its semantics are what a routed statement must reproduce.
+LOCAL_DIALECT = "duckdb"
+
+
+@dataclass(frozen=True)
+class RoutingPlan:
+    """Outcome of analysing one statement.
+
+    ``namespace`` is None when the statement must stay on the local engine;
+    ``reason`` then says why, so callers can record it instead of guessing.
+    """
+
+    namespace: Optional[str]
+    sql: str
+    reason: str
+
+    @property
+    def is_routable(self) -> bool:
+        return self.namespace is not None
+
+
+def _declined(reason: str) -> RoutingPlan:
+    return RoutingPlan(namespace=None, sql="", reason=reason)
+
+
+def _self_defined_names(statement: exp.Expression) -> set[str]:
+    """Names the statement introduces itself, e.g. CTEs.
+
+    A reference to one of these is resolved by the engine running the statement,
+    not by a catalog, so it must not be mistaken for a local table.
+    """
+    return {cte.alias_or_name.lower() for cte in statement.find_all(exp.CTE)}
+
+
+def _has_unnamed_projection(statement: exp.Expression) -> bool:
+    """Whether any projection would be named by the engine rather than the query.
+
+    An engine is free to invent a name for a projection the statement does not
+    alias, and they disagree: ``SELECT COUNT(*)`` yields ``count_star()`` on
+    DuckDB and ``count`` on PostgreSQL. Worse, PostgreSQL names by function so
+    ``SELECT COUNT(*), COUNT(DISTINCT a)`` returns two columns both called
+    ``count``. Values match either way, but headers are read by whatever
+    consumes the result. Aliased projections and plain column references carry
+    their own name and are safe.
+    """
+    select = statement.find(exp.Select)
+    if select is None:
+        return False
+    return any(
+        not isinstance(projection, (exp.Alias, exp.Column, exp.Star))
+        for projection in select.expressions
+    )
+
+
+def probe_sql(sql: str, *, local_dialect: str = LOCAL_DIALECT) -> Optional[str]:
+    """Render ``sql`` so the local engine reports its result columns cheaply.
+
+    ``LIMIT 0`` makes the engine plan the statement and describe its output
+    without reading rows. The limit is set on the parsed statement rather than
+    appended as text, so a statement that already carries a ``LIMIT`` is
+    rewritten instead of producing ``LIMIT 5 LIMIT 0``.
+    """
+    try:
+        statement = sqlglot.parse_one(sql, dialect=local_dialect)
+    except Exception:  # noqa: BLE001
+        return None
+    if statement is None:
+        return None
+    return statement.limit(0).sql(dialect=local_dialect)
+
+
+def _apply_local_names(
+    statement: exp.Expression,
+    local_names: Sequence[str],
+    max_identifier_bytes: Optional[int],
+) -> bool:
+    """Alias unnamed projections with the names the local engine gives them.
+
+    Returns False when the names cannot be reproduced faithfully — a different
+    number of projections, or a name the target cannot hold. Callers treat that
+    as "do not route": a truncated header is the very difference this is meant
+    to remove.
+    """
+    select = statement.find(exp.Select)
+    if select is None or len(select.expressions) != len(local_names):
+        return False
+
+    for index, projection in enumerate(select.expressions):
+        if isinstance(projection, (exp.Alias, exp.Column, exp.Star)):
+            continue
+        name = local_names[index]
+        if max_identifier_bytes is not None and len(name.encode()) > max_identifier_bytes:
+            return False
+        select.expressions[index] = exp.alias_(
+            projection.copy(), exp.Identifier(this=name, quoted=True)
+        )
+    return True
+
+
+def _namespace_qualifier(table: exp.Table, candidates: set[str]) -> Optional[str]:
+    """Return the namespace this table reference is qualified with, if any.
+
+    A reference may name the namespace in either position depending on how many
+    parts it has: ``ns.schema.table`` puts it in the catalog slot, ``ns.table``
+    in the schema slot. The second form is only a namespace if it matches a
+    configured one — otherwise it is an ordinary schema and the reference says
+    nothing about which engine owns the table.
+    """
+    if table.catalog:
+        return table.catalog
+    if table.db and table.db in candidates:
+        return table.db
+    return None
+
+
+def _clear_namespace_qualifier(table: exp.Table, namespace: str) -> None:
+    """Drop the namespace from a reference; the remote engine has no such name."""
+    if table.catalog == namespace:
+        table.set("catalog", None)
+    elif table.db == namespace:
+        table.set("db", None)
+
+
+def analyze(
+    sql: str,
+    candidate_namespaces: Iterable[str],
+    *,
+    target_dialect: str,
+    local_dialect: str = LOCAL_DIALECT,
+    local_column_names: Optional[Sequence[str]] = None,
+    max_identifier_bytes: Optional[int] = None,
+) -> RoutingPlan:
+    """Return how (or whether) ``sql`` can be executed on a remote namespace.
+
+    Routable only when every table reference is qualified with the *same*
+    namespace and that namespace is one of ``candidate_namespaces``. Any
+    unqualified reference could be a local view, so it forces local execution.
+
+    The returned ``sql`` has the namespace qualifier removed — the remote engine
+    knows nothing about it — and is rendered in ``target_dialect`` so dialect
+    defaults survive the move.
+
+    Projections the query does not name are declined, because the engines would
+    name them differently. Pass ``local_column_names`` (see :func:`probe_sql`)
+    to alias them with the local engine's own names instead, and
+    ``max_identifier_bytes`` to decline rather than let the target truncate a
+    name it cannot hold.
+    """
+    candidates = {str(ns) for ns in candidate_namespaces}
+    if not candidates:
+        return _declined("no remote namespace configured")
+
+    try:
+        statement = sqlglot.parse_one(sql, dialect=local_dialect)
+    except Exception as exc:  # noqa: BLE001 — unparsable means "not our call"
+        return _declined(f"unparsable: {type(exc).__name__}")
+    if statement is None:
+        return _declined("empty statement")
+
+    local_names = _self_defined_names(statement)
+    namespaces: set[str] = set()
+    for table in statement.find_all(exp.Table):
+        qualifier = _namespace_qualifier(table, candidates)
+        if qualifier is not None:
+            namespaces.add(qualifier)
+        elif table.name.lower() not in local_names:
+            return _declined(f"unqualified table reference: {table.name}")
+
+    if not namespaces:
+        return _declined("no qualified table reference")
+    if len(namespaces) > 1:
+        return _declined("spans multiple namespaces")
+    (namespace,) = namespaces
+    if namespace not in candidates:
+        return _declined(f"namespace not routable: {namespace}")
+
+    rewritten = statement.copy()
+    if _has_unnamed_projection(rewritten):
+        if local_column_names is None:
+            return _declined("unaliased projection: local column names not supplied")
+        if not _apply_local_names(rewritten, local_column_names, max_identifier_bytes):
+            return _declined("unaliased projection: local names not reproducible")
+
+    for table in rewritten.find_all(exp.Table):
+        _clear_namespace_qualifier(table, namespace)
+
+    try:
+        target_sql = rewritten.sql(dialect=target_dialect)
+    except Exception as exc:  # noqa: BLE001 — cannot express it there
+        return _declined(f"not expressible in {target_dialect}: {type(exc).__name__}")
+
+    return RoutingPlan(namespace=namespace, sql=target_sql, reason="")

--- a/tests/ask/test_chart_shape_and_export.py
+++ b/tests/ask/test_chart_shape_and_export.py
@@ -1,0 +1,406 @@
+"""Tests for the M9 chart enhancements: shape contracts, series, exported CSV.
+
+Three behaviours, each guarding a failure the renderer would otherwise absorb
+silently and draw a wrong chart from:
+
+  - ``validate_chart_shape`` refuses shapes the renderer cannot draw faithfully
+  - a chart can be built from the CSV the turn exported, so table, download and
+    chart stay one dataset even when the values were computed, not queried
+  - the evidence-synthesis stage keeps ``visualize_chart`` available, so a turn
+    that spends its tool budget gathering evidence can still chart the result
+
+No network and no engine: everything here is local.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import duckdb
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.toolsets import FunctionToolset
+
+from seeknal.ask.agents.tools._chart_payload import (
+    CHART_MAX_POINTS,
+    MAX_CHART_COLUMNS,
+    build_chart_payload,
+    validate_chart_shape,
+)
+from seeknal.ask.agents.tools._context import (
+    ToolContext,
+    build_evidence_synthesis_prompt,
+    register_exported_dataset,
+    reset_turn_governor,
+    set_tool_context,
+)
+from seeknal.ask.agents.tools.visualize_chart import visualize_chart
+from seeknal.ask.gateway.server import _chart_only_toolset
+
+
+class _REPLStub:
+    def __init__(self) -> None:
+        self.conn = duckdb.connect(":memory:")
+
+    def execute_oneshot(self, sql: str, limit=None):
+        result = self.conn.execute(sql)
+        if not result.description:
+            return [], []
+        return [d[0] for d in result.description], result.fetchall()
+
+
+@pytest.fixture
+def ctx(tmp_path: Path) -> ToolContext:
+    ctx = ToolContext(
+        repl=_REPLStub(),
+        artifact_discovery=MagicMock(),
+        project_path=tmp_path,
+        sql_timeout_seconds=0,
+        request_limit=100,
+    )
+    set_tool_context(ctx)
+    return ctx
+
+
+def _chart(ctx: ToolContext) -> dict:
+    assert ctx.pending_visualization is not None
+    return ctx.pending_visualization[0]["chart_json"]
+
+
+# ---------------------------------------------------------------------------
+# Shape contracts — wide data
+
+
+def test_wide_data_is_refused_and_the_reshape_is_named() -> None:
+    columns = ["bulan", "kode_a", "kode_b", "kode_c", "total"]
+    rows = [["2024-01-01", 1, 2, 3, 6]]
+
+    problem = validate_chart_shape("grouped_line_chart", columns, rows)
+
+    assert problem is not None
+    # The dropped columns are named, so the agent can see what it would lose.
+    assert "kode_c" in problem and "total" in problem
+    assert "long" in problem.lower()
+
+
+def test_wide_data_is_refused_by_the_tool_without_registering_a_chart(
+    ctx: ToolContext,
+) -> None:
+    rows = [["2024-01-01", 1, 2, 3, 6], ["2024-02-01", 2, 3, 4, 9]]
+
+    result = visualize_chart(
+        "grouped_line_chart",
+        "Four codes",
+        data=rows,
+        columns=["bulan", "a", "b", "c", "total"],
+    )
+
+    assert ctx.pending_visualization is None
+    assert "at most" in result and str(MAX_CHART_COLUMNS) in result
+
+
+def test_three_columns_are_accepted_for_a_series_capable_type() -> None:
+    assert (
+        validate_chart_shape(
+            "grouped_line_chart",
+            ["bulan", "jumlah", "kode"],
+            [["2024-01-01", 5, "A"]],
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shape contracts — series a type cannot draw
+
+
+def test_bar_chart_refuses_a_series_column_and_suggests_grouped() -> None:
+    problem = validate_chart_shape(
+        "bar_chart", ["kategori", "jumlah", "kode"], [["A", 5, "x"]]
+    )
+
+    assert problem is not None
+    assert "grouped_bar_chart" in problem
+
+
+def test_pie_chart_refuses_a_series_column() -> None:
+    problem = validate_chart_shape(
+        "pie_chart", ["kategori", "jumlah", "kode"], [["A", 5, "x"]]
+    )
+
+    assert problem is not None
+
+
+def test_grouped_bar_chart_accepts_a_series_column() -> None:
+    assert (
+        validate_chart_shape(
+            "grouped_bar_chart", ["kategori", "jumlah", "kode"], [["A", 5, "x"]]
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shape contracts — X axis encoding
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["Januari", "Jan 2024", "2024-0319", "bulan-1", ""],
+)
+def test_line_chart_refuses_an_x_axis_that_is_not_a_date(value: str) -> None:
+    problem = validate_chart_shape("line_chart", ["bulan", "jumlah"], [[value, 5]])
+
+    assert problem is not None
+    assert "bar_chart" in problem
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["2024", "2024-01", "2024-01-01", "2024-01-01T00:00:00", "2024-01-01T00:00:00Z"],
+)
+def test_line_chart_accepts_iso_periods(value: str) -> None:
+    assert validate_chart_shape("line_chart", ["bulan", "jumlah"], [[value, 5]]) is None
+
+
+def test_line_chart_accepts_real_date_objects() -> None:
+    assert (
+        validate_chart_shape("line_chart", ["bulan", "jumlah"], [[date(2024, 1, 1), 5]])
+        is None
+    )
+
+
+def test_bar_chart_accepts_any_label_on_x() -> None:
+    assert validate_chart_shape("bar_chart", ["bulan", "jumlah"], [["Januari", 5]]) is None
+
+
+def test_scatter_plot_refuses_a_non_numeric_x() -> None:
+    problem = validate_chart_shape("scatter_plot", ["a", "b"], [["Januari", 5]])
+
+    assert problem is not None
+    assert "number" in problem
+
+
+# ---------------------------------------------------------------------------
+# Multi-series payload + caps
+
+
+def test_series_column_becomes_the_third_widget_data_key(ctx: ToolContext) -> None:
+    rows = [
+        ["2024-01-01", 10, "301"],
+        ["2024-01-01", 4, "302"],
+        ["2024-02-01", 12, "301"],
+        ["2024-02-01", 6, "302"],
+    ]
+
+    visualize_chart(
+        "grouped_line_chart", "Per code", data=rows, columns=["bulan", "jumlah", "kode"]
+    )
+
+    widget_data = _chart(ctx)["widgetData"]
+    assert list(widget_data[0].keys()) == ["bulan", "jumlah", "kode"]
+    assert {row["kode"] for row in widget_data} == {"301", "302"}
+
+
+def test_confirmation_reports_each_series_so_the_answer_can_match(
+    ctx: ToolContext,
+) -> None:
+    rows = [
+        ["2024-01-01", 10, "301"],
+        ["2024-01-01", 4, "302"],
+        ["2024-01-01", 7, "303"],
+    ]
+
+    result = visualize_chart(
+        "grouped_bar_chart", "Per code", data=rows, columns=["b", "j", "kode"]
+    )
+
+    assert "Series drawn (3)" in result
+    assert "legend" in result
+    for code in ("301", "302", "303"):
+        assert code in result
+
+
+def test_downsampling_keeps_every_series_intact() -> None:
+    # Two series long enough to trip the point cap. A single global stride
+    # would keep different periods per series and draw lines through points
+    # the data never had.
+    start = date(2024, 1, 1)
+    rows: list[list[object]] = []
+    for i in range(CHART_MAX_POINTS + 60):
+        period = (start + timedelta(days=i)).isoformat()
+        rows.append([period, i, "A"])
+        rows.append([period, i * 2, "B"])
+
+    payload, notices = build_chart_payload(
+        widget_type="grouped_line_chart",
+        widget_title="Two long series",
+        widget_id="w-1",
+        columns=["period", "value", "series"],
+        rows=rows,
+    )
+
+    widget_data = payload[0]["chart_json"]["widgetData"]
+    per_series: dict[str, list[str]] = {}
+    for row in widget_data:
+        per_series.setdefault(row["series"], []).append(row["period"])
+
+    assert set(per_series) == {"A", "B"}
+    # Both series survive, both respect the cap, and both cover the same
+    # periods -- the property a global stride would break.
+    for periods in per_series.values():
+        assert len(periods) <= CHART_MAX_POINTS
+    assert per_series["A"] == per_series["B"]
+    assert any("downsampled" in notice for notice in notices)
+
+
+# ---------------------------------------------------------------------------
+# Charting the exported CSV
+
+
+def _register_forecast_like_export(ctx: ToolContext) -> None:
+    """Register an export shaped like run_forecast's combined CSV."""
+    register_exported_dataset(
+        "forecast-combined.csv",
+        ["period", "kind", "value", "point", "lower_80", "upper_80"],
+        [
+            ["2024-01-01", "historis", 100, "", "", ""],
+            ["2024-02-01", "historis", 110, "", "", ""],
+            ["2024-03-01", "proyeksi-3bulan", "", 120, 110, 130],
+            ["2024-04-01", "proyeksi-3bulan", "", 130, 118, 142],
+        ],
+        ctx=ctx,
+    )
+
+
+def test_chart_is_built_from_the_exported_csv(ctx: ToolContext) -> None:
+    _register_forecast_like_export(ctx)
+
+    result = visualize_chart(
+        "grouped_line_chart",
+        "History and projection",
+        columns=["period", "value", "kind"],
+    )
+
+    widget_data = _chart(ctx)["widgetData"]
+    assert list(widget_data[0].keys()) == ["period", "value", "kind"]
+    # Both the historical and the projected segment are present -- the whole
+    # point: a projection is computed in-process and no SQL can return it.
+    assert {row["kind"] for row in widget_data} == {"historis", "proyeksi-3bulan"}
+    assert "Series drawn (2)" in result
+
+
+def test_exported_csv_columns_are_selected_case_insensitively(ctx: ToolContext) -> None:
+    _register_forecast_like_export(ctx)
+
+    visualize_chart(
+        "grouped_line_chart", "Any case", columns=["PERIOD", "Value", "KIND"]
+    )
+
+    # Selection tolerates the agent's casing, but the chart keeps the CSV's own
+    # column names so its labels match the file the user downloads.
+    assert list(_chart(ctx)["widgetData"][0].keys()) == ["period", "value", "kind"]
+
+
+def test_unknown_column_names_the_available_ones(ctx: ToolContext) -> None:
+    _register_forecast_like_export(ctx)
+
+    result = visualize_chart(
+        "grouped_line_chart", "Wrong column", columns=["period", "jumlah", "kind"]
+    )
+
+    assert ctx.pending_visualization is None
+    assert "jumlah" in result
+    assert "lower_80" in result  # the real columns are listed
+
+
+def test_charting_without_an_export_says_so(ctx: ToolContext) -> None:
+    result = visualize_chart("bar_chart", "Nothing exported", columns=["a", "b"])
+
+    assert ctx.pending_visualization is None
+    assert "No CSV has been exported" in result
+
+
+def test_reset_turn_governor_clears_the_exported_dataset(ctx: ToolContext) -> None:
+    _register_forecast_like_export(ctx)
+    assert ctx.exported_dataset is not None
+
+    reset_turn_governor()
+
+    # Anti-leak: turn N's CSV must not become turn N+1's chart.
+    assert ctx.exported_dataset is None
+
+
+def test_registering_twice_keeps_the_last_export(ctx: ToolContext) -> None:
+    register_exported_dataset("first.csv", ["a", "b"], [[1, 2]], ctx=ctx)
+    register_exported_dataset("second.csv", ["c", "d"], [[3, 4]], ctx=ctx)
+
+    # Last-wins, matching pending_upload: the chart follows the CSV the user
+    # actually gets a Download button for.
+    assert ctx.exported_dataset is not None
+    assert ctx.exported_dataset["name"] == "second.csv"
+
+
+# ---------------------------------------------------------------------------
+# Synthesis stage keeps charting available
+
+
+def _stub_visualize_chart(widget_type: str, widget_title: str) -> str:
+    """A stand-in tool; only its name matters to the lookup."""
+    return ""
+
+
+def test_synthesis_toolset_exposes_only_the_chart_tool() -> None:
+    def execute_sql(sql: str) -> str:
+        """Run SQL."""
+        return ""
+
+    def visualize_chart(widget_type: str) -> str:  # noqa: F811 - local stand-in
+        """Chart it."""
+        return ""
+
+    agent = Agent("test", toolsets=[FunctionToolset(tools=[execute_sql, visualize_chart])])
+
+    toolset = _chart_only_toolset(agent)
+
+    assert toolset is not None
+    # The stage exists to stop further exploration, so everything that could
+    # explore must stay out.
+    assert list(toolset.tools) == ["visualize_chart"]
+
+
+def test_synthesis_toolset_is_none_when_charting_is_not_enabled() -> None:
+    def execute_sql(sql: str) -> str:
+        """Run SQL."""
+        return ""
+
+    agent = Agent("test", toolsets=[FunctionToolset(tools=[execute_sql])])
+
+    # A project without the chart tool keeps the original no-tools behaviour.
+    assert _chart_only_toolset(agent) is None
+
+
+def test_synthesis_prompt_permits_charting_when_the_tool_is_offered(
+    ctx: ToolContext,
+) -> None:
+    ctx.current_question = "tren per bulan"
+    ctx.evidence_snippets_this_turn.append("| bulan | jumlah |\n| 2024-01 | 10 |")
+
+    permitted = build_evidence_synthesis_prompt("budget reached", allow_chart=True)
+
+    # Offering the tool while the prompt still bans tools makes the model obey
+    # the prompt and write "a chart could not be shown" -- the exact failure
+    # this stage produced. Prompt and toolset have to agree.
+    assert "Do not call any tools" not in permitted
+    assert "visualize_chart" in permitted
+
+
+def test_synthesis_prompt_still_bans_tools_by_default(ctx: ToolContext) -> None:
+    ctx.current_question = "tren per bulan"
+    ctx.evidence_snippets_this_turn.append("| bulan | jumlah |\n| 2024-01 | 10 |")
+
+    # Callers that cannot offer the tool (the interactive one-shot path) keep
+    # the original no-tools contract.
+    assert "Do not call any tools" in build_evidence_synthesis_prompt("budget reached")

--- a/tests/ask/test_chart_shape_and_export.py
+++ b/tests/ask/test_chart_shape_and_export.py
@@ -404,3 +404,242 @@ def test_synthesis_prompt_still_bans_tools_by_default(ctx: ToolContext) -> None:
     # Callers that cannot offer the tool (the interactive one-shot path) keep
     # the original no-tools contract.
     assert "Do not call any tools" in build_evidence_synthesis_prompt("budget reached")
+
+
+def _synthesis_gate(agent, ctx: ToolContext):
+    """Mirror the gateway's chart-offer gate (server.py UsageLimitExceeded path).
+
+    The real decision lives in ``_run_agent_inner``; replicate the exact
+    expression here so this test guards the branch that leaked a second,
+    text-narrated chart into the answer when the main pass had already charted.
+    """
+    return _chart_only_toolset(agent) if ctx.pending_visualization is None else None
+
+
+def _chart_agent() -> Agent:
+    def execute_sql(sql: str) -> str:
+        """Run SQL."""
+        return ""
+
+    def visualize_chart(widget_type: str) -> str:  # local stand-in
+        """Chart it."""
+        return ""
+
+    return Agent("test", toolsets=[FunctionToolset(tools=[execute_sql, visualize_chart])])
+
+
+def test_synthesis_offers_chart_when_none_was_produced_yet(ctx: ToolContext) -> None:
+    ctx.current_question = "tren per bulan"
+    ctx.evidence_snippets_this_turn.append("| bulan | jumlah |\n| 2024-01 | 10 |")
+    assert ctx.pending_visualization is None  # Case A: nothing charted yet
+
+    chart_toolset = _synthesis_gate(_chart_agent(), ctx)
+
+    # Case A keeps the rescue: the tool is offered and the prompt agrees.
+    assert chart_toolset is not None
+    prompt = build_evidence_synthesis_prompt(
+        "budget reached", allow_chart=chart_toolset is not None
+    )
+    assert "Do not call any tools" not in prompt
+    assert "visualize_chart" in prompt
+
+
+def test_synthesis_does_not_reoffer_chart_when_one_already_exists(
+    ctx: ToolContext,
+) -> None:
+    ctx.current_question = "tren per bulan"
+    ctx.evidence_snippets_this_turn.append("| bulan | jumlah |\n| 2024-01 | 10 |")
+    # Case B: the main pass already produced a chart this turn.
+    ctx.pending_visualization = [
+        {"chart_json": {"widgetType": "line_chart", "widgetData": []}, "chart_type": "line_chart"}
+    ]
+
+    chart_toolset = _synthesis_gate(_chart_agent(), ctx)
+
+    # No second chart is invited, so the prompt bans tools and no ReAct
+    # {"action": ...} block can be narrated into the answer. The existing
+    # chart is still emitted by _drain_pending_side_channels in the gateway.
+    assert chart_toolset is None
+    prompt = build_evidence_synthesis_prompt(
+        "terminal tool error after sufficient evidence",
+        allow_chart=chart_toolset is not None,
+    )
+    assert "Do not call any tools" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Full-fidelity integration: drive the REAL _run_agent_inner synthesis branch.
+#
+# Unlike the gate-replica tests above, this patches create_agent (the same
+# hook test_gateway_parity.py uses) and runs the actual gateway generator, so
+# the assertions cover the exact lines changed in server.py, not a copy.
+
+
+class _FakeRun:
+    """Minimal async-iterable stand-in for pydantic-ai's agent.iter() handle."""
+
+    def __init__(self, ctx, chart_payload) -> None:
+        self._ctx = ctx
+        self._chart_payload = chart_payload
+        self.result = MagicMock()
+        self.result.output = ""
+        self.result.all_messages = list
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def __aiter__(self):
+        return self._gen()
+
+    async def _gen(self):
+        # Main pass: the chart tool ran (slot filled), then a later tool failed
+        # terminally -- exactly the captured-session sequence. Raise the stop the
+        # gateway maps to the evidence-synthesis branch.
+        from pydantic_ai.exceptions import UsageLimitExceeded
+
+        self._ctx.pending_visualization = self._chart_payload
+        raise UsageLimitExceeded("terminal tool error after sufficient evidence")
+        yield  # pragma: no cover - makes this an async generator
+
+
+def _named_visualize_chart(widget_type: str) -> str:
+    """Tool literally named ``visualize_chart`` so _chart_only_toolset finds it."""
+    return ""
+
+
+# FunctionToolset keys tools by function name; use the canonical name.
+_named_visualize_chart.__name__ = "visualize_chart"
+
+
+class _FakeAgent:
+    """Fake agent that mimics a model narrating a ReAct block WHEN offered the
+    chart tool -- the exact failure the captured session showed. If the gateway
+    (correctly) does not offer the tool, no scaffold can appear."""
+
+    def __init__(self, ctx, chart_payload) -> None:
+        self._ctx = ctx
+        self._chart_payload = chart_payload
+        self.toolsets = [FunctionToolset(tools=[_named_visualize_chart])]
+        self.override_called_with = None
+        self.run_calls = 0
+        self._chart_offered = False
+
+    def iter(self, *args, **kwargs):
+        return _FakeRun(self._ctx, self._chart_payload)
+
+    def override(self, *, toolsets=None, **kwargs):
+        # The gateway enters this override only when it re-offers the chart.
+        self.override_called_with = toolsets
+        self._chart_offered = True
+
+        class _Noop:
+            def __enter__(self_inner):
+                return self_inner
+
+            def __exit__(self_inner, *exc):
+                return False
+
+        return _Noop()
+
+    async def run(self, prompt, **kwargs):
+        self.run_calls += 1
+        result = MagicMock()
+        if self._chart_offered:
+            # A preview model narrates the tool call as text instead of a real
+            # function call -- this is the leak the fix prevents.
+            result.output = (
+                "Berikut tren pendaftaran NIE.\n\n"
+                '```json\n{"action": "visualize_chart", '
+                '"action_input": "{\'widget_type\': \'grouped_line_chart\'}"}\n```'
+            )
+        else:
+            result.output = "Registrations grew each year; Campuran leads."
+        result.all_messages = list
+        return result
+
+
+@pytest.mark.asyncio
+async def test_run_agent_inner_does_not_reoffer_chart_after_one_was_built(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Case B through the real gateway: a chart already built + a terminal tool
+    error routes into synthesis, and synthesis must NOT re-offer the chart tool
+    (which is what leaked a {"action": ...} block into the answer)."""
+    from seeknal.ask.agents.tools._context import ToolContext, set_tool_context
+    from seeknal.ask.gateway import server as gw
+
+    chart_payload = [
+        {
+            "chart_json": {
+                "widgetId": "sess-x-1",
+                "widgetType": "grouped_line_chart",
+                "widgetTitle": "Tren Penerbitan NIE per Jenis Produk",
+                "widgetData": [{"periode": "2025-01-01", "jumlah": 1024, "jenis": "Campuran"}],
+                "widgetSize": 1,
+            },
+            "chart_type": "grouped_line_chart",
+        }
+    ]
+
+    captured: dict = {}
+
+    def fake_create_agent(*args, **kwargs):
+        ctx = ToolContext(
+            repl=MagicMock(),
+            artifact_discovery=MagicMock(),
+            project_path=tmp_path,
+            disable_quality_gate=True,
+        )
+        # Evidence + terminal error so _gateway_tool_stop_reason would fire and
+        # build_evidence_synthesis_prompt has snippets to work with.
+        ctx.current_question = "tren penerbitan NIE per jenis produk ERBA"
+        ctx.successful_sql_results_this_turn = 1
+        ctx.evidence_snippets_this_turn.append(
+            "[execute_sql]\n| periode | jumlah |\n| 2025-01 | 1024 |\n(1 row)"
+        )
+        ctx.terminal_tool_errors_this_turn.append(
+            "upload_to_s3: terminal_dependency_unavailable — SeaweedFS rejected the write"
+        )
+        set_tool_context(ctx)
+        captured["ctx"] = ctx
+        agent = _FakeAgent(ctx, chart_payload)
+        captured["agent"] = agent
+        return agent, MagicMock(), [], {}
+
+    monkeypatch.setattr(
+        "seeknal.ask.agents.agent.create_agent", fake_create_agent
+    )
+
+    events = [
+        ev
+        async for ev in gw._run_agent_inner(
+            tmp_path, "sess-caseB", "tren penerbitan NIE per jenis produk ERBA"
+        )
+    ]
+
+    agent = captured["agent"]
+    types = [ev["type"] for ev in events]
+
+    # 1. The chart built in the main pass is still delivered (drain path).
+    assert "visualization" in types
+    viz = next(ev for ev in events if ev["type"] == "visualization")
+    assert viz["data"][0]["chart_json"]["widgetTitle"].startswith("Tren Penerbitan")
+
+    # 2. An answer is produced.
+    answer_ev = next(ev for ev in events if ev["type"] == "answer")
+    answer = answer_ev["data"]
+
+    # 3. THE FIX: synthesis was NOT offered the chart tool (slot was full), so
+    #    the model could not be invited to narrate a second chart.
+    assert agent.override_called_with is None, (
+        "synthesis re-offered the chart tool despite an existing chart"
+    )
+
+    # 4. No ReAct tool-call scaffold leaked into the visible answer.
+    assert '"action"' not in answer
+    assert "action_input" not in answer
+    assert "visualize_chart" not in answer

--- a/tests/ask/test_forecast_tool.py
+++ b/tests/ask/test_forecast_tool.py
@@ -318,3 +318,86 @@ def test_forecast_accepts_dynamic_schemas(ctx):
         assert "## Proyeksi" in out, f"schema {label} did not produce r5 table output"
     # Engine called once per successful run — proves all three shapes reached it.
     assert post.call_count == 3
+
+
+# ── s234: combined CSV schema — `value` carries numbers for every row ──
+
+
+def test_combined_csv_projection_rows_value_equals_point():
+    """Projection rows: `value` is the point estimate, not an empty string.
+
+    This was the root cause of s234 — the tool wrote Y to two mutually exclusive
+    columns.  After the fix, ``value`` is continuous across both ``historis``
+    and ``proyeksi-*`` rows, so ``[period, value, kind]`` is chartable as
+    ``[x, y, series]``.
+    """
+    from seeknal.ask.agents.tools.forecast import _upload_combined_forecast_csv
+
+    history = [["2024-01-01", 10], ["2024-02-01", 15], ["2024-03-01", 12]]
+    result = {
+        "forecast": {
+            "points": [
+                {"period": "2024-04-01", "point": 18, "lower_80": 14, "upper_80": 22, "lower_95": 12, "upper_95": 24},
+                {"period": "2024-05-01", "point": 20, "lower_80": 16, "upper_80": 24, "lower_95": 14, "upper_95": 26},
+            ]
+        }
+    }
+
+    with patch("seeknal.ask.agents.tools.upload_to_s3.upload_to_s3") as mock_upload:
+        _upload_combined_forecast_csv("SELECT 1", history, result, periods=2, freq="MS")
+
+    assert mock_upload.called
+    kwargs = mock_upload.call_args.kwargs
+    called_data = kwargs["data"]
+    called_columns = kwargs["columns"]
+
+    # Eight columns, names unchanged.
+    assert called_columns == ["period", "kind", "value", "point", "lower_80", "upper_80", "lower_95", "upper_95"]
+
+    # History rows: value filled, point empty (unchanged behaviour).
+    assert called_data[0][2] == 10   # value
+    assert called_data[0][3] == ""   # point
+    assert called_data[1][2] == 15
+    assert called_data[1][3] == ""
+
+    # Projection rows: value == point (this is the fix).
+    assert called_data[3][2] == 18   # value (was "")
+    assert called_data[3][3] == 18   # point
+    assert called_data[3][2] != ""   # no longer empty
+    assert called_data[4][2] == 20
+    assert called_data[4][3] == 20
+
+
+def test_combined_csv_column_count_stays_8():
+    """Column count is 8 — the fix only fills value, it doesn't alter layout."""
+    from seeknal.ask.agents.tools.forecast import _upload_combined_forecast_csv
+
+    history = [["2024-01-01", 5]]
+    result = {
+        "forecast": {
+            "points": [{"period": "2024-02-01", "point": 7, "lower_80": 5, "upper_80": 9, "lower_95": 3, "upper_95": 11}]
+        }
+    }
+
+    with patch("seeknal.ask.agents.tools.upload_to_s3.upload_to_s3") as mock_upload:
+        _upload_combined_forecast_csv("SELECT 1", history, result, periods=1, freq="MS")
+
+    kwargs = mock_upload.call_args.kwargs
+    assert len(kwargs["columns"]) == 8
+
+
+def test_combined_csv_history_rows_unchanged():
+    """History rows still have value filled and projection columns blank."""
+    from seeknal.ask.agents.tools.forecast import _upload_combined_forecast_csv
+
+    history = [["2024-01-01", 5], ["2024-02-01", 10]]
+    result: dict[str, Any] = {"forecast": {"points": []}}
+
+    with patch("seeknal.ask.agents.tools.upload_to_s3.upload_to_s3") as mock_upload:
+        _upload_combined_forecast_csv("SELECT 1", history, result, periods=0, freq="MS")
+
+    kwargs = mock_upload.call_args.kwargs
+    data = kwargs["data"]
+    assert len(data) == 2
+    assert data[0] == ["2024-01-01", "historis", 5, "", "", "", "", ""]
+    assert data[1] == ["2024-02-01", "historis", 10, "", "", "", "", ""]

--- a/tests/ask/test_hooks.py
+++ b/tests/ask/test_hooks.py
@@ -305,12 +305,12 @@ class TestGetAskHooks:
         assert hooks[0].event == HookEvent.PRE_TOOL_USE
         # Covers execute_sql, upload_to_s3, run_forecast, detect_anomaly
         # (audit fix 2026-07-09; extended for forecast/anomaly 2026-07-22).
-        assert hooks[0].matcher == "execute_sql|upload_to_s3|run_forecast|detect_anomaly"
+        assert hooks[0].matcher == "execute_sql|upload_to_s3|run_forecast|detect_anomaly|visualize_chart"
 
     def test_second_hook_is_post_tool_use(self):
         hooks = get_ask_hooks()
         assert hooks[1].event == HookEvent.POST_TOOL_USE
-        assert hooks[1].matcher == "execute_sql|upload_to_s3|run_forecast|detect_anomaly"
+        assert hooks[1].matcher == "execute_sql|upload_to_s3|run_forecast|detect_anomaly|visualize_chart"
 
     def test_backward_compat_alias(self):
         """get_security_hooks is an alias for get_ask_hooks."""

--- a/tests/ask/test_pending_visualization_gateway.py
+++ b/tests/ask/test_pending_visualization_gateway.py
@@ -1,0 +1,193 @@
+"""Tests for the pending_visualization ToolContext field + gateway contract (M9).
+
+The gateway streaming loop emits ``visualization`` when
+``ctx.pending_visualization`` is set and CONTINUES the turn (no ``return``),
+same lifecycle as ``pending_upload`` and unlike ``pending_clarification`` which
+ends the turn. Two properties matter and are testable without a live LLM:
+
+  - anti-leak: ``reset_turn_governor`` clears the slot between turns, so a
+    chart built in turn N never re-emits in turn N+1
+  - no-return: the answer the chart belongs to is still streamed afterwards
+
+A full streaming integration test is out of scope here because it would require
+standing up the complete gateway request path; the control-flow replica below
+mirrors the real block in ``gateway/server.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import duckdb
+import pytest
+
+from seeknal.ask.agents.tools._context import (
+    ToolContext,
+    reset_turn_governor,
+    set_tool_context,
+)
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+def _chart_payload(title: str = "Sales per month") -> list[dict]:
+    return [
+        {
+            "chart_json": {
+                "widgetId": "sess-abc-9f21a3",
+                "widgetType": "line_chart",
+                "widgetTitle": title,
+                "widgetData": [{"bulan": "2026-01-01", "total": 10}],
+                "widgetSize": 1,
+            },
+            "chart_type": "line_chart",
+        }
+    ]
+
+
+class _REPLStub:
+    def __init__(self) -> None:
+        self.conn = duckdb.connect(":memory:")
+
+    def execute_oneshot(self, sql, limit=None):
+        return [], []
+
+
+def _ctx(tmp_path: Path) -> ToolContext:
+    ctx = ToolContext(
+        repl=_REPLStub(),
+        artifact_discovery=MagicMock(),
+        project_path=tmp_path,
+        sql_timeout_seconds=0,
+    )
+    set_tool_context(ctx)
+    return ctx
+
+
+def test_pending_visualization_field_defaults_none(tmp_path: Path):
+    ctx = _ctx(tmp_path)
+    assert ctx.pending_visualization is None
+
+
+def test_reset_turn_governor_clears_pending_visualization(tmp_path: Path):
+    ctx = _ctx(tmp_path)
+    ctx.pending_visualization = _chart_payload()
+
+    reset_turn_governor(question="next question")  # turn N+1 begins
+
+    assert ctx.pending_visualization is None  # anti-leak: stale chart cleared
+
+
+def test_reset_clears_every_pending_side_channel(tmp_path: Path):
+    ctx = _ctx(tmp_path)
+    ctx.pending_clarification = [{"question": "q?"}]
+    ctx.pending_upload = {"download_url": "http://x/f.csv"}
+    ctx.pending_visualization = _chart_payload()
+
+    reset_turn_governor(question="next")
+
+    assert ctx.pending_clarification is None
+    assert ctx.pending_upload is None
+    assert ctx.pending_visualization is None
+
+
+# ---------------------------------------------------------------------------
+# No-return control-flow contract (M9 gateway block).
+#
+# Faithful replica of the pending_* block in ``gateway/server.py``:
+# clarification ends the turn; upload and visualization emit and fall through.
+# ---------------------------------------------------------------------------
+
+
+async def _gateway_loop_replica(ctx, nodes):
+    """Replica of the server.py pending_* block inside the run loop."""
+    for node in nodes:
+        # A tool executed during this node may have set pending state.
+        node_hook = node.get("on_enter")
+        if node_hook:
+            node_hook(ctx)
+
+        if ctx.pending_clarification:
+            _prompts = ctx.pending_clarification
+            ctx.pending_clarification = None
+            yield {"type": "ask_user", "data": {"prompts": _prompts}}
+            return  # clarification ENDS the turn
+
+        if ctx.pending_upload:
+            _upload = ctx.pending_upload
+            ctx.pending_upload = None
+            yield {"type": "upload_complete", "data": _upload}
+            # deliberately NO return — continue the turn
+
+        if ctx.pending_visualization:
+            _visualization = ctx.pending_visualization
+            ctx.pending_visualization = None
+            yield {"type": "visualization", "data": _visualization}
+            # deliberately NO return — continue the turn
+
+        if node.get("answer"):
+            yield {"type": "message", "data": {"text": node["answer"]}}
+
+        if node.get("final"):
+            yield {"type": "done", "data": {}}
+
+
+@pytest.mark.asyncio
+async def test_visualization_does_not_end_turn(tmp_path: Path):
+    """The chart is yielded AND the answer still follows (no-return)."""
+    ctx = _ctx(tmp_path)
+
+    def set_chart(ctx):
+        ctx.pending_visualization = _chart_payload()
+
+    nodes = [
+        {"on_enter": set_chart},                 # visualize_chart runs here
+        {"answer": "Sales grew every month."},   # agent presents its answer
+        {"final": True},
+    ]
+
+    events = [ev async for ev in _gateway_loop_replica(ctx, nodes)]
+
+    types = [ev["type"] for ev in events]
+    assert types == ["visualization", "message", "done"], types
+    # The answer survived — proving visualization did NOT end the turn.
+    assert events[1]["data"]["text"] == "Sales grew every month."
+    # Slot cleared after emit (anti-double-emit).
+    assert ctx.pending_visualization is None
+
+
+@pytest.mark.asyncio
+async def test_visualization_event_carries_the_array_payload(tmp_path: Path):
+    """The event data is the array the frontend parses, not a flat object."""
+    ctx = _ctx(tmp_path)
+
+    def set_chart(ctx):
+        ctx.pending_visualization = _chart_payload()
+
+    events = [
+        ev
+        async for ev in _gateway_loop_replica(ctx, [{"on_enter": set_chart}])
+    ]
+
+    data = events[0]["data"]
+    assert isinstance(data, list)
+    assert data[0]["chart_json"]["widgetType"] == "line_chart"
+    assert data[0]["chart_type"] == "line_chart"
+
+
+@pytest.mark.asyncio
+async def test_upload_and_chart_can_both_emit_in_one_turn(tmp_path: Path):
+    """A CSV export and a chart are independent side channels, not rivals."""
+    ctx = _ctx(tmp_path)
+
+    def set_both(ctx):
+        ctx.pending_upload = {"download_url": "http://x/f.csv", "file_name": "f.csv"}
+        ctx.pending_visualization = _chart_payload()
+
+    nodes = [{"on_enter": set_both}, {"answer": "Done."}, {"final": True}]
+
+    events = [ev async for ev in _gateway_loop_replica(ctx, nodes)]
+
+    types = [ev["type"] for ev in events]
+    assert types == ["upload_complete", "visualization", "message", "done"], types

--- a/tests/ask/test_pg_query_routing.py
+++ b/tests/ask/test_pg_query_routing.py
@@ -1,0 +1,143 @@
+"""Tests for PG query routing on the agent path — SQLR.
+
+``_try_pg_route`` sends PG-only SQL straight to PostgreSQL so the source does
+the aggregation instead of DuckDB pulling raw columns over the network. The
+safety property under test: routing may decline, but it must never raise and
+never change what the caller receives.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from seeknal.ask.agents.tools.execute_sql import _try_pg_route
+
+
+class _Ctx:
+    """Minimal stand-in for ToolContext."""
+
+    def __init__(self, pg_passthrough: bool = True):
+        self.pg_passthrough = pg_passthrough
+        self.project_path = Path("/nonexistent-project")
+        self.db_lock = threading.Lock()
+        self.sql_timeout_seconds = 0
+
+
+SQL = "SELECT count(*) FROM warehouse.public.t WHERE x = 1"
+
+
+def test_gate_off_never_routes():
+    """Default-off means the routed path is not even attempted."""
+    with patch("seeknal.sources.config.load_source_registry") as loader:
+        assert _try_pg_route(_Ctx(pg_passthrough=False), SQL, None) is None
+        loader.assert_not_called()
+
+
+def test_registry_failure_falls_back():
+    """A broken/missing source registry declines routing instead of raising."""
+    with patch(
+        "seeknal.sources.config.load_source_registry",
+        side_effect=RuntimeError("no project"),
+    ):
+        assert _try_pg_route(_Ctx(), SQL, None) is None
+
+
+def test_non_pg_sql_declines():
+    """SQL that does not resolve to a single PG namespace stays on DuckDB."""
+    with patch("seeknal.sources.config.load_source_registry"), patch(
+        "seeknal.ask._pg_oracle.detect_pg_only_namespace", return_value=None
+    ):
+        assert _try_pg_route(_Ctx(), "SELECT 1", None) is None
+
+
+def test_pg_error_falls_back_and_is_recorded():
+    """A dialect/runtime error on PG must fall back, not surface to the agent."""
+    from seeknal.ask.testing import SqlOracleResult
+
+    events: list[tuple] = []
+
+    with patch("seeknal.sources.config.load_source_registry"), patch(
+        "seeknal.ask._pg_oracle.detect_pg_only_namespace", return_value="warehouse"
+    ), patch("seeknal.ask._pg_oracle.resolve_pg_dsn", return_value="postgresql://x/y"), patch(
+        "seeknal.ask._pg_oracle.strip_namespace", side_effect=lambda s, ns: s
+    ), patch(
+        "seeknal.ask._pg_oracle.execute_via_psycopg2",
+        return_value=SqlOracleResult(error="operator does not exist: text = integer"),
+    ), patch(
+        "seeknal.ask.agents.tools._context.record_timing_event",
+        side_effect=lambda name, ms, **kw: events.append((name, kw.get("reason", ""))),
+    ):
+        ctx = _Ctx()
+        # A namespace match requires a source whose .namespace matches; the
+        # patched registry is a MagicMock, so sources.values() yields mocks and
+        # the lookup returns None -> declines. Either way: no exception, no rows.
+        assert _try_pg_route(ctx, SQL, None) is None
+
+
+def test_unexpected_exception_falls_back():
+    """Any unforeseen failure declines routing rather than breaking the tool."""
+    with patch("seeknal.sources.config.load_source_registry"), patch(
+        "seeknal.ask._pg_oracle.detect_pg_only_namespace",
+        side_effect=ValueError("boom"),
+    ):
+        assert _try_pg_route(_Ctx(), SQL, None) is None
+
+
+@pytest.mark.parametrize(
+    "sql,expected",
+    [
+        # Regression: masking a qualified ref used to leave "FROM      WHERE",
+        # and WHERE was then read as a bare table name, rejecting every
+        # realistic qualified query.
+        ("SELECT a FROM pg_ns.public.t WHERE x = 1", "pg_ns"),
+        ("SELECT a FROM pg_ns.public.t GROUP BY a", "pg_ns"),
+        # A name the query defines itself is resolved by PostgreSQL, so a
+        # WITH-query over one PG namespace is still PG-only. This is how
+        # combined ERBA+ERLA questions are written.
+        (
+            "WITH x AS (SELECT a FROM pg_ns.public.t) SELECT * FROM x",
+            "pg_ns",
+        ),
+        (
+            "WITH a AS (SELECT n FROM pg_ns.public.t), b AS (SELECT n FROM pg_ns.public.u)"
+            " SELECT * FROM a UNION ALL SELECT * FROM b",
+            "pg_ns",
+        ),
+        # Still rejected: a bare table ref may be a local parquet view.
+        ("SELECT a FROM t WHERE x = 1", None),
+        ("SELECT a FROM pg_ns.public.t JOIN v ON v.k = t.k", None),
+        # A CTE does not launder an unqualified ref that is NOT locally defined.
+        (
+            "WITH x AS (SELECT a FROM pg_ns.public.t) SELECT * FROM x JOIN v ON 1=1",
+            None,
+        ),
+    ],
+)
+def test_detect_accepts_realistic_qualified_sql(sql, expected):
+    from seeknal.ask._pg_oracle import detect_pg_only_namespace
+    from seeknal.sources.config import SourceConfig, SourceRegistry
+
+    src = SourceConfig(
+        name="pg_ns",
+        source_kind="connected",
+        source_type="database",
+        namespace="pg_ns",
+        access="read_only",
+        role="other",
+        priority=0,
+        description="fixture",
+        connector="postgresql",
+        resource=None,
+        dsn_env=None,
+    )
+    registry = SourceRegistry(
+        sources={"pg_ns": src},
+        default_mode="analyst",
+        explicit=True,
+        project_path=None,
+    )
+    assert detect_pg_only_namespace(sql, registry) == expected

--- a/tests/ask/test_sql_routing.py
+++ b/tests/ask/test_sql_routing.py
@@ -1,0 +1,128 @@
+"""Tests for :mod:`seeknal.ask.sql_routing`.
+
+The module answers one question — may this statement run on a remote source
+instead of the local engine — from a parsed AST. These tests pin the two
+properties that make the answer trustworthy: it never routes a statement that
+could touch a local view, and a routed statement keeps its local meaning.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seeknal.ask.sql_routing import analyze
+
+REMOTE = {"warehouse"}
+
+
+def _plan(sql: str, namespaces=REMOTE):
+    return analyze(sql, namespaces, target_dialect="postgres")
+
+
+# ---------------------------------------------------------------------------
+# Routable: every table reference resolves to the one remote namespace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT a FROM warehouse.public.t WHERE x = 1",
+        "SELECT a, count(*) AS n FROM warehouse.public.t GROUP BY a",
+        # A name the statement defines for itself is not a local table.
+        "WITH c AS (SELECT a FROM warehouse.public.t) SELECT * FROM c",
+        "WITH a AS (SELECT n FROM warehouse.public.t),"
+        " b AS (SELECT n FROM warehouse.public.u)"
+        " SELECT * FROM a UNION ALL SELECT * FROM b",
+        # Two-part reference: namespace + table.
+        "SELECT a FROM warehouse.t",
+    ],
+)
+def test_routes_statements_confined_to_one_remote_namespace(sql):
+    assert _plan(sql).namespace == "warehouse"
+
+
+def test_routed_sql_drops_the_namespace_qualifier():
+    """The remote engine has no such catalog, so it must not be addressed."""
+    plan = _plan("SELECT a FROM warehouse.public.t")
+    assert plan.is_routable
+    assert "warehouse." not in plan.sql
+    assert "public.t" in plan.sql
+
+
+def test_routed_sql_preserves_null_ordering():
+    """DuckDB sorts NULLs last on DESC; PostgreSQL sorts them first.
+
+    Left implicit, an ordered query would come back in a different order than
+    the local engine produces. Transpiling must make the local default explicit.
+    """
+    plan = _plan("SELECT a FROM warehouse.public.t ORDER BY a DESC")
+    assert "NULLS LAST" in plan.sql.upper()
+
+
+# ---------------------------------------------------------------------------
+# Declined: anything that might not mean the same thing remotely
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sql,expected_reason",
+    [
+        # A bare name may be a local parquet/Iceberg view.
+        ("SELECT a FROM t", "unqualified table reference"),
+        (
+            "SELECT a FROM warehouse.public.t JOIN v ON v.k = t.k",
+            "unqualified table reference",
+        ),
+        # A CTE does not excuse a sibling reference that is not self-defined.
+        (
+            "WITH c AS (SELECT a FROM warehouse.public.t) SELECT * FROM c JOIN v ON 1=1",
+            "unqualified table reference",
+        ),
+        ("SELECT 1", "no qualified table reference"),
+        # Engines invent different names for a projection the statement does
+        # not alias: DuckDB says count_star(), PostgreSQL says count.
+        ("SELECT COUNT(*) FROM warehouse.public.t", "unaliased projection"),
+        (
+            "SELECT date_trunc('year', d) FROM warehouse.public.t",
+            "unaliased projection",
+        ),
+    ],
+)
+def test_declines_when_a_reference_may_be_local(sql, expected_reason):
+    plan = _plan(sql)
+    assert not plan.is_routable
+    assert expected_reason in plan.reason
+
+
+def test_declines_when_statement_spans_namespaces():
+    plan = analyze(
+        "SELECT * FROM ns_a.public.t JOIN ns_b.public.u ON 1=1",
+        {"ns_a", "ns_b"},
+        target_dialect="postgres",
+    )
+    assert not plan.is_routable
+    assert "multiple namespaces" in plan.reason
+
+
+def test_declines_unknown_namespace():
+    plan = _plan("SELECT a FROM other.public.t")
+    assert not plan.is_routable
+    assert "not routable" in plan.reason
+
+
+def test_declines_when_no_remote_source_configured():
+    plan = analyze("SELECT a FROM warehouse.public.t", set(), target_dialect="postgres")
+    assert not plan.is_routable
+    assert "no remote namespace" in plan.reason
+
+
+def test_declines_unparsable_sql_without_raising():
+    plan = _plan("SELECT FROM WHERE ((((")
+    assert not plan.is_routable
+    assert plan.reason
+
+
+def test_reason_is_empty_when_routable():
+    """Callers log ``reason`` only for declines; a routed plan carries none."""
+    assert _plan("SELECT a FROM warehouse.public.t").reason == ""

--- a/tests/ask/test_upload_to_s3_tool.py
+++ b/tests/ask/test_upload_to_s3_tool.py
@@ -246,3 +246,41 @@ def test_upload_data_mode_empty_rows_returns_nothing(ctx):
     out = upload_to_s3("file.csv", data=[], columns=["a"])
     assert "No rows" in out
     assert ctx.pending_upload is None
+
+
+def test_upload_sql_mode_exports_all_rows_no_5000_cap(ctx):
+    """CSV export row-limit fix (2026-08-03): Mode 1 exports EVERY row.
+
+    Regression guard for the removal of _CSV_EXPORT_ROW_LIMIT. A query
+    producing >5000 rows must land in the exported CSV in full — the tool now
+    passes limit=None to _execute_oneshot_with_timeout (repl.py only wraps
+    LIMIT when a non-None limit is given).
+    """
+    repl = ctx.repl
+    repl.conn.execute(
+        "CREATE TABLE big AS SELECT i AS id, 'row-' || i AS v "
+        "FROM generate_series(0, 11999) AS t(i)"
+    )
+    presign = _mock_response(_presign_response())
+    captured_put_bytes = []
+
+    def _capture_put(url, content=None, **kw):
+        captured_put_bytes.append(content)
+        m = MagicMock()
+        m.raise_for_status.return_value = None
+        return m
+
+    with patch("seeknal.ask.agents.tools.upload_to_s3.httpx.post", return_value=presign), patch(
+        "seeknal.ask.agents.tools.upload_to_s3.httpx.put", side_effect=_capture_put
+    ):
+        out = upload_to_s3("big.csv", "SELECT id, v FROM big")
+
+    assert "Upload complete" in out
+    csv_text = captured_put_bytes[0].decode("utf-8")
+    lines = [ln for ln in csv_text.splitlines() if ln]
+    # Header + all 12000 rows — NOT truncated at 5000.
+    assert len(lines) == 12001, f"expected 12001 lines, got {len(lines)}"
+    assert lines[0] == "id,v"
+    assert lines[1] == "0,row-0"
+    assert lines[-1] == "11999,row-11999"
+    assert ctx.pending_upload["file_size"] == len(csv_text.encode("utf-8"))

--- a/tests/ask/test_visualize_chart_tool.py
+++ b/tests/ask/test_visualize_chart_tool.py
@@ -1,0 +1,354 @@
+"""Tests for the visualize_chart tool — payload shape, caps, cache reuse, mutex.
+
+No network and no engine: the tool is purely local, so these run against an
+in-memory DuckDB.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import duckdb
+import pytest
+
+from seeknal.ask.agents.tools._chart_payload import (
+    CHART_MAX_POINTS,
+    CHART_MAX_SERIES,
+    CHART_TOP_N,
+    OTHERS_LABEL,
+)
+from seeknal.ask.agents.tools._context import (
+    ToolContext,
+    get_structured_sql_cache,
+    reset_turn_governor,
+    set_tool_context,
+)
+from seeknal.ask.agents.tools.visualize_chart import visualize_chart
+
+
+class _REPLStub:
+    def __init__(self) -> None:
+        self.conn = duckdb.connect(":memory:")
+        self.executions = 0
+
+    def execute_oneshot(self, sql: str, limit=None):
+        self.executions += 1
+        if limit is not None:
+            sql = f"SELECT * FROM ({sql}) AS _q LIMIT {int(limit)}"
+        result = self.conn.execute(sql)
+        if not result.description:
+            return [], []
+        cols = [d[0] for d in result.description]
+        return cols, result.fetchall()
+
+
+@pytest.fixture
+def ctx(tmp_path: Path) -> ToolContext:
+    repl = _REPLStub()
+    repl.conn.execute(
+        "CREATE TABLE sales AS "
+        "SELECT DATE '2026-01-01' + INTERVAL (i) MONTH AS bulan, "
+        "       (i + 1) * 10 AS total "
+        "FROM generate_series(0, 5) AS t(i)"
+    )
+    ctx = ToolContext(
+        repl=repl,
+        artifact_discovery=MagicMock(),
+        project_path=tmp_path,
+        sql_timeout_seconds=0,
+        request_limit=100,
+    )
+    set_tool_context(ctx)
+    return ctx
+
+
+SQL = "SELECT bulan, total FROM sales ORDER BY 1"
+
+
+def _chart(ctx: ToolContext) -> dict:
+    """Return the single chart_json the tool registered."""
+    assert ctx.pending_visualization is not None
+    assert len(ctx.pending_visualization) == 1
+    return ctx.pending_visualization[0]["chart_json"]
+
+
+# ---------------------------------------------------------------------------
+# Payload shape
+# ---------------------------------------------------------------------------
+
+
+def test_registers_chart_in_legacy_array_shape(ctx: ToolContext) -> None:
+    out = visualize_chart("line_chart", "Sales per month", sql=SQL)
+
+    assert "Chart ready" in out
+    payload = ctx.pending_visualization
+    assert isinstance(payload, list) and len(payload) == 1
+    assert set(payload[0]) == {"chart_json", "chart_type"}
+    assert payload[0]["chart_type"] == "line_chart"
+    assert set(payload[0]["chart_json"]) == {
+        "widgetId",
+        "widgetType",
+        "widgetTitle",
+        "widgetData",
+        "widgetSize",
+    }
+
+
+def test_payload_carries_no_vega_spec(ctx: ToolContext) -> None:
+    """The frontend builds its own spec; nothing spec-shaped goes on the wire."""
+    visualize_chart("bar_chart", "Sales", sql=SQL)
+
+    chart = _chart(ctx)
+    for dropped in ("vegaSpec", "schemaVersion", "summary", "xField", "yField",
+                    "seriesField", "sourceTool"):
+        assert dropped not in chart
+
+
+def test_widget_data_preserves_column_order(ctx: ToolContext) -> None:
+    """Column order is the axis contract: keys[0] = X, keys[1] = Y."""
+    visualize_chart("line_chart", "Sales", sql=SQL)
+
+    rows = _chart(ctx)["widgetData"]
+    assert list(rows[0].keys()) == ["bulan", "total"]
+
+
+def test_widget_id_is_deterministic(ctx: ToolContext) -> None:
+    visualize_chart("line_chart", "Sales", sql=SQL)
+    first = _chart(ctx)["widgetId"]
+
+    ctx.pending_visualization = None
+    visualize_chart("line_chart", "Sales", sql=SQL)
+
+    assert _chart(ctx)["widgetId"] == first
+
+
+def test_payload_is_json_serializable(ctx: ToolContext) -> None:
+    """DATE cells must survive json.dumps — the payload rides the SSE stream."""
+    visualize_chart("line_chart", "Sales", sql=SQL)
+
+    encoded = json.dumps(ctx.pending_visualization)
+    assert "2026-01-01" in encoded
+
+
+def test_decimal_and_bytes_cells_are_coerced(ctx: ToolContext) -> None:
+    ctx.repl.conn.execute(
+        "CREATE TABLE mixed AS SELECT 'a' AS k, CAST(1.5 AS DECIMAL(4,2)) AS v"
+    )
+    visualize_chart("bar_chart", "Mixed", sql="SELECT k, v FROM mixed")
+
+    row = _chart(ctx)["widgetData"][0]
+    assert row["v"] == pytest.approx(1.5)
+    json.dumps(ctx.pending_visualization)
+
+
+# ---------------------------------------------------------------------------
+# Mode 2 — computed data
+# ---------------------------------------------------------------------------
+
+
+def test_data_mode_builds_chart_without_sql(ctx: ToolContext) -> None:
+    out = visualize_chart(
+        "line_chart",
+        "History and projection",
+        data=[["2026-01", 10, "history"], ["2026-02", 12, "projection"]],
+        columns=["period", "value", "segment"],
+    )
+
+    assert "Chart ready" in out
+    rows = _chart(ctx)["widgetData"]
+    assert list(rows[0].keys()) == ["period", "value", "segment"]
+    assert {row["segment"] for row in rows} == {"history", "projection"}
+    assert ctx.repl.executions == 0
+
+
+def test_data_mode_rejects_jagged_rows(ctx: ToolContext) -> None:
+    out = visualize_chart(
+        "bar_chart",
+        "Broken",
+        data=[["a", 1], ["b"]],
+        columns=["k", "v"],
+    )
+
+    assert "row length mismatch" in out
+    assert ctx.pending_visualization is None
+
+
+def test_data_mode_requires_columns(ctx: ToolContext) -> None:
+    out = visualize_chart("bar_chart", "Broken", data=[["a", 1]])
+
+    assert "columns=" in out
+    assert ctx.pending_visualization is None
+
+
+def test_sql_and_data_together_are_refused(ctx: ToolContext) -> None:
+    out = visualize_chart(
+        "bar_chart", "Conflict", sql=SQL, data=[["a", 1]], columns=["k", "v"]
+    )
+
+    assert "argument conflict" in out
+    assert ctx.pending_visualization is None
+
+
+def test_no_source_at_all_is_refused(ctx: ToolContext) -> None:
+    out = visualize_chart("bar_chart", "Nothing")
+
+    assert "nothing to chart" in out
+    assert ctx.pending_visualization is None
+
+
+# ---------------------------------------------------------------------------
+# Validation and refusals
+# ---------------------------------------------------------------------------
+
+
+def test_unsupported_widget_type_is_refused(ctx: ToolContext) -> None:
+    out = visualize_chart("sankey_diagram", "Nope", sql=SQL)
+
+    assert "Unsupported widget_type" in out
+    assert ctx.pending_visualization is None
+
+
+def test_empty_result_emits_no_chart(ctx: ToolContext) -> None:
+    out = visualize_chart(
+        "line_chart", "Empty", sql="SELECT bulan, total FROM sales WHERE total < 0"
+    )
+
+    assert out == "No rows to chart."
+    assert ctx.pending_visualization is None
+
+
+def test_single_column_is_refused_for_a_real_chart(ctx: ToolContext) -> None:
+    out = visualize_chart("bar_chart", "One column", sql="SELECT total FROM sales")
+
+    assert "needs at least 2 column(s)" in out
+    assert ctx.pending_visualization is None
+
+
+def test_single_column_is_accepted_for_big_number(ctx: ToolContext) -> None:
+    out = visualize_chart(
+        "big_number", "Total", sql="SELECT SUM(total) AS total FROM sales"
+    )
+
+    assert "Chart ready" in out
+    assert _chart(ctx)["widgetType"] == "big_number"
+
+
+def test_sql_failure_returns_structured_error(ctx: ToolContext) -> None:
+    """Same JSON shape execute_sql returns, so the self-correction hook applies."""
+    out = visualize_chart("bar_chart", "Broken", sql="SELECT * FROM no_such_table")
+
+    error = json.loads(out)
+    assert error["category"] == "retryable_missing_ref"
+    assert error["retryable"] is True
+    assert ctx.pending_visualization is None
+
+
+# ---------------------------------------------------------------------------
+# One chart per question
+# ---------------------------------------------------------------------------
+
+
+def test_second_chart_in_same_turn_is_refused(ctx: ToolContext) -> None:
+    visualize_chart("line_chart", "First", sql=SQL)
+    first = _chart(ctx)["widgetTitle"]
+
+    out = visualize_chart("bar_chart", "Second", sql=SQL)
+
+    assert "already prepared" in out
+    assert _chart(ctx)["widgetTitle"] == first
+
+
+def test_turn_reset_clears_pending_chart(ctx: ToolContext) -> None:
+    visualize_chart("line_chart", "First", sql=SQL)
+    assert ctx.pending_visualization is not None
+
+    reset_turn_governor("next question")
+
+    assert ctx.pending_visualization is None
+
+
+# ---------------------------------------------------------------------------
+# Structured cache reuse
+# ---------------------------------------------------------------------------
+
+
+def test_reuses_structured_cache_without_re_executing(ctx: ToolContext) -> None:
+    """A cache hit is what keeps the chart and the answer text on one dataset."""
+    from seeknal.ask.agents.tools.execute_sql import _sql_cache_key
+
+    get_structured_sql_cache(ctx)[_sql_cache_key(SQL)] = {
+        "columns": ["bulan", "total"],
+        "rows": [[date(2026, 1, 1), 999]],
+    }
+
+    visualize_chart("line_chart", "Cached", sql=SQL)
+
+    assert ctx.repl.executions == 0
+    assert _chart(ctx)["widgetData"] == [{"bulan": "2026-01-01", "total": 999}]
+
+
+def test_execute_sql_populates_the_structured_cache(ctx: ToolContext) -> None:
+    from seeknal.ask.agents.tools.execute_sql import _sql_cache_key, execute_sql
+
+    execute_sql(SQL)
+
+    cached = get_structured_sql_cache(ctx)[_sql_cache_key(SQL)]
+    assert cached["columns"] == ["bulan", "total"]
+    assert len(cached["rows"]) == 6
+
+
+# ---------------------------------------------------------------------------
+# Payload caps
+# ---------------------------------------------------------------------------
+
+
+def test_categorical_chart_buckets_beyond_top_n(ctx: ToolContext) -> None:
+    rows = [[f"cat-{i}", i] for i in range(CHART_TOP_N + 8)]
+    visualize_chart("bar_chart", "Many categories", data=rows, columns=["k", "v"])
+
+    widget_data = _chart(ctx)["widgetData"]
+    assert len(widget_data) == CHART_TOP_N + 1
+    assert widget_data[-1]["k"] == OTHERS_LABEL
+
+
+def test_others_bucket_preserves_the_total(ctx: ToolContext) -> None:
+    rows = [[f"cat-{i}", i] for i in range(CHART_TOP_N + 8)]
+    visualize_chart("bar_chart", "Many categories", data=rows, columns=["k", "v"])
+
+    charted = sum(row["v"] for row in _chart(ctx)["widgetData"])
+    assert charted == sum(row[1] for row in rows)
+
+
+def test_time_series_is_downsampled_and_keeps_the_last_point(ctx: ToolContext) -> None:
+    start = date(2026, 1, 1)
+    rows = [
+        [(start + timedelta(days=i)).isoformat(), i]
+        for i in range(CHART_MAX_POINTS + 120)
+    ]
+    visualize_chart("line_chart", "Long series", data=rows, columns=["period", "v"])
+
+    widget_data = _chart(ctx)["widgetData"]
+    assert len(widget_data) <= CHART_MAX_POINTS
+    assert widget_data[-1]["period"] == rows[-1][0]
+
+
+def test_series_column_is_capped(ctx: ToolContext) -> None:
+    rows = [[f"p{i}", i, f"series-{i}"] for i in range(CHART_MAX_SERIES + 5)]
+    visualize_chart(
+        "grouped_bar_chart", "Many series", data=rows, columns=["p", "v", "s"]
+    )
+
+    series = {row["s"] for row in _chart(ctx)["widgetData"]}
+    assert len(series) == CHART_MAX_SERIES
+
+
+def test_applied_limits_are_reported_to_the_agent(ctx: ToolContext) -> None:
+    rows = [[f"cat-{i}", i] for i in range(CHART_TOP_N + 8)]
+    out = visualize_chart("bar_chart", "Many categories", data=rows, columns=["k", "v"])
+
+    assert "Applied limits" in out
+    assert OTHERS_LABEL in out

--- a/uv.lock
+++ b/uv.lock
@@ -4213,7 +4213,7 @@ wheels = [
 
 [[package]]
 name = "seeknal"
-version = "2.10.1"
+version = "2.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary
- Add `visualize_chart` deterministic chart tool with dual-mode data sources (SQL cache / raw data)
- Add gateway `_drain_pending_side_channels()` to fix pre-existing `upload_complete` drop + chart emission
- Add chart config flags: `agent.visualize_chart.enabled` and `agent.visualize_chart.auto_emit`
- Add tool registration, access role, SQL security hook integration
- Add generic chart trigger skill
- Add GCP build script + ask_user/ambiguity tests

## Changes
### Commit 1 — M9 code (13 files)
- `src/seeknal/ask/agents/tools/visualize_chart.py` — new chart tool
- `src/seeknal/ask/agents/tools/_chart_payload.py` — payload builder + caps
- `src/seeknal/ask/agents/tools/_context.py` — pending_visualization, exported_dataset, structured SQL cache
- `src/seeknal/ask/agents/tools/execute_sql.py` — write structured cache
- `src/seeknal/ask/agents/tools/upload_to_s3.py` — register exported dataset
- `src/seeknal/ask/agents/agent.py` — include_visualize_chart param
- `src/seeknal/ask/agents/tools/toolset.py` — tool registration
- `src/seeknal/ask/agents/hooks.py` — SQL security hook +visualize_chart
- `src/seeknal/ask/gateway/server.py` — side-channel drain + chart emission
- `src/seeknal/ask/config.py` — config flags
- `src/seeknal/ask/access/registry.py` — access role
- `src/seeknal/ask/builtin_skills/chart-visualize/SKILL.md` — generic skill
- `uv.lock` — version bump

### Commit 2 — M9 tests (4 files)
- `tests/ask/test_visualize_chart_tool.py`
- `tests/ask/test_chart_shape_and_export.py`
- `tests/ask/test_pending_visualization_gateway.py`
- `tests/ask/test_hooks.py`

### Commit 3 — infra/other tests (5 files)
- `scripts/build-gcp.sh`
- `draft_second_order_aggregation_test.yml`
- `tests/ask/test_ask_user_gateway.py`
- `tests/ask/test_ask_user_http.py`
- `tests/ask/test_dict_ambiguity_gate.py`

## Spec Reference
- `specs/2026-07-10-spec-m9-chart-visualization-pipeline.md` §3.7, §3.14, §3.18, §3.21

## Rollout Gate
`agent.visualize_chart.enabled` must NOT be enabled until iba-service carries the `visualization` enum + transform (iba PR).