### PR TITLE
[feat, ask] Make read_project_file window configurable per project

### DIFF
--- a/src/seeknal/ask/_pg_oracle.py
+++ b/src/seeknal/ask/_pg_oracle.py
@@ -50,23 +50,6 @@ from seeknal.connections.postgresql import (
 from seeknal.sources.config import SourceConfig, SourceRegistry
 
 
-# Regexes for namespace detection (used in detect_pg_only_namespace).
-# Quoted variants like "ns"."schema"."table" are also recognized.
-_IDENT = r'(?:"[^"]+"|[A-Za-z_][A-Za-z0-9_]*)'
-_RE_3PART = re.compile(rf'\b({_IDENT})\.({_IDENT})\.({_IDENT})\b')
-_RE_2PART = re.compile(rf'\b({_IDENT})\.({_IDENT})\b')
-_RE_UNQUALIFIED = re.compile(
-    rf'\b(?:FROM|JOIN)\s+({_IDENT})\b(?!\s*\.)',
-    flags=re.IGNORECASE,
-)
-
-
-def _strip_ident_quotes(token: str) -> str:
-    if token.startswith('"') and token.endswith('"'):
-        return token[1:-1]
-    return token
-
-
 def detect_pg_only_namespace(
     sql: str,
     registry: SourceRegistry,
@@ -80,7 +63,14 @@ def detect_pg_only_namespace(
     A connected-PG source is one where ``source_kind == "connected"``,
     ``source_type == "database"``, ``connector in {"postgresql", "postgres"}``,
     and the source is read-only.
+
+    The structural decision is delegated to :mod:`seeknal.ask.sql_routing`,
+    which parses the statement instead of matching text — a name can be a
+    remote table, a local view, or a CTE the statement defines, and only a
+    parser can tell those apart.
     """
+    from seeknal.ask.sql_routing import analyze
+
     pg_ns_set: set[str] = set()
     for source in registry.sources.values():
         if (
@@ -91,39 +81,7 @@ def detect_pg_only_namespace(
         ):
             pg_ns_set.add(source.namespace)
 
-    if not pg_ns_set:
-        return None
-
-    # Collect leading-identifier set from qualified refs.
-    # 3-part scan FIRST; replace those spans with whitespace so a follow-up
-    # 2-part scan does not double-count the inner ``schema.table`` portion.
-    leading: set[str] = set()
-    masked = list(sql)
-    for m in _RE_3PART.finditer(sql):
-        leading.add(_strip_ident_quotes(m.group(1)))
-        for idx in range(m.start(), m.end()):
-            masked[idx] = " "
-    masked_sql = "".join(masked)
-    for m in _RE_2PART.finditer(masked_sql):
-        leading.add(_strip_ident_quotes(m.group(1)))
-
-    if not leading:
-        return None
-
-    # Any unqualified table ref forces a DuckDB fallback. This prevents
-    # false-positive routing on SQL that mixes a qualified PG table and a
-    # bare parquet view. Scan the masked SQL so the leading identifier of
-    # a 3-part ref is not counted as an unqualified ``FROM`` ident.
-    if _RE_UNQUALIFIED.search(masked_sql):
-        return None
-
-    # Every leading identifier must be the same single connected-PG namespace.
-    if not leading.issubset(pg_ns_set):
-        return None
-    if len(leading) != 1:
-        return None
-    (ns,) = leading
-    return ns
+    return analyze(sql, pg_ns_set, target_dialect="postgres").namespace
 
 
 def resolve_pg_dsn(

--- a/src/seeknal/ask/agents/agent.py
+++ b/src/seeknal/ask/agents/agent.py
@@ -273,6 +273,9 @@ def create_agent(
     tool_ctx = get_tool_context()
     tool_ctx.request_limit = get_request_limit(agent_config)
     tool_ctx.sql_timeout_seconds = get_sql_timeout_seconds(agent_config)
+    from seeknal.ask.config import get_pg_passthrough_enabled
+
+    tool_ctx.pg_passthrough = get_pg_passthrough_enabled(agent_config)
     tool_ctx.discovery_cache_ttl_seconds = get_discovery_cache_ttl_seconds(agent_config)
     tool_ctx.background_threshold = get_background_threshold(agent_config)
     from seeknal.ask.config import get_sql_pair_mode

--- a/src/seeknal/ask/agents/agent.py
+++ b/src/seeknal/ask/agents/agent.py
@@ -273,9 +273,10 @@ def create_agent(
     tool_ctx = get_tool_context()
     tool_ctx.request_limit = get_request_limit(agent_config)
     tool_ctx.sql_timeout_seconds = get_sql_timeout_seconds(agent_config)
-    from seeknal.ask.config import get_pg_passthrough_enabled
+    from seeknal.ask.config import get_pg_passthrough_enabled, get_read_max_lines
 
     tool_ctx.pg_passthrough = get_pg_passthrough_enabled(agent_config)
+    tool_ctx.read_max_lines = get_read_max_lines(agent_config)
     tool_ctx.discovery_cache_ttl_seconds = get_discovery_cache_ttl_seconds(agent_config)
     tool_ctx.background_threshold = get_background_threshold(agent_config)
     from seeknal.ask.config import get_sql_pair_mode

--- a/src/seeknal/ask/agents/tools/_context.py
+++ b/src/seeknal/ask/agents/tools/_context.py
@@ -76,6 +76,10 @@ class ToolContext:
     sql_pairs_checked_this_turn: bool = False
     authoritative_sql_pair_result_this_turn: dict[str, str] | None = None
     sql_timeout_seconds: int = 60
+    # SQLR: route PG-only SQL straight to PostgreSQL instead of running it
+    # through DuckDB's postgres_scanner. Off unless the project opts in; any
+    # failure on that path falls back to DuckDB (see execute_sql._try_pg_route).
+    pg_passthrough: bool = False
     discovery_cache_ttl_seconds: int = 300
     discovery_cache: dict[str, tuple[float, Any]] = field(default_factory=dict)
     timing_events_this_turn: list[dict[str, Any]] = field(default_factory=list)

--- a/src/seeknal/ask/agents/tools/_context.py
+++ b/src/seeknal/ask/agents/tools/_context.py
@@ -76,6 +76,10 @@ class ToolContext:
     sql_pairs_checked_this_turn: bool = False
     authoritative_sql_pair_result_this_turn: dict[str, str] | None = None
     sql_timeout_seconds: int = 60
+    # How many lines read_project_file returns per call. 200 suits source files;
+    # projects whose rule documents run longer can raise it so the tail is not
+    # silently cut (see ask.config.get_read_max_lines).
+    read_max_lines: int = 200
     # SQLR: route PG-only SQL straight to PostgreSQL instead of running it
     # through DuckDB's postgres_scanner. Off unless the project opts in; any
     # failure on that path falls back to DuckDB (see execute_sql._try_pg_route).

--- a/src/seeknal/ask/agents/tools/execute_sql.py
+++ b/src/seeknal/ask/agents/tools/execute_sql.py
@@ -822,12 +822,137 @@ def _count_total(ctx, sql: str) -> int | None:
     return None
 
 
+# PostgreSQL truncates identifiers at NAMEDATALEN-1 bytes. A name it cannot
+# hold would come back truncated — a different header, which is exactly what
+# carrying the local names over is meant to prevent — so such a statement is
+# left on the local engine instead.
+_PG_MAX_IDENTIFIER_BYTES = 63
+
+
+def _local_column_names(ctx, sql: str) -> list[str] | None:
+    """Ask the local engine what it would call this statement's result columns.
+
+    Returns None when the question cannot be answered; the caller then leaves
+    the statement on the local engine rather than guessing at a name.
+    """
+    from seeknal.ask.sql_routing import probe_sql
+
+    probe = probe_sql(sql)
+    if probe is None:
+        return None
+    try:
+        with ctx.db_lock:
+            cursor = ctx.repl.conn.execute(probe)
+            return [str(column[0]) for column in cursor.description or []]
+    except Exception:  # noqa: BLE001 — probing is best-effort
+        return None
+
+
+def _try_pg_route(ctx, sql: str, limit: int | None):
+    """Run PG-only SQL directly on PostgreSQL; return ``(columns, rows)`` or None.
+
+    DuckDB's postgres_scanner pushes down predicates but never aggregation, so
+    ``COUNT(DISTINCT ...)`` over an attached table transfers the raw column and
+    computes locally. Sending PG-only SQL to PostgreSQL lets the source do the
+    aggregation and return only the result rows.
+
+    Returning None means "not routed" and the caller continues on the DuckDB
+    path. That is the case for every failure too — unsupported SQL, a dialect
+    error, an unreachable database. Routing may make a query slower by falling
+    back, but it can never change the answer or surface a new error.
+
+    This is the one place the agent path deliberately differs from the oracle
+    path in ``ask/testing.py``, which must NOT fall back (a wrong-engine answer
+    would defeat a ground-truth oracle). Here availability wins.
+    """
+    import time
+
+    from seeknal.ask.agents.tools._context import record_timing_event
+
+    if not getattr(ctx, "pg_passthrough", False):
+        return None
+
+    started = time.monotonic()
+    try:
+        from seeknal.ask._pg_oracle import execute_via_psycopg2, resolve_pg_dsn
+        from seeknal.ask.sql_routing import analyze
+        from seeknal.sources.config import load_source_registry
+        from seeknal.workflow.materialization.profile_loader import ProfileLoader
+
+        registry = load_source_registry(ctx.project_path)
+        remote = {
+            s.namespace
+            for s in registry.sources.values()
+            if s.source_kind == "connected"
+            and s.source_type == "database"
+            and s.connector in ("postgresql", "postgres")
+            and s.is_read_only
+        }
+        plan = analyze(sql, remote, target_dialect="postgres")
+        if not plan.is_routable and plan.reason.startswith("unaliased projection"):
+            # The statement leaves a projection for the engine to name, and the
+            # engines disagree. Ask the local engine what it would call them —
+            # LIMIT 0 plans the statement without reading rows — then carry
+            # those names over so the routed result is labelled identically.
+            plan = analyze(
+                sql,
+                remote,
+                target_dialect="postgres",
+                local_column_names=_local_column_names(ctx, sql),
+                max_identifier_bytes=_PG_MAX_IDENTIFIER_BYTES,
+            )
+        if not plan.is_routable:
+            return None
+        # registry.sources is keyed by .name, not .namespace — match on the
+        # attribute (same lookup as ask/testing.py:266).
+        source = next(
+            (s for s in registry.sources.values() if s.namespace == plan.namespace),
+            None,
+        )
+        if source is None:
+            return None
+
+        profile_path = ctx.project_path / "profiles.yml"
+        loader = ProfileLoader(
+            profile_path=profile_path if profile_path.exists() else None
+        )
+        dsn = resolve_pg_dsn(source, loader._load_profile_data())
+
+        pg_sql = plan.sql
+        if limit is not None:
+            pg_sql = f"SELECT * FROM ({pg_sql}) _seeknal_routed LIMIT {int(limit)}"
+
+        result = execute_via_psycopg2(dsn, pg_sql)
+        if result.error:
+            record_timing_event(
+                "execute_sql_pg_fallback",
+                int((time.monotonic() - started) * 1000),
+                reason=str(result.error)[:200],
+            )
+            return None
+        return [str(col) for col in result.columns], list(result.rows)
+    except Exception as exc:  # noqa: BLE001 — any failure means "use DuckDB"
+        try:
+            record_timing_event(
+                "execute_sql_pg_fallback",
+                int((time.monotonic() - started) * 1000),
+                reason=f"{type(exc).__name__}: {exc}"[:200],
+            )
+        except Exception:  # noqa: BLE001 — observability never blocks
+            pass
+        return None
+
+
 def _execute_oneshot_with_timeout(ctx, sql: str, limit: int | None = None):
     """Execute REPL SQL with the session db lock and optional hard timeout."""
     import concurrent.futures
     import time
 
     from seeknal.ask.agents.tools._context import record_timing_event
+
+    routed = _try_pg_route(ctx, sql, limit)
+    if routed is not None:
+        return routed
 
     timeout = int(getattr(ctx, "sql_timeout_seconds", 0) or 0)
     started = time.monotonic()

--- a/src/seeknal/ask/agents/tools/read_project_file.py
+++ b/src/seeknal/ask/agents/tools/read_project_file.py
@@ -65,7 +65,7 @@ def _do_read(path: str, project_path, start_line: int = 1, max_lines: int = 200)
 def read_project_file(
     path: str,
     start_line: int = 1,
-    max_lines: int = 200,
+    max_lines: int | None = None,
 ) -> str:
     """Read any file in the project by its relative path.
 
@@ -78,9 +78,12 @@ def read_project_file(
     Args:
         path: File path relative to the project root.
         start_line: Line number to start reading from (default 1).
-        max_lines: Maximum number of lines to return (default 200).
+        max_lines: Maximum number of lines to return. Omit to use the
+            project's configured window.
     """
     from seeknal.ask.agents.tools._context import get_tool_context
 
     ctx = get_tool_context()
+    if max_lines is None:
+        max_lines = getattr(ctx, "read_max_lines", 200)
     return _do_read(path, ctx.project_path, start_line, max_lines)

--- a/src/seeknal/ask/agents/tools/upload_to_s3.py
+++ b/src/seeknal/ask/agents/tools/upload_to_s3.py
@@ -198,16 +198,31 @@ def upload_to_s3(
             timeout=60.0,
         )
         put.raise_for_status()
-    except httpx.HTTPError:
+    # FC2i: split the two failure modes STEP 3 above already distinguishes.
+    # httpx.HTTPError is the base class of BOTH HTTPStatusError (the endpoint
+    # answered with a status) and RequestError (it was never reached), so
+    # catching it lost the one detail that identifies the fault — and named
+    # SeaweedFS, which is three hops away and often never contacted at all.
+    except httpx.RequestError as exc:
         record_tool_result(
             "upload_to_s3",
             format_tool_error(
                 TERMINAL_DEPENDENCY_UNAVAILABLE,
-                "CSV upload failed (SeaweedFS rejected the write).",
+                f"CSV upload failed: storage endpoint unreachable ({type(exc).__name__}).",
             ),
             args={"filename": filename, "mode": "sql" if used_sql_mode else "data"},
         )
-        return "CSV upload failed (SeaweedFS rejected the write)."
+        return f"CSV upload failed: storage endpoint unreachable ({type(exc).__name__})."
+    except httpx.HTTPStatusError as exc:
+        record_tool_result(
+            "upload_to_s3",
+            format_tool_error(
+                TERMINAL_DEPENDENCY_UNAVAILABLE,
+                f"CSV upload failed: storage rejected the write (HTTP {exc.response.status_code}).",
+            ),
+            args={"filename": filename, "mode": "sql" if used_sql_mode else "data"},
+        )
+        return f"CSV upload failed: storage rejected the write (HTTP {exc.response.status_code})."
 
     # ── STEP 5: register pending_upload — gateway loop emits upload_complete
     # expires_at is sourced VERBATIM from the server response

--- a/src/seeknal/ask/config.py
+++ b/src/seeknal/ask/config.py
@@ -315,6 +315,9 @@ def get_background_threshold(config: dict[str, Any]) -> int:
 
 _DEFAULT_HARNESS_SECTION = "agent_harness"
 
+# read_project_file window. 200 fits source files; rule documents are read whole.
+_DEFAULT_READ_MAX_LINES = 200
+
 
 def get_agent_harness_settings(config: dict[str, Any]) -> dict[str, Any]:
     """Return optional low-level pydantic-deep harness settings.
@@ -522,6 +525,32 @@ def get_ask_toolset_mode(config: dict[str, Any]) -> str:
     if mode in _READ_ONLY_ANALYST_MODES:
         return "analysis"
     return "full"
+
+
+def get_read_max_lines(config: dict[str, Any]) -> int:
+    """Return how many lines ``read_project_file`` returns per call.
+
+    The default suits source files, where a 200-line window is usually the part
+    worth reading. Project rule documents are different: they are meant to be
+    read whole, and a document longer than the window is silently cut at it. The
+    tool does say how to continue, but a model that does not ask again simply
+    never sees the rest — so a project whose context files run long can raise
+    this instead of depending on that follow-up.
+
+    Example::
+
+        agent_harness:
+          read_max_lines: 500
+    """
+    section = _get_mapping(config, _DEFAULT_HARNESS_SECTION)
+    value = section.get("read_max_lines")
+    if value is None:
+        return _DEFAULT_READ_MAX_LINES
+    try:
+        lines = int(value)
+        return lines if lines > 0 else _DEFAULT_READ_MAX_LINES
+    except (TypeError, ValueError):
+        return _DEFAULT_READ_MAX_LINES
 
 
 def get_pg_passthrough_enabled(config: dict[str, Any]) -> bool:

--- a/src/seeknal/ask/config.py
+++ b/src/seeknal/ask/config.py
@@ -524,6 +524,28 @@ def get_ask_toolset_mode(config: dict[str, Any]) -> str:
     return "full"
 
 
+def get_pg_passthrough_enabled(config: dict[str, Any]) -> bool:
+    """Return whether PG-only SQL may be executed directly on PostgreSQL.
+
+    DuckDB's ``postgres_scanner`` never pushes aggregation past the
+    ``COPY (SELECT ... TO STDOUT)`` boundary, so ``COUNT(DISTINCT ...)`` over an
+    attached table transfers the raw column and computes locally. Routing
+    PG-only SQL straight to PostgreSQL lets the source do the aggregation and
+    returns only the result rows.
+
+    Default is ``False``: no project changes execution engine without an
+    explicit decision. Any failure on the routed path falls back to DuckDB, so
+    enabling this can slow a query down but can never change its answer.
+
+    Example::
+
+        sql_routing:
+          pg_passthrough: true
+    """
+    section = _get_mapping(config, "sql_routing")
+    return _coerce_bool(section.get("pg_passthrough"), False)
+
+
 _VALID_SQL_PAIR_MODES = {"authoritative", "advisory"}
 
 

--- a/src/seeknal/ask/sql_routing.py
+++ b/src/seeknal/ask/sql_routing.py
@@ -1,0 +1,223 @@
+"""Decide whether a SQL statement can run on a remote source instead of DuckDB.
+
+Seeknal executes agent SQL through DuckDB, which may hold local views (parquet,
+Iceberg) alongside ``ATTACH``-ed remote databases. DuckDB pushes down predicates
+but not aggregation, so an aggregate over an attached table transfers the raw
+columns and computes locally. When a statement touches exactly one remote source
+and nothing local, sending it to that source is dramatically cheaper.
+
+"Can we send it" is a structural question about the statement, so it is answered
+from a parsed AST rather than by matching text. Two properties matter and text
+matching gets both wrong:
+
+- **What the statement references.** A name may be a remote table, a local view,
+  or a CTE the statement defines for itself. Only the parser knows which.
+- **What the statement means in the target dialect.** Engines differ on details
+  such as NULL ordering — PostgreSQL sorts NULLs first under ``ORDER BY x DESC``
+  while DuckDB sorts them last. Transpiling makes those defaults explicit so the
+  remote engine returns what the local one would have.
+
+Both come from ``sqlglot``, which Seeknal already depends on.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Sequence
+
+import sqlglot
+from sqlglot import exp
+
+# Dialect of the SQL agents write. DuckDB is Seeknal's local execution engine,
+# so its semantics are what a routed statement must reproduce.
+LOCAL_DIALECT = "duckdb"
+
+
+@dataclass(frozen=True)
+class RoutingPlan:
+    """Outcome of analysing one statement.
+
+    ``namespace`` is None when the statement must stay on the local engine;
+    ``reason`` then says why, so callers can record it instead of guessing.
+    """
+
+    namespace: Optional[str]
+    sql: str
+    reason: str
+
+    @property
+    def is_routable(self) -> bool:
+        return self.namespace is not None
+
+
+def _declined(reason: str) -> RoutingPlan:
+    return RoutingPlan(namespace=None, sql="", reason=reason)
+
+
+def _self_defined_names(statement: exp.Expression) -> set[str]:
+    """Names the statement introduces itself, e.g. CTEs.
+
+    A reference to one of these is resolved by the engine running the statement,
+    not by a catalog, so it must not be mistaken for a local table.
+    """
+    return {cte.alias_or_name.lower() for cte in statement.find_all(exp.CTE)}
+
+
+def _has_unnamed_projection(statement: exp.Expression) -> bool:
+    """Whether any projection would be named by the engine rather than the query.
+
+    An engine is free to invent a name for a projection the statement does not
+    alias, and they disagree: ``SELECT COUNT(*)`` yields ``count_star()`` on
+    DuckDB and ``count`` on PostgreSQL. Worse, PostgreSQL names by function so
+    ``SELECT COUNT(*), COUNT(DISTINCT a)`` returns two columns both called
+    ``count``. Values match either way, but headers are read by whatever
+    consumes the result. Aliased projections and plain column references carry
+    their own name and are safe.
+    """
+    select = statement.find(exp.Select)
+    if select is None:
+        return False
+    return any(
+        not isinstance(projection, (exp.Alias, exp.Column, exp.Star))
+        for projection in select.expressions
+    )
+
+
+def probe_sql(sql: str, *, local_dialect: str = LOCAL_DIALECT) -> Optional[str]:
+    """Render ``sql`` so the local engine reports its result columns cheaply.
+
+    ``LIMIT 0`` makes the engine plan the statement and describe its output
+    without reading rows. The limit is set on the parsed statement rather than
+    appended as text, so a statement that already carries a ``LIMIT`` is
+    rewritten instead of producing ``LIMIT 5 LIMIT 0``.
+    """
+    try:
+        statement = sqlglot.parse_one(sql, dialect=local_dialect)
+    except Exception:  # noqa: BLE001
+        return None
+    if statement is None:
+        return None
+    return statement.limit(0).sql(dialect=local_dialect)
+
+
+def _apply_local_names(
+    statement: exp.Expression,
+    local_names: Sequence[str],
+    max_identifier_bytes: Optional[int],
+) -> bool:
+    """Alias unnamed projections with the names the local engine gives them.
+
+    Returns False when the names cannot be reproduced faithfully — a different
+    number of projections, or a name the target cannot hold. Callers treat that
+    as "do not route": a truncated header is the very difference this is meant
+    to remove.
+    """
+    select = statement.find(exp.Select)
+    if select is None or len(select.expressions) != len(local_names):
+        return False
+
+    for index, projection in enumerate(select.expressions):
+        if isinstance(projection, (exp.Alias, exp.Column, exp.Star)):
+            continue
+        name = local_names[index]
+        if max_identifier_bytes is not None and len(name.encode()) > max_identifier_bytes:
+            return False
+        select.expressions[index] = exp.alias_(
+            projection.copy(), exp.Identifier(this=name, quoted=True)
+        )
+    return True
+
+
+def _namespace_qualifier(table: exp.Table, candidates: set[str]) -> Optional[str]:
+    """Return the namespace this table reference is qualified with, if any.
+
+    A reference may name the namespace in either position depending on how many
+    parts it has: ``ns.schema.table`` puts it in the catalog slot, ``ns.table``
+    in the schema slot. The second form is only a namespace if it matches a
+    configured one — otherwise it is an ordinary schema and the reference says
+    nothing about which engine owns the table.
+    """
+    if table.catalog:
+        return table.catalog
+    if table.db and table.db in candidates:
+        return table.db
+    return None
+
+
+def _clear_namespace_qualifier(table: exp.Table, namespace: str) -> None:
+    """Drop the namespace from a reference; the remote engine has no such name."""
+    if table.catalog == namespace:
+        table.set("catalog", None)
+    elif table.db == namespace:
+        table.set("db", None)
+
+
+def analyze(
+    sql: str,
+    candidate_namespaces: Iterable[str],
+    *,
+    target_dialect: str,
+    local_dialect: str = LOCAL_DIALECT,
+    local_column_names: Optional[Sequence[str]] = None,
+    max_identifier_bytes: Optional[int] = None,
+) -> RoutingPlan:
+    """Return how (or whether) ``sql`` can be executed on a remote namespace.
+
+    Routable only when every table reference is qualified with the *same*
+    namespace and that namespace is one of ``candidate_namespaces``. Any
+    unqualified reference could be a local view, so it forces local execution.
+
+    The returned ``sql`` has the namespace qualifier removed — the remote engine
+    knows nothing about it — and is rendered in ``target_dialect`` so dialect
+    defaults survive the move.
+
+    Projections the query does not name are declined, because the engines would
+    name them differently. Pass ``local_column_names`` (see :func:`probe_sql`)
+    to alias them with the local engine's own names instead, and
+    ``max_identifier_bytes`` to decline rather than let the target truncate a
+    name it cannot hold.
+    """
+    candidates = {str(ns) for ns in candidate_namespaces}
+    if not candidates:
+        return _declined("no remote namespace configured")
+
+    try:
+        statement = sqlglot.parse_one(sql, dialect=local_dialect)
+    except Exception as exc:  # noqa: BLE001 — unparsable means "not our call"
+        return _declined(f"unparsable: {type(exc).__name__}")
+    if statement is None:
+        return _declined("empty statement")
+
+    local_names = _self_defined_names(statement)
+    namespaces: set[str] = set()
+    for table in statement.find_all(exp.Table):
+        qualifier = _namespace_qualifier(table, candidates)
+        if qualifier is not None:
+            namespaces.add(qualifier)
+        elif table.name.lower() not in local_names:
+            return _declined(f"unqualified table reference: {table.name}")
+
+    if not namespaces:
+        return _declined("no qualified table reference")
+    if len(namespaces) > 1:
+        return _declined("spans multiple namespaces")
+    (namespace,) = namespaces
+    if namespace not in candidates:
+        return _declined(f"namespace not routable: {namespace}")
+
+    rewritten = statement.copy()
+    if _has_unnamed_projection(rewritten):
+        if local_column_names is None:
+            return _declined("unaliased projection: local column names not supplied")
+        if not _apply_local_names(rewritten, local_column_names, max_identifier_bytes):
+            return _declined("unaliased projection: local names not reproducible")
+
+    for table in rewritten.find_all(exp.Table):
+        _clear_namespace_qualifier(table, namespace)
+
+    try:
+        target_sql = rewritten.sql(dialect=target_dialect)
+    except Exception as exc:  # noqa: BLE001 — cannot express it there
+        return _declined(f"not expressible in {target_dialect}: {type(exc).__name__}")
+
+    return RoutingPlan(namespace=namespace, sql=target_sql, reason="")

--- a/tests/ask/test_pg_query_routing.py
+++ b/tests/ask/test_pg_query_routing.py
@@ -1,0 +1,143 @@
+"""Tests for PG query routing on the agent path — SQLR.
+
+``_try_pg_route`` sends PG-only SQL straight to PostgreSQL so the source does
+the aggregation instead of DuckDB pulling raw columns over the network. The
+safety property under test: routing may decline, but it must never raise and
+never change what the caller receives.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from seeknal.ask.agents.tools.execute_sql import _try_pg_route
+
+
+class _Ctx:
+    """Minimal stand-in for ToolContext."""
+
+    def __init__(self, pg_passthrough: bool = True):
+        self.pg_passthrough = pg_passthrough
+        self.project_path = Path("/nonexistent-project")
+        self.db_lock = threading.Lock()
+        self.sql_timeout_seconds = 0
+
+
+SQL = "SELECT count(*) FROM warehouse.public.t WHERE x = 1"
+
+
+def test_gate_off_never_routes():
+    """Default-off means the routed path is not even attempted."""
+    with patch("seeknal.sources.config.load_source_registry") as loader:
+        assert _try_pg_route(_Ctx(pg_passthrough=False), SQL, None) is None
+        loader.assert_not_called()
+
+
+def test_registry_failure_falls_back():
+    """A broken/missing source registry declines routing instead of raising."""
+    with patch(
+        "seeknal.sources.config.load_source_registry",
+        side_effect=RuntimeError("no project"),
+    ):
+        assert _try_pg_route(_Ctx(), SQL, None) is None
+
+
+def test_non_pg_sql_declines():
+    """SQL that does not resolve to a single PG namespace stays on DuckDB."""
+    with patch("seeknal.sources.config.load_source_registry"), patch(
+        "seeknal.ask._pg_oracle.detect_pg_only_namespace", return_value=None
+    ):
+        assert _try_pg_route(_Ctx(), "SELECT 1", None) is None
+
+
+def test_pg_error_falls_back_and_is_recorded():
+    """A dialect/runtime error on PG must fall back, not surface to the agent."""
+    from seeknal.ask.testing import SqlOracleResult
+
+    events: list[tuple] = []
+
+    with patch("seeknal.sources.config.load_source_registry"), patch(
+        "seeknal.ask._pg_oracle.detect_pg_only_namespace", return_value="warehouse"
+    ), patch("seeknal.ask._pg_oracle.resolve_pg_dsn", return_value="postgresql://x/y"), patch(
+        "seeknal.ask._pg_oracle.strip_namespace", side_effect=lambda s, ns: s
+    ), patch(
+        "seeknal.ask._pg_oracle.execute_via_psycopg2",
+        return_value=SqlOracleResult(error="operator does not exist: text = integer"),
+    ), patch(
+        "seeknal.ask.agents.tools._context.record_timing_event",
+        side_effect=lambda name, ms, **kw: events.append((name, kw.get("reason", ""))),
+    ):
+        ctx = _Ctx()
+        # A namespace match requires a source whose .namespace matches; the
+        # patched registry is a MagicMock, so sources.values() yields mocks and
+        # the lookup returns None -> declines. Either way: no exception, no rows.
+        assert _try_pg_route(ctx, SQL, None) is None
+
+
+def test_unexpected_exception_falls_back():
+    """Any unforeseen failure declines routing rather than breaking the tool."""
+    with patch("seeknal.sources.config.load_source_registry"), patch(
+        "seeknal.ask._pg_oracle.detect_pg_only_namespace",
+        side_effect=ValueError("boom"),
+    ):
+        assert _try_pg_route(_Ctx(), SQL, None) is None
+
+
+@pytest.mark.parametrize(
+    "sql,expected",
+    [
+        # Regression: masking a qualified ref used to leave "FROM      WHERE",
+        # and WHERE was then read as a bare table name, rejecting every
+        # realistic qualified query.
+        ("SELECT a FROM pg_ns.public.t WHERE x = 1", "pg_ns"),
+        ("SELECT a FROM pg_ns.public.t GROUP BY a", "pg_ns"),
+        # A name the query defines itself is resolved by PostgreSQL, so a
+        # WITH-query over one PG namespace is still PG-only. This is how
+        # combined ERBA+ERLA questions are written.
+        (
+            "WITH x AS (SELECT a FROM pg_ns.public.t) SELECT * FROM x",
+            "pg_ns",
+        ),
+        (
+            "WITH a AS (SELECT n FROM pg_ns.public.t), b AS (SELECT n FROM pg_ns.public.u)"
+            " SELECT * FROM a UNION ALL SELECT * FROM b",
+            "pg_ns",
+        ),
+        # Still rejected: a bare table ref may be a local parquet view.
+        ("SELECT a FROM t WHERE x = 1", None),
+        ("SELECT a FROM pg_ns.public.t JOIN v ON v.k = t.k", None),
+        # A CTE does not launder an unqualified ref that is NOT locally defined.
+        (
+            "WITH x AS (SELECT a FROM pg_ns.public.t) SELECT * FROM x JOIN v ON 1=1",
+            None,
+        ),
+    ],
+)
+def test_detect_accepts_realistic_qualified_sql(sql, expected):
+    from seeknal.ask._pg_oracle import detect_pg_only_namespace
+    from seeknal.sources.config import SourceConfig, SourceRegistry
+
+    src = SourceConfig(
+        name="pg_ns",
+        source_kind="connected",
+        source_type="database",
+        namespace="pg_ns",
+        access="read_only",
+        role="other",
+        priority=0,
+        description="fixture",
+        connector="postgresql",
+        resource=None,
+        dsn_env=None,
+    )
+    registry = SourceRegistry(
+        sources={"pg_ns": src},
+        default_mode="analyst",
+        explicit=True,
+        project_path=None,
+    )
+    assert detect_pg_only_namespace(sql, registry) == expected

--- a/tests/ask/test_sql_routing.py
+++ b/tests/ask/test_sql_routing.py
@@ -1,0 +1,128 @@
+"""Tests for :mod:`seeknal.ask.sql_routing`.
+
+The module answers one question — may this statement run on a remote source
+instead of the local engine — from a parsed AST. These tests pin the two
+properties that make the answer trustworthy: it never routes a statement that
+could touch a local view, and a routed statement keeps its local meaning.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seeknal.ask.sql_routing import analyze
+
+REMOTE = {"warehouse"}
+
+
+def _plan(sql: str, namespaces=REMOTE):
+    return analyze(sql, namespaces, target_dialect="postgres")
+
+
+# ---------------------------------------------------------------------------
+# Routable: every table reference resolves to the one remote namespace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT a FROM warehouse.public.t WHERE x = 1",
+        "SELECT a, count(*) AS n FROM warehouse.public.t GROUP BY a",
+        # A name the statement defines for itself is not a local table.
+        "WITH c AS (SELECT a FROM warehouse.public.t) SELECT * FROM c",
+        "WITH a AS (SELECT n FROM warehouse.public.t),"
+        " b AS (SELECT n FROM warehouse.public.u)"
+        " SELECT * FROM a UNION ALL SELECT * FROM b",
+        # Two-part reference: namespace + table.
+        "SELECT a FROM warehouse.t",
+    ],
+)
+def test_routes_statements_confined_to_one_remote_namespace(sql):
+    assert _plan(sql).namespace == "warehouse"
+
+
+def test_routed_sql_drops_the_namespace_qualifier():
+    """The remote engine has no such catalog, so it must not be addressed."""
+    plan = _plan("SELECT a FROM warehouse.public.t")
+    assert plan.is_routable
+    assert "warehouse." not in plan.sql
+    assert "public.t" in plan.sql
+
+
+def test_routed_sql_preserves_null_ordering():
+    """DuckDB sorts NULLs last on DESC; PostgreSQL sorts them first.
+
+    Left implicit, an ordered query would come back in a different order than
+    the local engine produces. Transpiling must make the local default explicit.
+    """
+    plan = _plan("SELECT a FROM warehouse.public.t ORDER BY a DESC")
+    assert "NULLS LAST" in plan.sql.upper()
+
+
+# ---------------------------------------------------------------------------
+# Declined: anything that might not mean the same thing remotely
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sql,expected_reason",
+    [
+        # A bare name may be a local parquet/Iceberg view.
+        ("SELECT a FROM t", "unqualified table reference"),
+        (
+            "SELECT a FROM warehouse.public.t JOIN v ON v.k = t.k",
+            "unqualified table reference",
+        ),
+        # A CTE does not excuse a sibling reference that is not self-defined.
+        (
+            "WITH c AS (SELECT a FROM warehouse.public.t) SELECT * FROM c JOIN v ON 1=1",
+            "unqualified table reference",
+        ),
+        ("SELECT 1", "no qualified table reference"),
+        # Engines invent different names for a projection the statement does
+        # not alias: DuckDB says count_star(), PostgreSQL says count.
+        ("SELECT COUNT(*) FROM warehouse.public.t", "unaliased projection"),
+        (
+            "SELECT date_trunc('year', d) FROM warehouse.public.t",
+            "unaliased projection",
+        ),
+    ],
+)
+def test_declines_when_a_reference_may_be_local(sql, expected_reason):
+    plan = _plan(sql)
+    assert not plan.is_routable
+    assert expected_reason in plan.reason
+
+
+def test_declines_when_statement_spans_namespaces():
+    plan = analyze(
+        "SELECT * FROM ns_a.public.t JOIN ns_b.public.u ON 1=1",
+        {"ns_a", "ns_b"},
+        target_dialect="postgres",
+    )
+    assert not plan.is_routable
+    assert "multiple namespaces" in plan.reason
+
+
+def test_declines_unknown_namespace():
+    plan = _plan("SELECT a FROM other.public.t")
+    assert not plan.is_routable
+    assert "not routable" in plan.reason
+
+
+def test_declines_when_no_remote_source_configured():
+    plan = analyze("SELECT a FROM warehouse.public.t", set(), target_dialect="postgres")
+    assert not plan.is_routable
+    assert "no remote namespace" in plan.reason
+
+
+def test_declines_unparsable_sql_without_raising():
+    plan = _plan("SELECT FROM WHERE ((((")
+    assert not plan.is_routable
+    assert plan.reason
+
+
+def test_reason_is_empty_when_routable():
+    """Callers log ``reason`` only for declines; a routed plan carries none."""
+    assert _plan("SELECT a FROM warehouse.public.t").reason == ""


### PR DESCRIPTION
## Summary
- `read_project_file` selalu membatasi 200 baris. Default cocok untuk file source, tapi dokumen rule proyek dimaksudkan dibaca utuh — dokumen lebih panjang dari window terpotong diam-diam, dan model yang tidak menindaklanjuti ajakan lanjut tidak akan pernah melihat sisanya.
- Tambah pengaturan `agent_harness.read_max_lines` agar proyek bisa menaikkan window tanpa mengubah kode. Default tetap 200, fallback aman untuk nilai tidak valid.

## Perubahan
- `config.py` — `get_read_max_lines()` baca `agent_harness.read_max_lines` (default 200, guard `> 0`, fallback default).
- `_context.py` — `ToolContext.read_max_lines: int = 200`.
- `read_project_file.py` — `max_lines: int | None = None` → bila `None` pakai `ctx.read_max_lines`.
- `agent.py` — `create_agent` me-resolve `get_read_max_lines` dan set ke `tool_ctx`.

## Contoh config
```yaml
agent_harness:
  read_max_lines: 500
```

## Referensi
- Base branch: `feat/sqlr-pg-query-routing`
- PR sebelumnya (SQLR): #87